### PR TITLE
CI: npm trusted publishing, tests in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,9 @@ jobs:
  
     - name: Lint
       run: bun run lint
-    
+
+    - name: Test
+      run: bun run test
+
+    - name: Build
+      run: bun run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 permissions:
   contents: write
+  id-token: write
 
 on:
   push:
@@ -35,28 +36,32 @@ jobs:
         
       - name: Lint
         run: bun run lint
-      
+
+      - name: Test
+        run: bun run test
+
       - name: Build
         run: bun run build
-      
+
+      - name: Setup Node for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Create GitHub Release
-        if: ${{ !inputs.dry_run && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ !inputs.dry_run }}
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
       
-      - name: Dry Run - Skip GitHub Release
-        if: ${{ inputs.dry_run || github.event_name == 'workflow_dispatch' }}
-        run: echo "SKIPPING GITHUB RELEASE in dry run mode"
-      
       - name: Publish to npm
-        if: ${{ !inputs.dry_run && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
-        run: bunx npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
+        if: ${{ !inputs.dry_run }}
+        run: npm publish
+
       - name: Dry Run - Simulate npm Publish
-        if: ${{ inputs.dry_run || github.event_name == 'workflow_dispatch' }}
-        run: |
-          echo "DRY RUN: Would publish package to npm"
-          bunx npm publish --dry-run
+        if: ${{ inputs.dry_run }}
+        run: npm publish --dry-run


### PR DESCRIPTION
Modernizes the existing workflows now that the fix stack has landed.

## Changes

- **`release.yml`**: publishing switches from the `NPM_TOKEN` secret to **npm OIDC trusted publishing** (`id-token: write` + npm ≥ 11.5 via Node 24 setup) — keyless, with provenance attestation automatic. Adds the test suite to the release gate. Fixes the dry-run conditions: previously a `workflow_dispatch` with `dry_run: false` executed both the real publish and the dry-run steps; now `dry_run` alone decides, and tag pushes always do the real publish.
- **`ci.yml`**: adds `test` (136 tests, new since vitest landed in #32) and `build` steps.

## One manual step (repo owner only)

On npmjs.com → package `micugl` → Settings → Publishing access: add a **Trusted Publisher** — GitHub Actions, repository `mcullan/micugl`, workflow `release.yml`, environment blank. After the first successful publish, the `NPM_TOKEN` secret can be deleted.

Until that's configured, a tag push will fail at the publish step (loudly, after all checks) — nothing publishes with the old token path anymore.
