### PR TITLE
Live-value uniforms: fix frozen ping-pong uniforms, dirty-checked uploads

### DIFF
--- a/demo/PerformanceTest.tsx
+++ b/demo/PerformanceTest.tsx
@@ -64,22 +64,12 @@ const renderShader = /* glsl */`
 `;
 
 interface PerformanceMetrics {
-    hookCacheHits: number;
-    hookCacheMisses: number;
-    engineSkippedInits: number;
-    engineActualInits: number;
     shaderRenderCount: number;
 }
 
 const metrics: PerformanceMetrics = {
-    hookCacheHits: 0,
-    hookCacheMisses: 0,
-    engineSkippedInits: 0,
-    engineActualInits: 0,
     shaderRenderCount: 0
 };
-
-(window as unknown as { __micuglMetrics: PerformanceMetrics }).__micuglMetrics = metrics;
 
 const MetricsDisplay = () => {
     const [displayMetrics, setDisplayMetrics] = useState<PerformanceMetrics>({ ...metrics });
@@ -104,13 +94,9 @@ const MetricsDisplay = () => {
         }}>
             <div style={{ fontWeight: 600, marginBottom: '8px' }}>Performance Metrics</div>
             <div>Shader component renders: <strong>{displayMetrics.shaderRenderCount}</strong></div>
-            <div>Hook cache hits: <strong style={{ color: '#4ade80' }}>{displayMetrics.hookCacheHits}</strong></div>
-            <div>Hook cache misses: <strong style={{ color: '#f87171' }}>{displayMetrics.hookCacheMisses}</strong></div>
-            <div>Engine skipped inits: <strong style={{ color: '#4ade80' }}>{displayMetrics.engineSkippedInits}</strong></div>
-            <div>Engine actual inits: <strong style={{ color: '#f87171' }}>{displayMetrics.engineActualInits}</strong></div>
             <div style={{ marginTop: '8px', fontSize: '11px', opacity: 0.7 }}>
                 Click "Force Parent Rerender" to test stability.<br/>
-                Cache hits should increase, misses should stay low.
+                Passes stay identity-stable, so the engine does not rebuild.
             </div>
         </div>
     );

--- a/examples/Ripple/RippleScene.tsx
+++ b/examples/Ripple/RippleScene.tsx
@@ -144,7 +144,7 @@ export const Ripple = ({
             uniforms={{
                 u_mouse: {
                     type: 'vec2',
-                    value: vec2(mousePos.current)
+                    value: () => vec2(mousePos.current)
                 },
                 u_mouseForce: {
                     type: 'float',

--- a/src/core/lib/uniformDirtyCheck.test.ts
+++ b/src/core/lib/uniformDirtyCheck.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    createScalarUpdater,
+    createVectorUpdater,
+    writeFloatBuffer
+} from '@/core/lib/uniformDirtyCheck';
+
+describe('writeFloatBuffer', () => {
+    it('writes changed elements and reports the change', () => {
+        const buffer = new Float32Array([0, 0, 0]);
+        const changed = writeFloatBuffer(buffer, [1, 2, 3]);
+
+        expect(changed).toBe(true);
+        expect(Array.from(buffer)).toEqual([1, 2, 3]);
+    });
+
+    it('reports no change when every element matches', () => {
+        const buffer = new Float32Array([1, 2, 3]);
+        const changed = writeFloatBuffer(buffer, [1, 2, 3]);
+
+        expect(changed).toBe(false);
+        expect(Array.from(buffer)).toEqual([1, 2, 3]);
+    });
+
+    it('reports a change when a single element differs', () => {
+        const buffer = new Float32Array([1, 2, 3]);
+        const changed = writeFloatBuffer(buffer, [1, 2, 4]);
+
+        expect(changed).toBe(true);
+        expect(Array.from(buffer)).toEqual([1, 2, 4]);
+    });
+});
+
+describe('createScalarUpdater', () => {
+    it('uploads on the first evaluation', () => {
+        const uploaded: number[] = [];
+        const update = createScalarUpdater(() => 5, v => uploaded.push(v));
+
+        update();
+
+        expect(uploaded).toEqual([5]);
+    });
+
+    it('does not re-upload an unchanged value', () => {
+        let source = 5;
+        const uploaded: number[] = [];
+        const update = createScalarUpdater(() => source, v => uploaded.push(v));
+
+        update();
+        update();
+        update();
+
+        expect(uploaded).toEqual([5]);
+
+        source = 9;
+        update();
+        update();
+
+        expect(uploaded).toEqual([5, 9]);
+    });
+});
+
+describe('createVectorUpdater', () => {
+    it('uploads once even when the initial value equals the zeroed buffer', () => {
+        let uploads = 0;
+        const update = createVectorUpdater(2, () => [0, 0], () => { uploads++ });
+
+        update();
+        update();
+
+        expect(uploads).toBe(1);
+    });
+
+    it('re-uploads only when an element changes', () => {
+        let source: number[] = [1, 2, 3];
+        const uploads: number[][] = [];
+        const update = createVectorUpdater(3, () => source, buffer => uploads.push(Array.from(buffer)));
+
+        update();
+        update();
+        expect(uploads).toEqual([[1, 2, 3]]);
+
+        source = [1, 2, 4];
+        update();
+        expect(uploads).toEqual([[1, 2, 3], [1, 2, 4]]);
+
+        update();
+        expect(uploads).toEqual([[1, 2, 3], [1, 2, 4]]);
+    });
+
+    it('evaluates function-valued sources every frame', () => {
+        let t = 0;
+        const uploads: number[][] = [];
+        const update = createVectorUpdater(2, () => [t, t], buffer => uploads.push(Array.from(buffer)));
+
+        t = 1;
+        update();
+        t = 2;
+        update();
+
+        expect(uploads).toEqual([[1, 1], [2, 2]]);
+    });
+
+    it('detects in-place mutation of a reused source object', () => {
+        const source = new Float32Array([0, 0]);
+        const uploads: number[][] = [];
+        const update = createVectorUpdater(2, () => source, buffer => uploads.push(Array.from(buffer)));
+
+        update();
+        source[0] = 1;
+        update();
+        source[1] = 2;
+        update();
+
+        expect(uploads).toEqual([[0, 0], [1, 0], [1, 2]]);
+    });
+
+    it('does not re-upload when a reused source object is left unchanged', () => {
+        const source = new Float32Array([3, 4]);
+        let uploads = 0;
+        const update = createVectorUpdater(2, () => source, () => { uploads++ });
+
+        update();
+        update();
+        update();
+
+        expect(uploads).toBe(1);
+    });
+
+    it('treats NaN as always-changed and keeps uploading', () => {
+        const uploads: number[][] = [];
+        const update = createVectorUpdater(1, () => [NaN], buffer => uploads.push(Array.from(buffer)));
+
+        update();
+        update();
+
+        expect(uploads).toHaveLength(2);
+        expect(uploads.every(([v]) => Number.isNaN(v))).toBe(true);
+    });
+});
+
+describe('createScalarUpdater NaN', () => {
+    it('re-uploads every frame while the value is NaN', () => {
+        const uploaded: number[] = [];
+        const update = createScalarUpdater(() => NaN, v => uploaded.push(v));
+
+        update();
+        update();
+
+        expect(uploaded).toHaveLength(2);
+        expect(uploaded.every(Number.isNaN)).toBe(true);
+    });
+});

--- a/src/core/lib/uniformDirtyCheck.ts
+++ b/src/core/lib/uniformDirtyCheck.ts
@@ -1,0 +1,47 @@
+import type { UniformType, UniformTypeMap, UniformUpdateFn } from '@/types';
+
+type Evaluate = (time?: number, width?: number, height?: number) => unknown;
+
+export function writeFloatBuffer(buffer: Float32Array, value: ArrayLike<number>): boolean {
+    let changed = false;
+    for (let i = 0; i < buffer.length; i++) {
+        if (buffer[i] !== value[i]) {
+            buffer[i] = value[i];
+            changed = true;
+        }
+    }
+    return changed;
+}
+
+export function createScalarUpdater(
+    evaluate: Evaluate,
+    upload: (value: number) => void
+): UniformUpdateFn<UniformType> {
+    let last: number | undefined;
+    return (time, width, height) => {
+        const value = evaluate(time, width, height) as number;
+        if (value !== last) {
+            last = value;
+            upload(value);
+        }
+        return value as UniformTypeMap[UniformType];
+    };
+}
+
+export function createVectorUpdater(
+    size: number,
+    evaluate: Evaluate,
+    upload: (buffer: Float32Array) => void
+): UniformUpdateFn<UniformType> {
+    const buffer = new Float32Array(size);
+    let uploaded = false;
+    return (time, width, height) => {
+        const value = evaluate(time, width, height) as ArrayLike<number>;
+        const changed = writeFloatBuffer(buffer, value);
+        if (changed || !uploaded) {
+            uploaded = true;
+            upload(buffer);
+        }
+        return buffer as UniformTypeMap[UniformType];
+    };
+}

--- a/src/core/managers/WebGLManager.ts
+++ b/src/core/managers/WebGLManager.ts
@@ -11,7 +11,8 @@ import type {
     WebGLExtensionTypes
 } from '@/core';
 import { FBOManager } from '@/core';
-import type { TypedFloat32Array, UniformTypeMap } from '@/types';
+import { createScalarUpdater, createVectorUpdater } from '@/core/lib/uniformDirtyCheck';
+import type { BufferData, UniformTypeMap } from '@/types';
 
 declare global {
     interface WebGLRenderingContext {
@@ -69,8 +70,7 @@ export class WebGLManager {
         const vShader = this.getOrCompileShader('vertex:' + vertexShader, gl.VERTEX_SHADER, vertexShader);
         const fShader = this.getOrCompileShader('fragment:' + fragmentShader, gl.FRAGMENT_SHADER, fragmentShader);
 
-        const program = gl.createProgram();
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const program = gl.createProgram() as WebGLProgram | null;
         if (!program) {
             throw new Error('Failed to create WebGL program');
         }
@@ -152,8 +152,7 @@ export class WebGLManager {
         }
 
          
-        const buffer = gl.createBuffer();
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const buffer = gl.createBuffer() as WebGLBuffer | null;
         if (!buffer) {
             throw new Error('Failed to create buffer');
         }
@@ -172,8 +171,7 @@ export class WebGLManager {
             throw new Error(`Program with id ${programId} not found`);
         }
 
-        const bufferData = resources.buffers[attributeName];
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const bufferData = resources.buffers[attributeName] as BufferData | undefined;
         if (!bufferData) {
             throw new Error(`Buffer for attribute ${attributeName} not found`);
         }
@@ -210,119 +208,30 @@ export class WebGLManager {
 
         switch (type) {
             case 'int':
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as number;
-                    gl.uniform1i(location, value);
-                    return value;
-                };
+            case 'sampler2D':
+                updateFunction = createScalarUpdater(updateFn, value => { gl.uniform1i(location, value) });
                 break;
             case 'float':
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as number;
-                    gl.uniform1f(location, value);
-                    return value;
-                };
+                updateFunction = createScalarUpdater(updateFn, value => { gl.uniform1f(location, value) });
                 break;
-            case 'sampler2D':
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as number;
-                    gl.uniform1i(location, value);
-                    return value;
-                };
+            case 'vec2':
+                updateFunction = createVectorUpdater(2, updateFn, buffer => { gl.uniform2fv(location, buffer) });
                 break;
-
-            case 'vec2': {
-                const buffer = new Float32Array(2);
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as TypedFloat32Array<2> | number[];
-                    if (Array.isArray(value)) {
-                        buffer[0] = value[0];
-                        buffer[1] = value[1];
-                        gl.uniform2fv(location, buffer);
-                    } else {
-                        gl.uniform2fv(location, value);
-                    }
-                    return buffer as TypedFloat32Array<2>;
-                };
+            case 'vec3':
+                updateFunction = createVectorUpdater(3, updateFn, buffer => { gl.uniform3fv(location, buffer) });
                 break;
-            }
-            case 'vec3': {
-                const buffer = new Float32Array(3);
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as TypedFloat32Array<3> | number[];
-                    if (Array.isArray(value)) {
-                        buffer[0] = value[0];
-                        buffer[1] = value[1];
-                        buffer[2] = value[2];
-                        gl.uniform3fv(location, buffer);
-                    } else {
-                        gl.uniform3fv(location, value);
-                    }
-                    return buffer as TypedFloat32Array<3>;
-                };
+            case 'vec4':
+                updateFunction = createVectorUpdater(4, updateFn, buffer => { gl.uniform4fv(location, buffer) });
                 break;
-            }
-            case 'vec4': {
-                const buffer = new Float32Array(4);
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as TypedFloat32Array<4> | number[];
-                    if (Array.isArray(value)) {
-                        buffer[0] = value[0];
-                        buffer[1] = value[1];
-                        buffer[2] = value[2];
-                        buffer[3] = value[3];
-                        gl.uniform4fv(location, buffer);
-                    } else {
-                        gl.uniform4fv(location, value);
-                    }
-                    return buffer as TypedFloat32Array<4>;
-                };
+            case 'mat2':
+                updateFunction = createVectorUpdater(4, updateFn, buffer => { gl.uniformMatrix2fv(location, false, buffer) });
                 break;
-            }
-
-            case 'mat2': {
-                const buffer = new Float32Array(4);
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as TypedFloat32Array<4> | number[];
-                    if (Array.isArray(value)) {
-                        for (let i = 0; i < 4; i++) buffer[i] = value[i];
-                        gl.uniformMatrix2fv(location, false, buffer);
-                    } else {
-                        gl.uniformMatrix2fv(location, false, value);
-                    }
-                    return buffer as TypedFloat32Array<4>;
-                };
+            case 'mat3':
+                updateFunction = createVectorUpdater(9, updateFn, buffer => { gl.uniformMatrix3fv(location, false, buffer) });
                 break;
-            }
-            case 'mat3': {
-                const buffer = new Float32Array(9);
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as TypedFloat32Array<9> | number[];
-                    if (Array.isArray(value)) {
-                        for (let i = 0; i < 9; i++) buffer[i] = value[i];
-                        gl.uniformMatrix3fv(location, false, buffer);
-                    } else {
-                        gl.uniformMatrix3fv(location, false, value);
-                    }
-                    return buffer as TypedFloat32Array<9>;
-                };
+            case 'mat4':
+                updateFunction = createVectorUpdater(16, updateFn, buffer => { gl.uniformMatrix4fv(location, false, buffer) });
                 break;
-            }
-            case 'mat4': {
-                const buffer = new Float32Array(16);
-                updateFunction = (time, width, height) => {
-                    const value = updateFn(time, width, height) as TypedFloat32Array<16> | number[];
-                    if (Array.isArray(value)) {
-                        for (let i = 0; i < 16; i++) buffer[i] = value[i];
-                        gl.uniformMatrix4fv(location, false, buffer);
-                    } else {
-                        gl.uniformMatrix4fv(location, false, value);
-                    }
-                    return buffer as TypedFloat32Array<16>;
-                };
-                break;
-            }
-            
             default:
                 throw new Error(`Unsupported uniform type: ${type}`);
         }
@@ -465,8 +374,7 @@ export class WebGLManager {
             return;
         }
 
-        const bufferData = resources.buffers[attributeName];
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const bufferData = resources.buffers[attributeName] as BufferData | undefined;
         if (!bufferData) {
             throw new Error(`Buffer for attribute ${attributeName} not found`);
         }

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -27,24 +27,6 @@ interface PingPongShaderEngineProps {
 const DEFAULT_CLASS_NAME = '';
 const DEFAULT_STYLE: CSSProperties = {};
 
-interface EngineInitMetrics {
-    engineSkippedInits: number;
-    engineActualInits: number;
-}
-
-function readEngineMetrics(): EngineInitMetrics | undefined {
-    if (typeof window === 'undefined') {
-        return undefined;
-    }
-    return (window as unknown as { __micuglMetrics?: EngineInitMetrics }).__micuglMetrics;
-}
-
-function serializePasses(passes: RenderPass[]): string {
-    return passes.map(p =>
-        `${p.programId}|${p.outputFramebuffer ?? 'screen'}|${p.inputTextures.map(t => t.id).join(',')}`
-    ).join('||');
-}
-
 const PingPongShaderEngineComponent = ({
     programConfigs,
     passes,
@@ -65,7 +47,7 @@ const PingPongShaderEngineComponent = ({
     const passSystemRef = useRef<Passes | null>(null);
     const animationFrameRef = useRef<number | null>(null);
     const startTimeRef = useRef<number>(0);
-    const passesKeyRef = useRef<string>('');
+    const appliedPassesRef = useRef<RenderPass[] | null>(null);
 
     const renderLoopRef = useRef<(time: number) => void>((time: number) => {
         const manager = managerRef.current;
@@ -132,7 +114,7 @@ const PingPongShaderEngineComponent = ({
         initialPasses.forEach(pass => {
             passSystem.addPass(pass);
         });
-        passesKeyRef.current = serializePasses(initialPasses);
+        appliedPassesRef.current = initialPasses;
 
         passSystem.initializeResources();
 
@@ -168,19 +150,10 @@ const PingPongShaderEngineComponent = ({
         const passSystem = passSystemRef.current;
         if (!passSystem) return;
 
-        const metrics = readEngineMetrics();
-        const newKey = serializePasses(passes);
-        if (newKey === passesKeyRef.current) {
-            if (metrics) {
-                metrics.engineSkippedInits++;
-            }
+        if (passes === appliedPassesRef.current) {
             return;
         }
-        passesKeyRef.current = newKey;
-
-        if (metrics) {
-            metrics.engineActualInits++;
-        }
+        appliedPassesRef.current = passes;
 
         passSystem.clearPasses();
         passes.forEach(pass => {

--- a/src/react/hooks/useDarkMode.ts
+++ b/src/react/hooks/useDarkMode.ts
@@ -11,15 +11,9 @@ export const useDarkMode = () => {
 
         checkDarkMode();
 
-        const observer = new MutationObserver(mutations => {
-            mutations.forEach(mutation => {
-                if (mutation.attributeName === 'class') {
-                    checkDarkMode();
-                }
-            });
-        });
+        const observer = new MutationObserver(() => { checkDarkMode() });
 
-        observer.observe(document.documentElement, { attributes: true });
+        observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
 
         return () => { observer.disconnect() };
     }, []);

--- a/src/react/hooks/usePingPongPasses.ts
+++ b/src/react/hooks/usePingPongPasses.ts
@@ -1,7 +1,15 @@
-import { useRef } from 'react';
+import { useMemo } from 'react';
 
 import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
-import type { FramebufferOptions, RenderPass, UniformParam, UniformUpdaterDef } from '@/types';
+import {
+    buildPasses,
+    DEFAULT_FRAMEBUFFER_OPTIONS,
+    DEFAULT_RENDER_OPTIONS,
+    type PingPongRenderOptions,
+    serializeFramebufferOptions,
+    serializeRenderOptions
+} from '@/react/lib/pingPongPasses';
+import type { FramebufferOptions, RenderPass, UniformParam } from '@/types';
 
 interface PingPongPassesOptions {
     programId: string;
@@ -10,148 +18,18 @@ interface PingPongPassesOptions {
     uniforms: Record<string, UniformParam>;
     secondaryUniforms?: Record<string, UniformParam>;
     framebufferOptions?: FramebufferOptions;
-    renderOptions?: {
-        clear?: boolean;
-        clearColor?: [number, number, number, number];
-    };
+    renderOptions?: PingPongRenderOptions;
     customPasses?: RenderPass[];
 }
 
-interface PingPongPassesResult {
-    passes: RenderPass[];
-    framebuffers: Record<string, FramebufferOptions>;
-}
-
-const DEFAULT_FRAMEBUFFER_OPTIONS: FramebufferOptions = {
-    width: 0,
-    height: 0,
-    textureCount: 2,
-    textureOptions: {
-        minFilter: WebGLRenderingContext.LINEAR,
-        magFilter: WebGLRenderingContext.LINEAR
-    }
-};
-
-const DEFAULT_RENDER_OPTIONS = { clear: true };
-
-function serializeFramebufferOptions(opts: FramebufferOptions): string {
-    return `${opts.width}|${opts.height}|${opts.textureCount ?? 1}|${JSON.stringify(opts.textureOptions ?? {})}`;
-}
-
-function serializeRenderOptions(opts: { clear?: boolean; clearColor?: [number, number, number, number] }): string {
-    return `${opts.clear ?? true}|${JSON.stringify(opts.clearColor ?? [0, 0, 0, 1])}`;
-}
-
-function buildPasses(
-    programId: string,
-    secondaryProgramId: string | undefined,
-    iterations: number,
-    primaryUniforms: Record<string, UniformUpdaterDef[]>,
-    secondaryUniformsConverted: Record<string, UniformUpdaterDef[]>,
-    framebufferOptions: FramebufferOptions,
-    renderOptions: { clear?: boolean; clearColor?: [number, number, number, number] },
-    customPasses: RenderPass[] | undefined
-): PingPongPassesResult {
-    const fbIdA = `${programId}-fb-a`;
-    const fbIdB = `${programId}-fb-b`;
-    const framebuffers = {
-        [fbIdA]: framebufferOptions,
-        [fbIdB]: framebufferOptions
-    };
-
-    let passes: RenderPass[] = [];
-
-    if (customPasses) {
-        passes = customPasses;
-    } else {
-        passes.push({
-            programId,
-            inputTextures: [],
-            outputFramebuffer: fbIdA,
-            renderOptions
-        });
-
-        let lastTarget = fbIdA;
-
-        for (let i = 0; i < iterations; i++) {
-            const currentProgramId = secondaryProgramId && i % 2 === 1
-                ? secondaryProgramId
-                : programId;
-            
-            const sourceId = i % 2 === 0 ? fbIdA : fbIdB;
-            const targetId = i % 2 === 0 ? fbIdB : fbIdA;
-            lastTarget = targetId;
-
-            const currentUniforms = secondaryProgramId && i % 2 === 1
-                ? secondaryUniformsConverted[secondaryProgramId]
-                : primaryUniforms[programId];
-            
-            const passUniforms: Record<string, any> = {};
-            
-            currentUniforms.forEach(updater => {
-                const originalUpdateFn = updater.updateFn;
-                
-                passUniforms[updater.name] = {
-                    type: updater.type,
-                    value: (time: number, width: number, height: number) => {
-                        return originalUpdateFn(time, width, height);
-                    }
-                };
-            });
-
-            passes.push({
-                programId: currentProgramId,
-                inputTextures: [{
-                    id: sourceId,
-                    textureUnit: 0,
-                    bindingType: 'read'
-                }],
-                outputFramebuffer: targetId,
-                uniforms: passUniforms,
-                renderOptions
-            });
-        }
-
-        const finalSourceId = lastTarget;
-        
-        const finalUniforms: Record<string, any> = {};
-        const finalUpdatersMap = secondaryProgramId 
-            ? secondaryUniformsConverted[secondaryProgramId] 
-            : primaryUniforms[programId];
-        
-        finalUpdatersMap.forEach(updater => {
-            const originalUpdateFn = updater.updateFn;
-            
-            finalUniforms[updater.name] = {
-                type: updater.type,
-                value: (time: number, width: number, height: number) => {
-                    return originalUpdateFn(time, width, height);
-                }
-            };
-        });
-        
-        passes.push({
-            programId: secondaryProgramId ?? programId,
-            inputTextures: [{
-                id: finalSourceId,
-                textureUnit: 0,
-                bindingType: 'read'
-            }],
-            outputFramebuffer: null,
-            uniforms: finalUniforms,
-            renderOptions
-        });
-    }
-
-    return { passes, framebuffers };
-}
+const EMPTY_UNIFORMS: Record<string, UniformParam> = {};
 
 export const usePingPongPasses = ({
     programId,
     secondaryProgramId,
     iterations = 1,
     uniforms,
-    secondaryUniforms = {},
+    secondaryUniforms = EMPTY_UNIFORMS,
     framebufferOptions = DEFAULT_FRAMEBUFFER_OPTIONS,
     renderOptions = DEFAULT_RENDER_OPTIONS,
     customPasses
@@ -162,42 +40,30 @@ export const usePingPongPasses = ({
         secondaryUniforms
     );
 
-    const cacheRef = useRef<{
-        key: string;
-        result: PingPongPassesResult;
-    } | null>(null);
+    const framebufferKey = serializeFramebufferOptions(framebufferOptions);
+    const renderKey = serializeRenderOptions(renderOptions);
 
-    const fbKey = serializeFramebufferOptions(framebufferOptions);
-    const roKey = serializeRenderOptions(renderOptions);
-    const customKey = customPasses ? customPasses.length.toString() : 'none';
-    const cacheKey = `${programId}|${secondaryProgramId ?? ''}|${iterations}|${fbKey}|${roKey}|${customKey}`;
-
-    if (cacheRef.current && cacheRef.current.key === cacheKey) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (typeof window !== 'undefined' && (window as any).__micuglMetrics) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            (window as any).__micuglMetrics.hookCacheHits++;
-        }
-        return cacheRef.current.result;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (typeof window !== 'undefined' && (window as any).__micuglMetrics) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (window as any).__micuglMetrics.hookCacheMisses++;
-    }
-
-    const result = buildPasses(
+    return useMemo(() => {
+        const framebufferOpts = JSON.parse(framebufferKey) as FramebufferOptions;
+        const renderOpts = JSON.parse(renderKey) as PingPongRenderOptions;
+        return buildPasses(
+            programId,
+            secondaryProgramId,
+            iterations,
+            primaryUniforms,
+            secondaryUniformsConverted,
+            framebufferOpts,
+            renderOpts,
+            customPasses
+        );
+    }, [
         programId,
         secondaryProgramId,
         iterations,
         primaryUniforms,
         secondaryUniformsConverted,
-        framebufferOptions,
-        renderOptions,
+        framebufferKey,
+        renderKey,
         customPasses
-    );
-
-    cacheRef.current = { key: cacheKey, result };
-    return result;
+    ]);
 };

--- a/src/react/hooks/useUniformUpdaters.ts
+++ b/src/react/hooks/useUniformUpdaters.ts
@@ -1,25 +1,30 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
-import { createCommonUpdaters, createUniformUpdater } from '@/react/lib/createUniformUpdater';
+import {
+    buildLiveUpdaters,
+    collectLiveValues,
+    type LiveValues,
+    parseUniformStructureKey,
+    uniformDescriptors,
+    uniformStructureKey
+} from '@/react/lib/liveUniformUpdaters';
 import type { UniformParam, UniformUpdaterDef } from '@/types';
 
 export const useUniformUpdaters = (
     programId: string,
     uniforms: Record<string, UniformParam>,
     options?: { skipDefaultUniforms?: boolean }
-) => {
+): Record<string, UniformUpdaterDef[]> => {
+    const skipDefaults = options?.skipDefaultUniforms ?? false;
+    const structureKey = uniformStructureKey(uniformDescriptors(uniforms), skipDefaults);
+
+    const valuesRef = useRef<LiveValues>({});
+    useEffect(() => {
+        valuesRef.current = collectLiveValues(uniforms);
+    });
+
     return useMemo(() => {
-        const skip = options?.skipDefaultUniforms ?? false;
-        const updaters: UniformUpdaterDef[] = skip ? [] : createCommonUpdaters().filter(u =>
-            (u.name === 'u_time' && !('u_time' in uniforms)) 
-            || (u.name === 'u_resolution' && !('u_resolution' in uniforms))
-        );
-
-        Object.entries(uniforms).forEach(([name, param]) => {
-            const uniformName = name.startsWith('u_') ? name : `u_${name}`;
-            updaters.push(createUniformUpdater(uniformName, param.type, param.value));
-        });
-
-        return { [programId]: updaters };
-    }, [programId, uniforms, options?.skipDefaultUniforms]);
+        const parsed = parseUniformStructureKey(structureKey);
+        return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef) };
+    }, [programId, structureKey]);
 };

--- a/src/react/lib/liveUniformUpdaters.test.ts
+++ b/src/react/lib/liveUniformUpdaters.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { vec2, vec3 } from '@/core/lib/vectorUtils';
+import {
+    buildLiveUpdaters,
+    collectLiveValues,
+    type LiveValues,
+    normalizeUniformName,
+    parseUniformStructureKey,
+    type UniformDescriptor,
+    uniformDescriptors,
+    uniformStructureKey
+} from '@/react/lib/liveUniformUpdaters';
+import type { UniformParam } from '@/types';
+
+describe('normalizeUniformName', () => {
+    it('prefixes bare names with u_', () => {
+        expect(normalizeUniformName('color')).toBe('u_color');
+    });
+
+    it('leaves already-prefixed names untouched', () => {
+        expect(normalizeUniformName('u_color')).toBe('u_color');
+    });
+});
+
+describe('uniformStructureKey', () => {
+    const uniformsA: Record<string, UniformParam> = {
+        u_color: { type: 'vec3', value: vec3([1, 2, 3]) },
+        u_strength: { type: 'float', value: 0.5 }
+    };
+
+    it('is stable when only values change', () => {
+        const uniformsB: Record<string, UniformParam> = {
+            u_color: { type: 'vec3', value: vec3([9, 9, 9]) },
+            u_strength: { type: 'float', value: 42 }
+        };
+
+        expect(uniformStructureKey(uniformDescriptors(uniformsA), false))
+            .toBe(uniformStructureKey(uniformDescriptors(uniformsB), false));
+    });
+
+    it('changes when a uniform is added', () => {
+        const withExtra: Record<string, UniformParam> = {
+            ...uniformsA,
+            u_extra: { type: 'float', value: 1 }
+        };
+
+        expect(uniformStructureKey(uniformDescriptors(uniformsA), false))
+            .not.toBe(uniformStructureKey(uniformDescriptors(withExtra), false));
+    });
+
+    it('changes when a uniform is retyped', () => {
+        const retyped: Record<string, UniformParam> = {
+            ...uniformsA,
+            u_strength: { type: 'int', value: 1 }
+        };
+
+        expect(uniformStructureKey(uniformDescriptors(uniformsA), false))
+            .not.toBe(uniformStructureKey(uniformDescriptors(retyped), false));
+    });
+
+    it('changes when the skipDefaults flag differs', () => {
+        expect(uniformStructureKey(uniformDescriptors(uniformsA), false))
+            .not.toBe(uniformStructureKey(uniformDescriptors(uniformsA), true));
+    });
+
+    it('round-trips through parseUniformStructureKey', () => {
+        const descriptors = uniformDescriptors(uniformsA);
+        const parsed = parseUniformStructureKey(uniformStructureKey(descriptors, true));
+
+        expect(parsed.skipDefaults).toBe(true);
+        expect(parsed.descriptors).toEqual(descriptors);
+    });
+
+    it('round-trips an empty uniform set', () => {
+        const parsed = parseUniformStructureKey(uniformStructureKey([], false));
+
+        expect(parsed.skipDefaults).toBe(false);
+        expect(parsed.descriptors).toEqual([]);
+    });
+
+    it('round-trips every uniform type without the head separator leaking into the body', () => {
+        const descriptors: UniformDescriptor[] = [
+            { name: 'u_i', type: 'int' },
+            { name: 'u_tex', type: 'sampler2D' },
+            { name: 'u_xform', type: 'mat4' },
+            { name: 'u_color', type: 'vec3' }
+        ];
+
+        const parsed = parseUniformStructureKey(uniformStructureKey(descriptors, true));
+
+        expect(parsed.skipDefaults).toBe(true);
+        expect(parsed.descriptors).toEqual(descriptors);
+    });
+});
+
+describe('buildLiveUpdaters', () => {
+    it('reads the latest value from the ref every call', () => {
+        const valuesRef: { current: LiveValues } = {
+            current: { u_color: vec3([1, 2, 3]) }
+        };
+        const updaters = buildLiveUpdaters([{ name: 'u_color', type: 'vec3' }], true, valuesRef);
+        const updater = updaters.find(u => u.name === 'u_color');
+
+        expect(updater?.updateFn()).toEqual(vec3([1, 2, 3]));
+
+        valuesRef.current = { u_color: vec3([4, 5, 6]) };
+        expect(updater?.updateFn()).toEqual(vec3([4, 5, 6]));
+    });
+
+    it('evaluates function-valued sources against the live ref', () => {
+        const valuesRef: { current: LiveValues } = {
+            current: { u_wave: (time?: number) => vec2([time ?? 0, 0]) }
+        };
+        const updaters = buildLiveUpdaters([{ name: 'u_wave', type: 'vec2' }], true, valuesRef);
+        const updater = updaters.find(u => u.name === 'u_wave');
+
+        expect(updater?.updateFn(2)).toEqual(vec2([2, 0]));
+        expect(updater?.updateFn(7)).toEqual(vec2([7, 0]));
+    });
+
+    it('injects u_time and u_resolution defaults unless skipped', () => {
+        const valuesRef: { current: LiveValues } = { current: {} };
+        const withDefaults = buildLiveUpdaters([], false, valuesRef);
+
+        expect(withDefaults.map(u => u.name)).toEqual(['u_time', 'u_resolution']);
+
+        const skipped = buildLiveUpdaters([], true, valuesRef);
+        expect(skipped).toEqual([]);
+    });
+
+    it('does not inject a default that the caller already declares', () => {
+        const valuesRef: { current: LiveValues } = { current: { u_time: 3 } };
+        const updaters = buildLiveUpdaters([{ name: 'u_time', type: 'float' }], false, valuesRef);
+
+        expect(updaters.map(u => u.name)).toEqual(['u_resolution', 'u_time']);
+    });
+});
+
+describe('collectLiveValues', () => {
+    it('keys values by the normalized uniform name', () => {
+        const values = collectLiveValues({
+            color: { type: 'vec3', value: vec3([1, 2, 3]) },
+            u_strength: { type: 'float', value: 0.5 }
+        });
+
+        expect(values).toEqual({
+            u_color: vec3([1, 2, 3]),
+            u_strength: 0.5
+        });
+    });
+});

--- a/src/react/lib/liveUniformUpdaters.ts
+++ b/src/react/lib/liveUniformUpdaters.ts
@@ -1,0 +1,95 @@
+import { createCommonUpdaters } from '@/react/lib/createUniformUpdater';
+import type {
+    UniformParam,
+    UniformType,
+    UniformUpdaterDef,
+    UniformValue
+} from '@/types';
+
+const HEAD_PREFIX = '__skip=';
+const ENTRY_SEPARATOR = ',';
+const FIELD_SEPARATOR = '=';
+
+export interface UniformDescriptor {
+    name: string;
+    type: UniformType;
+}
+
+export type LiveValues = Record<string, UniformValue<UniformType>>;
+
+export function normalizeUniformName(name: string): string {
+    return name.startsWith('u_') ? name : `u_${name}`;
+}
+
+export function uniformDescriptors(uniforms: Record<string, UniformParam>): UniformDescriptor[] {
+    return Object.entries(uniforms).map(([name, param]) => ({
+        name: normalizeUniformName(name),
+        type: param.type
+    }));
+}
+
+export function collectLiveValues(uniforms: Record<string, UniformParam>): LiveValues {
+    const values: LiveValues = {};
+    for (const [name, param] of Object.entries(uniforms)) {
+        values[normalizeUniformName(name)] = param.value;
+    }
+    return values;
+}
+
+export function uniformStructureKey(descriptors: UniformDescriptor[], skipDefaults: boolean): string {
+    const head = `${HEAD_PREFIX}${skipDefaults ? '1' : '0'}`;
+    const body = descriptors.map(d => `${d.name}${FIELD_SEPARATOR}${d.type}`);
+    return [head, ...body].join(ENTRY_SEPARATOR);
+}
+
+export function parseUniformStructureKey(
+    key: string
+): { skipDefaults: boolean; descriptors: UniformDescriptor[] } {
+    const parts = key.split(ENTRY_SEPARATOR);
+    const skipDefaults = parts[0] === `${HEAD_PREFIX}1`;
+    const descriptors: UniformDescriptor[] = [];
+
+    for (let i = 1; i < parts.length; i++) {
+        const part = parts[i];
+        if (part.length === 0) {
+            continue;
+        }
+        const separatorIndex = part.indexOf(FIELD_SEPARATOR);
+        descriptors.push({
+            name: part.slice(0, separatorIndex),
+            type: part.slice(separatorIndex + 1) as UniformType
+        });
+    }
+
+    return { skipDefaults, descriptors };
+}
+
+export function buildLiveUpdaters(
+    descriptors: UniformDescriptor[],
+    skipDefaults: boolean,
+    valuesRef: { current: LiveValues }
+): UniformUpdaterDef[] {
+    const hasName = (name: string): boolean => descriptors.some(d => d.name === name);
+
+    const updaters: UniformUpdaterDef[] = skipDefaults
+        ? []
+        : createCommonUpdaters().filter(u =>
+            (u.name === 'u_time' && !hasName('u_time'))
+            || (u.name === 'u_resolution' && !hasName('u_resolution'))
+        );
+
+    for (const { name, type } of descriptors) {
+        updaters.push({
+            name,
+            type,
+            updateFn: (time, width, height) => {
+                const current = valuesRef.current[name];
+                return typeof current === 'function'
+                    ? current(time, width, height)
+                    : current;
+            }
+        });
+    }
+
+    return updaters;
+}

--- a/src/react/lib/pingPongPasses.test.ts
+++ b/src/react/lib/pingPongPasses.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { vec3 } from '@/core/lib/vectorUtils';
+import {
+    buildPasses,
+    serializeFramebufferOptions,
+    serializeRenderOptions
+} from '@/react/lib/pingPongPasses';
+import type { FramebufferOptions, UniformUpdaterDef } from '@/types';
+
+const makeFramebufferOptions = (overrides: Partial<FramebufferOptions> = {}): FramebufferOptions => ({
+    width: 0,
+    height: 0,
+    textureCount: 2,
+    textureOptions: { minFilter: 9729, magFilter: 9729 },
+    ...overrides
+});
+
+const primary: Record<string, UniformUpdaterDef[]> = {
+    sim: [{ name: 'u_strength', type: 'float', updateFn: () => 1 }]
+};
+const secondary: Record<string, UniformUpdaterDef[]> = {
+    render: [{ name: 'u_color', type: 'vec3', updateFn: () => vec3([1, 2, 3]) }]
+};
+const renderOptions = { clear: true };
+
+describe('serializeFramebufferOptions', () => {
+    it('is stable across re-created but identical option objects', () => {
+        expect(serializeFramebufferOptions(makeFramebufferOptions()))
+            .toBe(serializeFramebufferOptions(makeFramebufferOptions()));
+    });
+
+    it('changes when dimensions change', () => {
+        expect(serializeFramebufferOptions(makeFramebufferOptions()))
+            .not.toBe(serializeFramebufferOptions(makeFramebufferOptions({ width: 256, height: 256 })));
+    });
+
+    it('treats an omitted textureCount as the default of 2', () => {
+        expect(serializeFramebufferOptions(makeFramebufferOptions({ textureCount: 2 })))
+            .toBe(serializeFramebufferOptions(makeFramebufferOptions({ textureCount: undefined })));
+    });
+
+    it('produces a JSON string that round-trips', () => {
+        const key = serializeFramebufferOptions(makeFramebufferOptions({ width: 128, height: 64 }));
+        expect(JSON.parse(key)).toEqual({
+            width: 128,
+            height: 64,
+            textureCount: 2,
+            textureOptions: { minFilter: 9729, magFilter: 9729 }
+        });
+    });
+});
+
+describe('serializeRenderOptions', () => {
+    it('normalizes an omitted clearColor to opaque black', () => {
+        expect(serializeRenderOptions({ clear: true }))
+            .toBe(serializeRenderOptions({ clear: true, clearColor: [0, 0, 0, 1] }));
+    });
+
+    it('changes when clearColor changes', () => {
+        expect(serializeRenderOptions({ clear: true }))
+            .not.toBe(serializeRenderOptions({ clear: true, clearColor: [1, 0, 0, 1] }));
+    });
+});
+
+describe('buildPasses', () => {
+    it('emits an init pass, one pass per iteration, and a final screen pass', () => {
+        const { passes } = buildPasses(
+            'sim', undefined, 3, primary, {}, makeFramebufferOptions(), renderOptions, undefined
+        );
+
+        expect(passes).toHaveLength(1 + 3 + 1);
+        expect(passes[0].outputFramebuffer).toBe('sim-fb-a');
+        expect(passes[passes.length - 1].outputFramebuffer).toBeNull();
+    });
+
+    it('exposes two ping-pong framebuffers keyed on the primary program id', () => {
+        const { framebuffers } = buildPasses(
+            'sim', undefined, 1, primary, {}, makeFramebufferOptions(), renderOptions, undefined
+        );
+
+        expect(Object.keys(framebuffers)).toEqual(['sim-fb-a', 'sim-fb-b']);
+    });
+
+    it('alternates to the secondary program on odd iterations and for the final pass', () => {
+        const { passes } = buildPasses(
+            'sim', 'render', 2, primary, secondary, makeFramebufferOptions(), renderOptions, undefined
+        );
+
+        expect(passes.map(p => p.programId)).toEqual(['sim', 'sim', 'render', 'render']);
+    });
+
+    it('carries the live updater function through as the pass uniform value', () => {
+        const { passes } = buildPasses(
+            'sim', undefined, 1, primary, {}, makeFramebufferOptions(), renderOptions, undefined
+        );
+
+        const iterationPass = passes[1];
+        expect(typeof iterationPass.uniforms?.u_strength.value).toBe('function');
+    });
+
+    it('passes custom passes through untouched', () => {
+        const custom = [{
+            programId: 'sim',
+            inputTextures: [],
+            outputFramebuffer: null
+        }];
+
+        const { passes } = buildPasses(
+            'sim', undefined, 4, primary, {}, makeFramebufferOptions(), renderOptions, custom
+        );
+
+        expect(passes).toBe(custom);
+    });
+});

--- a/src/react/lib/pingPongPasses.ts
+++ b/src/react/lib/pingPongPasses.ts
@@ -1,0 +1,126 @@
+import type {
+    FramebufferOptions,
+    RenderPass,
+    RenderPassUniformValue,
+    UniformType,
+    UniformUpdaterDef
+} from '@/types';
+
+export interface PingPongRenderOptions {
+    clear?: boolean;
+    clearColor?: [number, number, number, number];
+}
+
+export interface PingPongPassesResult {
+    passes: RenderPass[];
+    framebuffers: Record<string, FramebufferOptions>;
+}
+
+const LINEAR = 9729;
+
+export const DEFAULT_FRAMEBUFFER_OPTIONS: FramebufferOptions = {
+    width: 0,
+    height: 0,
+    textureCount: 2,
+    textureOptions: {
+        minFilter: LINEAR,
+        magFilter: LINEAR
+    }
+};
+
+export const DEFAULT_RENDER_OPTIONS: PingPongRenderOptions = { clear: true };
+
+export function serializeFramebufferOptions(options: FramebufferOptions): string {
+    return JSON.stringify({
+        width: options.width,
+        height: options.height,
+        textureCount: options.textureCount ?? 2,
+        textureOptions: options.textureOptions ?? {}
+    });
+}
+
+export function serializeRenderOptions(options: PingPongRenderOptions): string {
+    return JSON.stringify({
+        clear: options.clear ?? true,
+        clearColor: options.clearColor ?? [0, 0, 0, 1]
+    });
+}
+
+function passUniformsFrom(
+    updaters: UniformUpdaterDef[]
+): Record<string, { type: UniformType; value: RenderPassUniformValue }> {
+    const result: Record<string, { type: UniformType; value: RenderPassUniformValue }> = {};
+    for (const updater of updaters) {
+        result[updater.name] = { type: updater.type, value: updater.updateFn };
+    }
+    return result;
+}
+
+export function buildPasses(
+    programId: string,
+    secondaryProgramId: string | undefined,
+    iterations: number,
+    primaryUniforms: Record<string, UniformUpdaterDef[]>,
+    secondaryUniforms: Record<string, UniformUpdaterDef[]>,
+    framebufferOptions: FramebufferOptions,
+    renderOptions: PingPongRenderOptions,
+    customPasses: RenderPass[] | undefined
+): PingPongPassesResult {
+    const fbIdA = `${programId}-fb-a`;
+    const fbIdB = `${programId}-fb-b`;
+    const framebuffers = {
+        [fbIdA]: framebufferOptions,
+        [fbIdB]: framebufferOptions
+    };
+
+    if (customPasses) {
+        return { passes: customPasses, framebuffers };
+    }
+
+    const passes: RenderPass[] = [{
+        programId,
+        inputTextures: [],
+        outputFramebuffer: fbIdA,
+        renderOptions
+    }];
+
+    let lastTarget = fbIdA;
+
+    for (let i = 0; i < iterations; i++) {
+        const sourceId = i % 2 === 0 ? fbIdA : fbIdB;
+        const targetId = i % 2 === 0 ? fbIdB : fbIdA;
+        lastTarget = targetId;
+
+        let currentProgramId = programId;
+        let updaters = primaryUniforms[programId];
+        if (secondaryProgramId !== undefined && i % 2 === 1) {
+            currentProgramId = secondaryProgramId;
+            updaters = secondaryUniforms[secondaryProgramId];
+        }
+
+        passes.push({
+            programId: currentProgramId,
+            inputTextures: [{ id: sourceId, textureUnit: 0, bindingType: 'read' }],
+            outputFramebuffer: targetId,
+            uniforms: passUniformsFrom(updaters),
+            renderOptions
+        });
+    }
+
+    let finalProgramId = programId;
+    let finalUpdaters = primaryUniforms[programId];
+    if (secondaryProgramId !== undefined) {
+        finalProgramId = secondaryProgramId;
+        finalUpdaters = secondaryUniforms[secondaryProgramId];
+    }
+
+    passes.push({
+        programId: finalProgramId,
+        inputTextures: [{ id: lastTarget, textureUnit: 0, bindingType: 'read' }],
+        outputFramebuffer: null,
+        uniforms: passUniformsFrom(finalUpdaters),
+        renderOptions
+    });
+
+    return { passes, framebuffers };
+}


### PR DESCRIPTION
Part 2 of the fix stack (stacked on #32).

## Problem

On the ping-pong path, uniform prop changes never reached the GPU after mount: the pass cache key omitted uniforms entirely and `serializePasses` compared only topology, so original updater closures were served forever (changing `Ripple`'s `damping`/colors did nothing). Separately, `useUniformUpdaters` memoized on the identity of the `uniforms` record — which every caller rebuilds per render — and static uniform values were re-uploaded every frame.

## Changes

- **Stable structure, live values**: `useUniformUpdaters` memoizes on a structure key (names + types), and generated updaters read current values from a ref refreshed after each commit. Identity-stable across value-only changes; values land next frame; function-valued uniforms keep working.
- `usePingPongPasses`: hand-rolled render-phase cache replaced by `useMemo` on real structural inputs; pass building extracted to a pure, tested module. The render-phase ref-write hazard is gone.
- `PingPongShaderEngine`: `serializePasses` deleted; passes effect keys on identity (value-only changes rebuild nothing; structural changes re-add cleanly, verified across re-init).
- Dirty-checked uploads in `WebGLManager` via pure factories: unchanged static values skip the GL call; `u_resolution` re-uploads only when dimensions change.
- Misleading `__micuglMetrics` counters removed from library + demo.
- `Ripple` example: `u_mouse` is now live (ripples follow the cursor). `useDarkMode` observes only `class`. SSR-safe numeric GL constants in the extracted pass module.
- 37 new tests (56 total): structure keys, live-value freshness, dirty-check semantics including aliasing and NaN edges.

## Verification

typecheck / lint / test / build green. Independent adversarial review traced mount, value-change, structure-change, shader-source-change, and remount flows; fixed a render-phase ref write (moved to effect) before merge.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #32
2. **#34** 👈 current
3. #35
4. #36
<!-- stack:links:end -->