### PR TITLE
micugl/testing T1: fail-loud GL stub, dogfooded in core manager tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -112,9 +112,28 @@ export default tseslint.config(
       'no-restricted-imports': ['error', {
         paths: [],
         patterns: [
-          { 
-            group: ['../*', '../../*'], 
-            message: 'Use absolute imports instead of relative imports outside current directory' 
+          {
+            group: ['../*', '../../*'],
+            message: 'Use absolute imports instead of relative imports outside current directory'
+          }
+        ]
+      }]
+    }
+  },
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/testing/**', 'src/**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        paths: [],
+        patterns: [
+          {
+            group: ['../*', '../../*'],
+            message: 'Use absolute imports instead of relative imports outside current directory'
+          },
+          {
+            group: ['@/testing', '@/testing/*', '**/testing/**'],
+            message: 'micugl/testing is dev/test-only and must stay out of library source; only src/testing/** and *.test.* files may import it.'
           }
         ]
       }]

--- a/src/core/managers/FBOManager.test.ts
+++ b/src/core/managers/FBOManager.test.ts
@@ -1,128 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { GL_FLOAT, GL_HALF_FLOAT_OES, GL_LINEAR, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
+import { GL_FLOAT, GL_LINEAR, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
 import { FBOManager } from '@/core/managers/FBOManager';
-
-interface TexImage2DCall {
-    internalFormat: number;
-    width: number;
-    height: number;
-    format: number;
-    type: number;
-}
-
-interface StubConfig {
-    floatExt?: boolean;
-    halfFloatExt?: boolean;
-    floatLinearExt?: boolean;
-    halfFloatLinearExt?: boolean;
-    renderableTypes?: number[];
-}
-
-interface GLStub {
-    gl: WebGLRenderingContext;
-    texImage2DCalls: TexImage2DCall[];
-    viewportCalls: number[][];
-}
-
-const ENUM = {
-    FLOAT: GL_FLOAT,
-    UNSIGNED_BYTE: GL_UNSIGNED_BYTE,
-    RGBA: 0x1908,
-    TEXTURE_2D: 0x0de1,
-    FRAMEBUFFER: 0x8d40,
-    COLOR_ATTACHMENT0: 0x8ce0,
-    FRAMEBUFFER_COMPLETE: 0x8cd5,
-    FRAMEBUFFER_INCOMPLETE_ATTACHMENT: 0x8cd6,
-    TEXTURE_MIN_FILTER: 0x2801,
-    TEXTURE_MAG_FILTER: 0x2800,
-    TEXTURE_WRAP_S: 0x2802,
-    TEXTURE_WRAP_T: 0x2803,
-    NEAREST: 0x2600,
-    LINEAR: GL_LINEAR,
-    CLAMP_TO_EDGE: 0x812f,
-    TEXTURE0: 0x84c0
-};
-
-function createGLStub(config: StubConfig = {}): GLStub {
-    const renderable = new Set<number>(config.renderableTypes ?? [GL_UNSIGNED_BYTE]);
-    const textureTypes = new Map<WebGLTexture, number>();
-    const fbAttachment = new Map<WebGLFramebuffer, WebGLTexture>();
-    const texImage2DCalls: TexImage2DCall[] = [];
-    const viewportCalls: number[][] = [];
-
-    let boundTexture: WebGLTexture | null = null;
-    let boundFramebuffer: WebGLFramebuffer | null = null;
-
-    const getExtension = (name: string): object | null => {
-        switch (name) {
-            case 'OES_texture_float':
-                return config.floatExt ? {} : null;
-            case 'OES_texture_half_float':
-                return config.halfFloatExt ? { HALF_FLOAT_OES: GL_HALF_FLOAT_OES } : null;
-            case 'OES_texture_float_linear':
-                return config.floatLinearExt ? {} : null;
-            case 'OES_texture_half_float_linear':
-                return config.halfFloatLinearExt ? {} : null;
-            default:
-                return null;
-        }
-    };
-
-    const stub = {
-        ...ENUM,
-        canvas: { width: 300, height: 150 },
-        getExtension,
-        createTexture: (): WebGLTexture => ({}),
-        createFramebuffer: (): WebGLFramebuffer => ({}),
-        bindTexture: (_target: number, texture: WebGLTexture | null): void => { boundTexture = texture },
-        bindFramebuffer: (_target: number, fb: WebGLFramebuffer | null): void => { boundFramebuffer = fb },
-        activeTexture: (): void => undefined,
-        texParameteri: (): void => undefined,
-        viewport: (x: number, y: number, width: number, height: number): void => {
-            viewportCalls.push([x, y, width, height]);
-        },
-        deleteTexture: (): void => undefined,
-        deleteFramebuffer: (): void => undefined,
-        texImage2D: (
-            _target: number, _level: number, internalFormat: number,
-            width: number, height: number, _border: number,
-            format: number, type: number
-        ): void => {
-            if (boundTexture) {
-                textureTypes.set(boundTexture, type);
-            }
-            texImage2DCalls.push({ internalFormat, width, height, format, type });
-        },
-        framebufferTexture2D: (
-            _target: number, _attachment: number, _textarget: number, texture: WebGLTexture
-        ): void => {
-            if (boundFramebuffer) {
-                fbAttachment.set(boundFramebuffer, texture);
-            }
-        },
-        checkFramebufferStatus: (): number => {
-            const texture = boundFramebuffer ? fbAttachment.get(boundFramebuffer) : undefined;
-            const type = texture ? textureTypes.get(texture) : undefined;
-            return type !== undefined && renderable.has(type)
-                ? ENUM.FRAMEBUFFER_COMPLETE
-                : ENUM.FRAMEBUFFER_INCOMPLETE_ATTACHMENT;
-        }
-    };
-
-    return { gl: stub as unknown as WebGLRenderingContext, texImage2DCalls, viewportCalls };
-}
+import { createGLStub } from '@/testing';
 
 describe('FBOManager capability resolution', () => {
     it('creates a FLOAT framebuffer when float is renderable', () => {
-        const { gl, texImage2DCalls } = createGLStub({
-            floatExt: true,
-            floatLinearExt: true,
+        const { gl, texImage2DCalls, reset } = createGLStub({
+            extensions: { OES_texture_float: true, OES_texture_float_linear: true },
             renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT]
         });
         const manager = new FBOManager(gl);
 
-        texImage2DCalls.length = 0;
+        reset();
         manager.createFramebuffer('sim', {
             width: 4,
             height: 4,
@@ -149,8 +39,7 @@ describe('FBOManager capability resolution', () => {
 
     it('records a filter downgrade when float is renderable but not filterable', () => {
         const { gl } = createGLStub({
-            floatExt: true,
-            floatLinearExt: false,
+            extensions: { OES_texture_float: true },
             renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT]
         });
         const manager = new FBOManager(gl);
@@ -168,8 +57,8 @@ describe('FBOManager capability resolution', () => {
 
 describe('FBOManager resizeFramebuffer', () => {
     it('reuses the creation texture type on resize instead of flipping to FLOAT', () => {
-        const { gl, texImage2DCalls } = createGLStub({
-            floatExt: true,
+        const { gl, texImage2DCalls, reset } = createGLStub({
+            extensions: { OES_texture_float: true },
             renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT]
         });
         const manager = new FBOManager(gl);
@@ -181,7 +70,7 @@ describe('FBOManager resizeFramebuffer', () => {
             textureOptions: { type: GL_UNSIGNED_BYTE }
         });
 
-        texImage2DCalls.length = 0;
+        reset();
         manager.resizeFramebuffer('post', 8, 8);
 
         expect(texImage2DCalls).toHaveLength(1);
@@ -189,7 +78,7 @@ describe('FBOManager resizeFramebuffer', () => {
     });
 
     it('resizes every texture in the ping-pong set', () => {
-        const { gl, texImage2DCalls } = createGLStub();
+        const { gl, texImage2DCalls, reset } = createGLStub();
         const manager = new FBOManager(gl);
 
         manager.createFramebuffer('feedback', {
@@ -199,7 +88,7 @@ describe('FBOManager resizeFramebuffer', () => {
             textureOptions: { type: GL_UNSIGNED_BYTE }
         });
 
-        texImage2DCalls.length = 0;
+        reset();
         manager.resizeFramebuffer('feedback', 16, 16);
 
         expect(texImage2DCalls).toHaveLength(2);
@@ -209,8 +98,8 @@ describe('FBOManager resizeFramebuffer', () => {
 
 describe('FBOManager destroy and recreate', () => {
     it('uses fresh texture options after destroy and recreate of the same id', () => {
-        const { gl, texImage2DCalls } = createGLStub({
-            floatExt: true,
+        const { gl, texImage2DCalls, reset } = createGLStub({
+            extensions: { OES_texture_float: true },
             renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT]
         });
         const manager = new FBOManager(gl);
@@ -231,7 +120,7 @@ describe('FBOManager destroy and recreate', () => {
             textureOptions: { type: GL_UNSIGNED_BYTE }
         });
 
-        texImage2DCalls.length = 0;
+        reset();
         manager.resizeFramebuffer('x', 8, 8);
 
         expect(texImage2DCalls[0].type).toBe(GL_UNSIGNED_BYTE);
@@ -240,7 +129,7 @@ describe('FBOManager destroy and recreate', () => {
 
 describe('FBOManager viewport cache', () => {
     it('applies the framebuffer viewport on bind, skips redundant binds, and restores canvas size', () => {
-        const { gl, viewportCalls } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
+        const { gl, viewportCalls, reset } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
         const manager = new FBOManager(gl);
 
         manager.createFramebuffer('a', {
@@ -250,7 +139,7 @@ describe('FBOManager viewport cache', () => {
             textureOptions: { type: GL_UNSIGNED_BYTE }
         });
 
-        viewportCalls.length = 0;
+        reset();
 
         manager.bindFramebuffer('a');
         manager.bindFramebuffer('a');

--- a/src/core/managers/WebGLManager.test.ts
+++ b/src/core/managers/WebGLManager.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { WebGLManager } from '@/core/managers/WebGLManager';
+import { createCanvasStub } from '@/testing';
 import type { ShaderProgramConfig } from '@/types';
 
 const CONFIG: ShaderProgramConfig = {
@@ -9,48 +10,10 @@ const CONFIG: ShaderProgramConfig = {
     uniforms: []
 };
 
-interface ManagerStub {
-    manager: WebGLManager;
-    useProgramCalls: WebGLProgram[];
-}
-
-function createManager(): ManagerStub {
-    const useProgramCalls: WebGLProgram[] = [];
-
-    const gl = {
-        VERTEX_SHADER: 0x8b31,
-        FRAGMENT_SHADER: 0x8b30,
-        COMPILE_STATUS: 0x8b81,
-        LINK_STATUS: 0x8b82,
-        COLOR_BUFFER_BIT: 0x4000,
-        canvas: { width: 300, height: 150 },
-        getExtension: (): null => null,
-        createShader: (): WebGLShader => ({}),
-        shaderSource: (): void => undefined,
-        compileShader: (): void => undefined,
-        getShaderParameter: (): boolean => true,
-        createProgram: (): WebGLProgram => ({}),
-        attachShader: (): void => undefined,
-        linkProgram: (): void => undefined,
-        getProgramParameter: (): boolean => true,
-        getProgramInfoLog: (): string => '',
-        getUniformLocation: (): WebGLUniformLocation => ({}),
-        getAttribLocation: (): number => 0,
-        useProgram: (program: WebGLProgram): void => { useProgramCalls.push(program) },
-        clearColor: (): void => undefined,
-        clear: (): void => undefined,
-        deleteProgram: (): void => undefined,
-        deleteShader: (): void => undefined,
-        deleteBuffer: (): void => undefined
-    };
-
-    const canvas = { getContext: (): unknown => gl } as unknown as HTMLCanvasElement;
-    return { manager: new WebGLManager(canvas), useProgramCalls };
-}
-
 describe('WebGLManager program tracking', () => {
     it('issues gl.useProgram only when the active program changes', () => {
-        const { manager, useProgramCalls } = createManager();
+        const { canvas, useProgramCalls } = createCanvasStub();
+        const manager = new WebGLManager(canvas);
         manager.createProgram('a', CONFIG);
         manager.createProgram('b', CONFIG);
 
@@ -64,7 +27,8 @@ describe('WebGLManager program tracking', () => {
     });
 
     it('re-issues gl.useProgram for a program recreated after destroying the current one', () => {
-        const { manager, useProgramCalls } = createManager();
+        const { canvas, useProgramCalls } = createCanvasStub();
+        const manager = new WebGLManager(canvas);
         manager.createProgram('a', CONFIG);
 
         manager.prepareRender('a');

--- a/src/testing/glStub.test.ts
+++ b/src/testing/glStub.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+
+import { GL_FLOAT, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
+import { createCanvasStub, createGLStub } from '@/testing';
+
+describe('createGLStub unstubbed calls', () => {
+    it('throws a descriptive error when calling a method the stub does not model', () => {
+        const { gl } = createGLStub();
+
+        expect(() => (gl as unknown as { getError: () => number }).getError())
+            .toThrow(/micugl test stub: unstubbed GL call gl\.getError\(\.\.\.\)/);
+    });
+
+    it('does not throw when merely reading an unmodeled method reference', () => {
+        const { gl } = createGLStub();
+
+        expect(() => (gl as unknown as { getError: unknown }).getError).not.toThrow();
+    });
+});
+
+describe('createGLStub enum-like fallback', () => {
+    it('returns a stable synthetic number for an unmodeled enum-looking property', () => {
+        const { gl } = createGLStub();
+        const stub = gl as unknown as Record<string, unknown>;
+
+        const first = stub.DEPTH_TEST;
+        const second = stub.DEPTH_TEST;
+
+        expect(typeof first).toBe('number');
+        expect(first).toBe(second);
+    });
+
+    it('gives different unmodeled enum names different synthetic numbers', () => {
+        const { gl } = createGLStub();
+        const stub = gl as unknown as Record<string, unknown>;
+
+        expect(stub.DEPTH_TEST).not.toBe(stub.STENCIL_TEST);
+    });
+});
+
+describe('createGLStub capability configuration', () => {
+    it('reflects renderableTypes in checkFramebufferStatus', () => {
+        const { gl } = createGLStub({
+            extensions: { OES_texture_float: true },
+            renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT]
+        });
+
+        const texture = gl.createTexture();
+        const framebuffer = gl.createFramebuffer();
+
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 4, 4, 0, gl.RGBA, GL_FLOAT, null);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+        expect(gl.checkFramebufferStatus(gl.FRAMEBUFFER)).toBe(gl.FRAMEBUFFER_COMPLETE);
+    });
+
+    it('reports incomplete when the bound texture type is not renderable', () => {
+        const { gl } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
+
+        const texture = gl.createTexture();
+        const framebuffer = gl.createFramebuffer();
+
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 4, 4, 0, gl.RGBA, GL_FLOAT, null);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+        expect(gl.checkFramebufferStatus(gl.FRAMEBUFFER)).not.toBe(gl.FRAMEBUFFER_COMPLETE);
+    });
+
+    it('reflects compileFails in getShaderParameter and getShaderInfoLog', () => {
+        const { gl } = createGLStub({ compileFails: true });
+        const shader = gl.createShader(gl.VERTEX_SHADER);
+        if (!shader) {
+            throw new Error('expected stub to create a shader');
+        }
+
+        expect(gl.getShaderParameter(shader, gl.COMPILE_STATUS)).toBe(false);
+        expect(gl.getShaderInfoLog(shader)).not.toBe('');
+    });
+
+    it('reflects linkFails in getProgramParameter and getProgramInfoLog', () => {
+        const { gl } = createGLStub({ linkFails: true });
+        const program = gl.createProgram();
+
+        expect(gl.getProgramParameter(program, gl.LINK_STATUS)).toBe(false);
+        expect(gl.getProgramInfoLog(program)).not.toBe('');
+    });
+
+    it('reflects missingAttributes in getAttribLocation', () => {
+        const { gl } = createGLStub({ missingAttributes: ['a_missing'] });
+        const program = gl.createProgram();
+
+        expect(gl.getAttribLocation(program, 'a_missing')).toBe(-1);
+        expect(gl.getAttribLocation(program, 'a_position')).toBe(0);
+        expect(gl.getAttribLocation(program, 'a_normal')).toBe(1);
+    });
+});
+
+describe('createGLStub call log ordering and typed views', () => {
+    it('records calls in invocation order in the generic calls log', () => {
+        const { gl, calls } = createGLStub();
+
+        gl.viewport(0, 0, 4, 4);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+
+        expect(calls.map(call => call.name)).toEqual(['viewport', 'clear']);
+    });
+
+    it('populates texImage2DCalls', () => {
+        const { gl, texImage2DCalls } = createGLStub();
+        const texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 4, 8, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+        expect(texImage2DCalls).toEqual([
+            { internalFormat: gl.RGBA, width: 4, height: 8, format: gl.RGBA, type: gl.UNSIGNED_BYTE }
+        ]);
+    });
+
+    it('populates viewportCalls', () => {
+        const { gl, viewportCalls } = createGLStub();
+
+        gl.viewport(1, 2, 3, 4);
+
+        expect(viewportCalls).toEqual([[1, 2, 3, 4]]);
+    });
+
+    it('populates useProgramCalls', () => {
+        const { gl, useProgramCalls } = createGLStub();
+        const program = gl.createProgram();
+
+        gl.useProgram(program);
+
+        expect(useProgramCalls).toEqual([program]);
+    });
+
+    it('populates uniformCalls across the uniform* family', () => {
+        const { gl, uniformCalls } = createGLStub();
+        const program = gl.createProgram();
+        gl.useProgram(program);
+        const location = gl.getUniformLocation(program, 'u_x');
+
+        gl.uniform1f(location, 1);
+        gl.uniform1i(location, 2);
+        gl.uniform2fv(location, [1, 2]);
+        gl.uniform3fv(location, [1, 2, 3]);
+        gl.uniform4fv(location, [1, 2, 3, 4]);
+        gl.uniformMatrix2fv(location, false, [1, 0, 0, 1]);
+        gl.uniformMatrix3fv(location, false, [1, 0, 0, 0, 1, 0, 0, 0, 1]);
+        gl.uniformMatrix4fv(location, false, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+        expect(uniformCalls.map(call => call.name)).toEqual([
+            'uniform1f',
+            'uniform1i',
+            'uniform2fv',
+            'uniform3fv',
+            'uniform4fv',
+            'uniformMatrix2fv',
+            'uniformMatrix3fv',
+            'uniformMatrix4fv'
+        ]);
+        expect(uniformCalls.every(call => call.location === location)).toBe(true);
+    });
+});
+
+describe('createGLStub uniform-location identity', () => {
+    it('returns the same location object for repeated lookups of the same name', () => {
+        const { gl } = createGLStub();
+        const program = gl.createProgram();
+
+        const first = gl.getUniformLocation(program, 'u_time');
+        const second = gl.getUniformLocation(program, 'u_time');
+
+        expect(first).toBe(second);
+    });
+
+    it('returns different location objects for different names', () => {
+        const { gl } = createGLStub();
+        const program = gl.createProgram();
+
+        const a = gl.getUniformLocation(program, 'u_a');
+        const b = gl.getUniformLocation(program, 'u_b');
+
+        expect(a).not.toBe(b);
+    });
+});
+
+describe('createGLStub reset', () => {
+    it('clears all recorded call logs but preserves gl identity', () => {
+        const { gl, calls, texImage2DCalls, viewportCalls, useProgramCalls, uniformCalls, reset } = createGLStub();
+        const program = gl.createProgram();
+        const texture = gl.createTexture();
+
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 4, 4, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        gl.viewport(0, 0, 4, 4);
+        gl.useProgram(program);
+        gl.uniform1f(gl.getUniformLocation(program, 'u_x'), 1);
+
+        const glBefore = gl;
+        reset();
+
+        expect(calls).toHaveLength(0);
+        expect(texImage2DCalls).toHaveLength(0);
+        expect(viewportCalls).toHaveLength(0);
+        expect(useProgramCalls).toHaveLength(0);
+        expect(uniformCalls).toHaveLength(0);
+        expect(gl).toBe(glBefore);
+    });
+});
+
+describe('createGLStub overrides', () => {
+    it('lets a consumer patch a single method without forking the stub', () => {
+        const calls: number[] = [];
+        const { gl } = createGLStub({
+            overrides: {
+                activeTexture: (texture: number): void => {
+                    calls.push(texture);
+                }
+            }
+        });
+
+        gl.activeTexture(gl.TEXTURE0);
+
+        expect(calls).toEqual([gl.TEXTURE0]);
+    });
+});
+
+describe('createCanvasStub', () => {
+    it('returns a canvas whose getContext resolves to the stubbed gl', () => {
+        const { canvas, gl } = createCanvasStub();
+
+        expect(canvas.getContext('webgl')).toBe(gl);
+        expect(canvas.getContext('experimental-webgl')).toBe(gl);
+        expect(canvas.getContext('2d')).toBeNull();
+    });
+
+    it('uses the configured canvas size', () => {
+        const { canvas } = createCanvasStub({ canvas: { width: 640, height: 480 } });
+
+        expect(canvas.width).toBe(640);
+        expect(canvas.height).toBe(480);
+    });
+});

--- a/src/testing/glStub.ts
+++ b/src/testing/glStub.ts
@@ -1,0 +1,465 @@
+import {
+    GL_CLAMP_TO_EDGE,
+    GL_FLOAT,
+    GL_HALF_FLOAT_OES,
+    GL_LINEAR,
+    GL_NEAREST,
+    GL_RGBA,
+    GL_UNSIGNED_BYTE
+} from '@/core/lib/glConstants';
+import type { WebGLExtensionName } from '@/types';
+
+const GL_ARRAY_BUFFER = 0x8892;
+const GL_BYTE = 0x1400;
+const GL_COLOR_ATTACHMENT0 = 0x8ce0;
+const GL_COLOR_BUFFER_BIT = 0x4000;
+const GL_COMPILE_STATUS = 0x8b81;
+const GL_FRAGMENT_SHADER = 0x8b30;
+const GL_FRAMEBUFFER = 0x8d40;
+const GL_FRAMEBUFFER_COMPLETE = 0x8cd5;
+const GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT = 0x8cd6;
+const GL_LINK_STATUS = 0x8b82;
+const GL_SHORT = 0x1402;
+const GL_STATIC_DRAW = 0x88e4;
+const GL_TEXTURE_2D = 0x0de1;
+const GL_TEXTURE_MAG_FILTER = 0x2800;
+const GL_TEXTURE_MIN_FILTER = 0x2801;
+const GL_TEXTURE_WRAP_S = 0x2802;
+const GL_TEXTURE_WRAP_T = 0x2803;
+const GL_TEXTURE0 = 0x84c0;
+const GL_TRIANGLE_STRIP = 0x0005;
+const GL_UNSIGNED_SHORT = 0x1403;
+const GL_VERTEX_SHADER = 0x8b31;
+
+const ENUM_CONSTANTS = {
+    ARRAY_BUFFER: GL_ARRAY_BUFFER,
+    BYTE: GL_BYTE,
+    CLAMP_TO_EDGE: GL_CLAMP_TO_EDGE,
+    COLOR_ATTACHMENT0: GL_COLOR_ATTACHMENT0,
+    COLOR_BUFFER_BIT: GL_COLOR_BUFFER_BIT,
+    COMPILE_STATUS: GL_COMPILE_STATUS,
+    FLOAT: GL_FLOAT,
+    FRAGMENT_SHADER: GL_FRAGMENT_SHADER,
+    FRAMEBUFFER: GL_FRAMEBUFFER,
+    FRAMEBUFFER_COMPLETE: GL_FRAMEBUFFER_COMPLETE,
+    FRAMEBUFFER_INCOMPLETE_ATTACHMENT: GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT,
+    LINEAR: GL_LINEAR,
+    LINK_STATUS: GL_LINK_STATUS,
+    NEAREST: GL_NEAREST,
+    RGBA: GL_RGBA,
+    SHORT: GL_SHORT,
+    STATIC_DRAW: GL_STATIC_DRAW,
+    TEXTURE_2D: GL_TEXTURE_2D,
+    TEXTURE_MAG_FILTER: GL_TEXTURE_MAG_FILTER,
+    TEXTURE_MIN_FILTER: GL_TEXTURE_MIN_FILTER,
+    TEXTURE_WRAP_S: GL_TEXTURE_WRAP_S,
+    TEXTURE_WRAP_T: GL_TEXTURE_WRAP_T,
+    TEXTURE0: GL_TEXTURE0,
+    TRIANGLE_STRIP: GL_TRIANGLE_STRIP,
+    UNSIGNED_BYTE: GL_UNSIGNED_BYTE,
+    UNSIGNED_SHORT: GL_UNSIGNED_SHORT,
+    VERTEX_SHADER: GL_VERTEX_SHADER
+} as const;
+
+const ENUM_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+function isEnumLikeName(name: string): boolean {
+    return ENUM_NAME_PATTERN.test(name);
+}
+
+function syntheticEnumValue(name: string): number {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+        hash = (hash * 31 + name.charCodeAt(i)) | 0;
+    }
+    return 0x40000 + (Math.abs(hash) % 0x10000);
+}
+
+export interface GLCall {
+    name: string;
+    args: unknown[];
+}
+
+export interface TexImage2DCallRecord {
+    internalFormat: number;
+    width: number;
+    height: number;
+    format: number;
+    type: number;
+}
+
+export interface UniformCallRecord {
+    name: string;
+    location: WebGLUniformLocation | null;
+    value: unknown;
+}
+
+export interface GLStubConfig {
+    extensions?: Partial<Record<WebGLExtensionName, boolean>>;
+    renderableTypes?: number[];
+    canvas?: { width: number; height: number };
+    compileFails?: boolean;
+    linkFails?: boolean;
+    missingAttributes?: string[];
+    overrides?: Partial<WebGLRenderingContext>;
+}
+
+export interface GLStubHandle {
+    gl: WebGLRenderingContext;
+    calls: readonly GLCall[];
+    texImage2DCalls: readonly TexImage2DCallRecord[];
+    viewportCalls: readonly [number, number, number, number][];
+    useProgramCalls: readonly WebGLProgram[];
+    uniformCalls: readonly UniformCallRecord[];
+    reset: () => void;
+    config: Readonly<GLStubConfig>;
+}
+
+export interface CanvasStubHandle extends GLStubHandle {
+    canvas: HTMLCanvasElement;
+}
+
+const UNSTUBBED_METHOD_MESSAGE_SUFFIX =
+    'This stub models capability probing, program/uniform/attribute accounting and ' +
+    'framebuffer-completeness only — it does not emulate rendering. Provide an override or file an issue.';
+
+export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
+    const resolvedConfig: Readonly<GLStubConfig> = { ...config };
+    const canvasSize = config.canvas ?? { width: 300, height: 150 };
+    const renderableTypes = new Set<number>(config.renderableTypes ?? [GL_UNSIGNED_BYTE]);
+    const missingAttributes = new Set<string>(config.missingAttributes ?? []);
+    const extensionFlags = (config.extensions ?? {}) as Record<string, boolean | undefined>;
+
+    const calls: GLCall[] = [];
+    const texImage2DCalls: TexImage2DCallRecord[] = [];
+    const viewportCalls: [number, number, number, number][] = [];
+    const useProgramCalls: WebGLProgram[] = [];
+    const uniformCalls: UniformCallRecord[] = [];
+
+    let boundTexture: WebGLTexture | null = null;
+    let boundFramebuffer: WebGLFramebuffer | null = null;
+    let boundBuffer: WebGLBuffer | null = null;
+    let currentProgram: WebGLProgram | null = null;
+
+    const textureTypes = new Map<WebGLTexture, number>();
+    const fbAttachment = new Map<WebGLFramebuffer, WebGLTexture>();
+    const uniformLocations = new Map<string, WebGLUniformLocation>();
+    const attributeLocations = new Map<string, number>();
+    let nextAttributeLocation = 0;
+
+    const record = (name: string, args: unknown[]): void => {
+        calls.push({ name, args });
+    };
+
+    const extensionObjects: Record<string, object> = {
+        OES_texture_float: {},
+        OES_texture_float_linear: {},
+        OES_texture_half_float: { HALF_FLOAT_OES: GL_HALF_FLOAT_OES },
+        OES_texture_half_float_linear: {},
+        OES_vertex_array_object: {},
+        ANGLE_instanced_arrays: {
+            vertexAttribDivisorANGLE: (index: number, divisor: number): void => {
+                record('vertexAttribDivisorANGLE', [index, divisor]);
+            }
+        },
+        WEBGL_lose_context: {
+            loseContext: (): void => {
+                record('loseContext', []);
+            }
+        }
+    };
+
+    const canvas = {
+        width: canvasSize.width,
+        height: canvasSize.height,
+        style: { width: '', height: '' },
+        getContext: (contextId: string): WebGLRenderingContext | null =>
+            contextId === 'webgl' || contextId === 'experimental-webgl' ? gl : null
+    };
+
+    const recordUniform = (name: string, location: WebGLUniformLocation | null, value: unknown, args: unknown[]): void => {
+        record(name, args);
+        uniformCalls.push({ name, location, value });
+    };
+
+    const impl = {
+        ...ENUM_CONSTANTS,
+        canvas,
+        getExtension: (name: string): object | null => {
+            record('getExtension', [name]);
+            if (!(extensionFlags[name] ?? false)) {
+                return null;
+            }
+            return extensionObjects[name] ?? {};
+        },
+        createTexture: (): WebGLTexture => {
+            record('createTexture', []);
+            return {};
+        },
+        createFramebuffer: (): WebGLFramebuffer => {
+            record('createFramebuffer', []);
+            return {};
+        },
+        createBuffer: (): WebGLBuffer => {
+            record('createBuffer', []);
+            return {};
+        },
+        createProgram: (): WebGLProgram => {
+            record('createProgram', []);
+            return {};
+        },
+        createShader: (type: number): WebGLShader => {
+            record('createShader', [type]);
+            return {};
+        },
+        bindTexture: (target: number, texture: WebGLTexture | null): void => {
+            record('bindTexture', [target, texture]);
+            boundTexture = texture;
+        },
+        bindFramebuffer: (target: number, framebuffer: WebGLFramebuffer | null): void => {
+            record('bindFramebuffer', [target, framebuffer]);
+            boundFramebuffer = framebuffer;
+        },
+        bindBuffer: (target: number, buffer: WebGLBuffer | null): void => {
+            record('bindBuffer', [target, buffer]);
+            boundBuffer = buffer;
+        },
+        activeTexture: (texture: number): void => {
+            record('activeTexture', [texture]);
+        },
+        texParameteri: (target: number, pname: number, param: number): void => {
+            record('texParameteri', [target, pname, param]);
+        },
+        viewport: (x: number, y: number, width: number, height: number): void => {
+            record('viewport', [x, y, width, height]);
+            viewportCalls.push([x, y, width, height]);
+        },
+        deleteTexture: (texture: WebGLTexture | null): void => {
+            record('deleteTexture', [texture]);
+            if (boundTexture === texture) {
+                boundTexture = null;
+            }
+        },
+        deleteFramebuffer: (framebuffer: WebGLFramebuffer | null): void => {
+            record('deleteFramebuffer', [framebuffer]);
+            if (boundFramebuffer === framebuffer) {
+                boundFramebuffer = null;
+            }
+        },
+        deleteBuffer: (buffer: WebGLBuffer | null): void => {
+            record('deleteBuffer', [buffer]);
+            if (boundBuffer === buffer) {
+                boundBuffer = null;
+            }
+        },
+        deleteProgram: (program: WebGLProgram | null): void => {
+            record('deleteProgram', [program]);
+            if (currentProgram === program) {
+                currentProgram = null;
+            }
+        },
+        deleteShader: (shader: WebGLShader | null): void => {
+            record('deleteShader', [shader]);
+        },
+        texImage2D: (
+            target: number,
+            level: number,
+            internalFormat: number,
+            width: number,
+            height: number,
+            border: number,
+            format: number,
+            type: number,
+            pixels: ArrayBufferView | null
+        ): void => {
+            record('texImage2D', [target, level, internalFormat, width, height, border, format, type, pixels]);
+            if (boundTexture) {
+                textureTypes.set(boundTexture, type);
+            }
+            texImage2DCalls.push({ internalFormat, width, height, format, type });
+        },
+        framebufferTexture2D: (
+            fbTarget: number,
+            attachment: number,
+            texTarget: number,
+            texture: WebGLTexture,
+            level: number
+        ): void => {
+            record('framebufferTexture2D', [fbTarget, attachment, texTarget, texture, level]);
+            if (boundFramebuffer) {
+                fbAttachment.set(boundFramebuffer, texture);
+            }
+        },
+        checkFramebufferStatus: (target: number): number => {
+            record('checkFramebufferStatus', [target]);
+            const texture = boundFramebuffer ? fbAttachment.get(boundFramebuffer) : undefined;
+            const type = texture ? textureTypes.get(texture) : undefined;
+            return type !== undefined && renderableTypes.has(type)
+                ? GL_FRAMEBUFFER_COMPLETE
+                : GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT;
+        },
+        shaderSource: (shader: WebGLShader, source: string): void => {
+            record('shaderSource', [shader, source]);
+        },
+        compileShader: (shader: WebGLShader): void => {
+            record('compileShader', [shader]);
+        },
+        attachShader: (program: WebGLProgram, shader: WebGLShader): void => {
+            record('attachShader', [program, shader]);
+        },
+        linkProgram: (program: WebGLProgram): void => {
+            record('linkProgram', [program]);
+        },
+        getShaderParameter: (shader: WebGLShader, pname: number): boolean => {
+            record('getShaderParameter', [shader, pname]);
+            return pname === GL_COMPILE_STATUS ? !config.compileFails : true;
+        },
+        getProgramParameter: (program: WebGLProgram, pname: number): boolean => {
+            record('getProgramParameter', [program, pname]);
+            return pname === GL_LINK_STATUS ? !config.linkFails : true;
+        },
+        getShaderInfoLog: (shader: WebGLShader): string => {
+            record('getShaderInfoLog', [shader]);
+            return config.compileFails ? 'micugl test stub: simulated shader compile failure' : '';
+        },
+        getProgramInfoLog: (program: WebGLProgram): string => {
+            record('getProgramInfoLog', [program]);
+            return config.linkFails ? 'micugl test stub: simulated program link failure' : '';
+        },
+        getUniformLocation: (program: WebGLProgram, name: string): WebGLUniformLocation => {
+            record('getUniformLocation', [program, name]);
+            let location = uniformLocations.get(name);
+            if (!location) {
+                location = {};
+                uniformLocations.set(name, location);
+            }
+            return location;
+        },
+        getAttribLocation: (program: WebGLProgram, name: string): number => {
+            record('getAttribLocation', [program, name]);
+            if (missingAttributes.has(name)) {
+                return -1;
+            }
+            let location = attributeLocations.get(name);
+            if (location === undefined) {
+                location = nextAttributeLocation;
+                nextAttributeLocation += 1;
+                attributeLocations.set(name, location);
+            }
+            return location;
+        },
+        useProgram: (program: WebGLProgram | null): void => {
+            record('useProgram', [program]);
+            currentProgram = program;
+            if (program) {
+                useProgramCalls.push(program);
+            }
+        },
+        clearColor: (red: number, green: number, blue: number, alpha: number): void => {
+            record('clearColor', [red, green, blue, alpha]);
+        },
+        clear: (mask: number): void => {
+            record('clear', [mask]);
+        },
+        bufferData: (target: number, data: ArrayBufferView, usage: number): void => {
+            record('bufferData', [target, data, usage]);
+        },
+        drawArrays: (mode: number, first: number, count: number): void => {
+            record('drawArrays', [mode, first, count]);
+        },
+        drawElements: (mode: number, count: number, type: number, offset: number): void => {
+            record('drawElements', [mode, count, type, offset]);
+        },
+        enableVertexAttribArray: (index: number): void => {
+            record('enableVertexAttribArray', [index]);
+        },
+        vertexAttribPointer: (
+            index: number,
+            size: number,
+            type: number,
+            normalized: boolean,
+            stride: number,
+            offset: number
+        ): void => {
+            record('vertexAttribPointer', [index, size, type, normalized, stride, offset]);
+        },
+        vertexAttribDivisor: (index: number, divisor: number): void => {
+            record('vertexAttribDivisor', [index, divisor]);
+        },
+        uniform1f: (location: WebGLUniformLocation | null, value: number): void => {
+            recordUniform('uniform1f', location, value, [location, value]);
+        },
+        uniform1i: (location: WebGLUniformLocation | null, value: number): void => {
+            recordUniform('uniform1i', location, value, [location, value]);
+        },
+        uniform2fv: (location: WebGLUniformLocation | null, value: Float32Array | number[]): void => {
+            recordUniform('uniform2fv', location, value, [location, value]);
+        },
+        uniform3fv: (location: WebGLUniformLocation | null, value: Float32Array | number[]): void => {
+            recordUniform('uniform3fv', location, value, [location, value]);
+        },
+        uniform4fv: (location: WebGLUniformLocation | null, value: Float32Array | number[]): void => {
+            recordUniform('uniform4fv', location, value, [location, value]);
+        },
+        uniformMatrix2fv: (location: WebGLUniformLocation | null, transpose: boolean, value: Float32Array | number[]): void => {
+            recordUniform('uniformMatrix2fv', location, value, [location, transpose, value]);
+        },
+        uniformMatrix3fv: (location: WebGLUniformLocation | null, transpose: boolean, value: Float32Array | number[]): void => {
+            recordUniform('uniformMatrix3fv', location, value, [location, transpose, value]);
+        },
+        uniformMatrix4fv: (location: WebGLUniformLocation | null, transpose: boolean, value: Float32Array | number[]): void => {
+            recordUniform('uniformMatrix4fv', location, value, [location, transpose, value]);
+        }
+    };
+
+    if (config.overrides) {
+        Object.assign(impl, config.overrides);
+    }
+
+    const handler: ProxyHandler<typeof impl> = {
+        get(obj, prop, receiver): unknown {
+            if (typeof prop === 'symbol') {
+                return Reflect.get(obj, prop, receiver);
+            }
+            if (prop in obj) {
+                return Reflect.get(obj, prop, receiver);
+            }
+            if (isEnumLikeName(prop)) {
+                return syntheticEnumValue(prop);
+            }
+            if (prop === 'then') {
+                return undefined;
+            }
+            return (): never => {
+                throw new Error(
+                    `micugl test stub: unstubbed GL call gl.${prop}(...). ${UNSTUBBED_METHOD_MESSAGE_SUFFIX}`
+                );
+            };
+        }
+    };
+
+    const gl = new Proxy(impl, handler) as unknown as WebGLRenderingContext;
+
+    return {
+        gl,
+        calls,
+        texImage2DCalls,
+        viewportCalls,
+        useProgramCalls,
+        uniformCalls,
+        reset: (): void => {
+            calls.length = 0;
+            texImage2DCalls.length = 0;
+            viewportCalls.length = 0;
+            useProgramCalls.length = 0;
+            uniformCalls.length = 0;
+        },
+        config: resolvedConfig
+    };
+}
+
+export function createCanvasStub(config: GLStubConfig = {}): CanvasStubHandle {
+    const handle = createGLStub(config);
+    const canvas = handle.gl.canvas as unknown as HTMLCanvasElement;
+    return { canvas, ...handle };
+}

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,0 +1,9 @@
+export type {
+    CanvasStubHandle,
+    GLCall,
+    GLStubConfig,
+    GLStubHandle,
+    TexImage2DCallRecord,
+    UniformCallRecord
+} from '@/testing/glStub';
+export { createCanvasStub, createGLStub } from '@/testing/glStub';


### PR DESCRIPTION
First slice of the `micugl/testing` subpath (plan: testing-devtools, §1.1a/§1.7 T1).

## What

- `src/testing/glStub.ts` — `createGLStub`/`createCanvasStub`: a consumer-grade, fail-loud WebGL stub. Union of the two hand-rolled stubs previously duplicated in the manager tests, plus the full GL surface the library actually calls. Unstubbed method calls throw a descriptive error via a Proxy (instead of an opaque `x is not a function`); enum-looking unknown property reads return stable synthetic numbers; `then` is explicitly `undefined` so the proxy is not a fake thenable.
- Ordered `calls` log plus typed views (`texImage2DCalls`, `viewportCalls`, `useProgramCalls`, `uniformCalls`) for asserting dirty-check/upload behavior.
- State tracked: bound texture/framebuffer/buffer/program, texture→type and framebuffer→attachment maps, stable uniform-location identity per name, configurable missing attributes, `renderableTypes`, `compileFails`/`linkFails`, per-method `overrides`.
- `FBOManager.test.ts` / `WebGLManager.test.ts` migrated to the shared stub — every prior assertion kept; the migration is the integration meta-test.
- eslint `no-restricted-imports` guard: nothing in non-test `src/**` may import from `src/testing/**`.

## Not in this PR (T2, stacked next)

Browser instrumentation (`installInstrumentation`), assertion helpers, the `./testing` export-map entry + vite entry + `sideEffects: false`, and the bench harness consuming the shipped counter core.

## Verification

- typecheck / lint / test / build all green; 156 tests (was 136).
- Import purity: `src/testing` imports cleanly in bare node (no browser-global deref at module scope).
- Adversarial review pass: one confirmed bug found and fixed (thenable leak through the Proxy get-trap); reset-semantics of the migrated suites checked call-site-by-call-site against the old per-view resets.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#38** 👈 current
2. #39
<!-- stack:links:end -->