### PR TITLE
devtools D1: beacon registry + engine registration, micugl/devtools skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing.mjs",
       "require": "./dist/testing.js"
+    },
+    "./devtools": {
+      "types": "./dist/react/devtools/index.d.ts",
+      "import": "./dist/devtools.mjs",
+      "require": "./dist/devtools.js"
     }
   },
   "files": [

--- a/src/core/managers/FBOManager.test.ts
+++ b/src/core/managers/FBOManager.test.ts
@@ -148,3 +148,21 @@ describe('FBOManager viewport cache', () => {
         expect(viewportCalls).toEqual([[0, 0, 4, 4], [0, 0, 300, 150]]);
     });
 });
+
+describe('FBOManager getFramebufferIds', () => {
+    it('lists created framebuffer ids and reflects destroy', () => {
+        const { gl } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
+        const manager = new FBOManager(gl);
+
+        expect(manager.getFramebufferIds()).toEqual([]);
+
+        manager.createFramebuffer('a', { width: 4, height: 4, textureCount: 1 });
+        manager.createFramebuffer('b', { width: 4, height: 4, textureCount: 1 });
+
+        expect(manager.getFramebufferIds().sort()).toEqual(['a', 'b']);
+
+        manager.destroy('a');
+
+        expect(manager.getFramebufferIds()).toEqual(['b']);
+    });
+});

--- a/src/core/managers/FBOManager.ts
+++ b/src/core/managers/FBOManager.ts
@@ -317,6 +317,10 @@ export class FBOManager {
         return this.capabilities;
     }
 
+    getFramebufferIds(): string[] {
+        return Array.from(this.resources.keys());
+    }
+
     isFloatTexturesSupported(): boolean {
         return this.capabilities.floatRenderable;
     }

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -16,6 +16,8 @@ import type {
 } from '@/core';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import { Passes } from '@/core/systems/Passes';
+import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
+import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
 import { framebuffersContentKey, programConfigsContentKey } from '@/react/lib/contentKeys';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import {
@@ -60,6 +62,32 @@ const readNow = (): number => (typeof performance === 'object' ? performance.now
 const readDevicePixelRatio = (): number =>
     typeof window === 'object' ? window.devicePixelRatio : 1;
 
+let engineIdCounter = 0;
+
+const createEngineId = (): string => {
+    if (typeof crypto === 'object' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+    engineIdCounter += 1;
+    return `pingpong-${engineIdCounter}`;
+};
+
+const emptyDebugState = (id: string): EngineDebugState => ({
+    kind: 'pingpong',
+    id,
+    canvas: { renderWidth: 0, renderHeight: 0, displayWidth: 0, displayHeight: 0 },
+    programIds: [],
+    framebufferIds: [],
+    capabilities: {
+        floatRenderable: false,
+        halfFloatRenderable: false,
+        floatLinearFilterable: false,
+        halfFloatLinearFilterable: false,
+        halfFloatType: 0
+    },
+    floatFilterDowngraded: false
+});
+
 const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEngineProps>(({
     programConfigs,
     passes,
@@ -80,6 +108,11 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
     fit = 'window'
 }, ref) => {
     const contentKey = `${programConfigsContentKey(programConfigs)}\u0002${framebuffersContentKey(framebuffers)}`;
+
+    const engineIdRef = useRef<string>('');
+    if (!engineIdRef.current) {
+        engineIdRef.current = createEngineId();
+    }
 
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const managerRef = useRef<WebGLManager | null>(null);
@@ -226,6 +259,51 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
             readyRef.current = true;
             applySizeRef.current();
             controllerRef.current?.start();
+
+            const managerWeak = new WeakRef(manager);
+            const engineId = engineIdRef.current;
+            let lastKnownState: EngineDebugState | null = null;
+
+            const handle: EngineHandle = {
+                id: engineId,
+                kind: 'pingpong',
+                getManager: () => managerWeak.deref() ?? null,
+                getState: () => {
+                    const currentManager = managerWeak.deref();
+                    if (!currentManager) {
+                        return lastKnownState ?? emptyDebugState(engineId);
+                    }
+                    try {
+                        const glCanvas = currentManager.context.canvas as HTMLCanvasElement;
+                        const state: EngineDebugState = {
+                            kind: 'pingpong',
+                            id: engineId,
+                            canvas: {
+                                renderWidth: glCanvas.width,
+                                renderHeight: glCanvas.height,
+                                displayWidth: glCanvas.clientWidth,
+                                displayHeight: glCanvas.clientHeight
+                            },
+                            programIds: Array.from(currentManager.resources.keys()),
+                            framebufferIds: currentManager.fbo.getFramebufferIds(),
+                            capabilities: currentManager.fbo.getCapabilities(),
+                            floatFilterDowngraded: currentManager.fbo.wasFloatFilterDowngraded(),
+                            frameloop: controllerRef.current?.getFrameloop(),
+                            paused: controllerRef.current?.isPaused(),
+                            speed: controllerRef.current?.getSpeed()
+                        };
+                        lastKnownState = state;
+                        return state;
+                    } catch {
+                        return lastKnownState ?? emptyDebugState(engineId);
+                    }
+                },
+                invalidate: () => { controllerRef.current?.invalidate() },
+                setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
+                getFrame: () => controllerRef.current?.getFrame() ?? 0,
+                setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) }
+            };
+            emitEngineMount(handle);
         }
 
         return () => {
@@ -233,6 +311,7 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
             controllerRef.current?.stop();
             manager.destroyAll();
             passSystemRef.current = null;
+            emitEngineUnmount(engineIdRef.current);
         };
     }, [contentKey, epoch]);
 

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -17,6 +17,8 @@ import type {
     UniformUpdateFn
 } from '@/core';
 import { WebGLManager } from '@/core/managers/WebGLManager';
+import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
+import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
 import { programConfigContentKey, singleProgramEntry } from '@/react/lib/contentKeys';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import {
@@ -69,6 +71,32 @@ const readNow = (): number => (typeof performance === 'object' ? performance.now
 const readDevicePixelRatio = (): number =>
     typeof window === 'object' ? window.devicePixelRatio : 1;
 
+let engineIdCounter = 0;
+
+const createEngineId = (): string => {
+    if (typeof crypto === 'object' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+    engineIdCounter += 1;
+    return `shader-${engineIdCounter}`;
+};
+
+const emptyDebugState = (id: string): EngineDebugState => ({
+    kind: 'shader',
+    id,
+    canvas: { renderWidth: 0, renderHeight: 0, displayWidth: 0, displayHeight: 0 },
+    programIds: [],
+    framebufferIds: [],
+    capabilities: {
+        floatRenderable: false,
+        halfFloatRenderable: false,
+        floatLinearFilterable: false,
+        halfFloatLinearFilterable: false,
+        halfFloatType: 0
+    },
+    floatFilterDowngraded: false
+});
+
 const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     programConfigs,
     renderCallback,
@@ -90,6 +118,11 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
 }, ref) => {
     const [keyProgramId, keyProgramConfig] = singleProgramEntry(programConfigs);
     const contentKey = programConfigContentKey(keyProgramId, keyProgramConfig);
+
+    const engineIdRef = useRef<string>('');
+    if (!engineIdRef.current) {
+        engineIdRef.current = createEngineId();
+    }
 
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const managerRef = useRef<WebGLManager | null>(null);
@@ -234,6 +267,51 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             readyRef.current = true;
             applySizeRef.current();
             controllerRef.current?.start();
+
+            const managerWeak = new WeakRef(manager);
+            const engineId = engineIdRef.current;
+            let lastKnownState: EngineDebugState | null = null;
+
+            const handle: EngineHandle = {
+                id: engineId,
+                kind: 'shader',
+                getManager: () => managerWeak.deref() ?? null,
+                getState: () => {
+                    const currentManager = managerWeak.deref();
+                    if (!currentManager) {
+                        return lastKnownState ?? emptyDebugState(engineId);
+                    }
+                    try {
+                        const glCanvas = currentManager.context.canvas as HTMLCanvasElement;
+                        const state: EngineDebugState = {
+                            kind: 'shader',
+                            id: engineId,
+                            canvas: {
+                                renderWidth: glCanvas.width,
+                                renderHeight: glCanvas.height,
+                                displayWidth: glCanvas.clientWidth,
+                                displayHeight: glCanvas.clientHeight
+                            },
+                            programIds: Array.from(currentManager.resources.keys()),
+                            framebufferIds: currentManager.fbo.getFramebufferIds(),
+                            capabilities: currentManager.fbo.getCapabilities(),
+                            floatFilterDowngraded: currentManager.fbo.wasFloatFilterDowngraded(),
+                            frameloop: controllerRef.current?.getFrameloop(),
+                            paused: controllerRef.current?.isPaused(),
+                            speed: controllerRef.current?.getSpeed()
+                        };
+                        lastKnownState = state;
+                        return state;
+                    } catch {
+                        return lastKnownState ?? emptyDebugState(engineId);
+                    }
+                },
+                invalidate: () => { controllerRef.current?.invalidate() },
+                setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
+                getFrame: () => controllerRef.current?.getFrame() ?? 0,
+                setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) }
+            };
+            emitEngineMount(handle);
         }
 
         return () => {
@@ -241,6 +319,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             controllerRef.current?.stop();
             manager.destroyAll();
             activeProgram.current = null;
+            emitEngineUnmount(engineIdRef.current);
         };
     }, [contentKey, epoch]);
 

--- a/src/react/devtools/beacon.test.ts
+++ b/src/react/devtools/beacon.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    emitEngineMount,
+    emitEngineUnmount,
+    type EngineHandle,
+    listEngines,
+    setDevtoolsSink
+} from '@/react/devtools/beacon';
+
+const emptyCapabilities = {
+    floatRenderable: false,
+    halfFloatRenderable: false,
+    floatLinearFilterable: false,
+    halfFloatLinearFilterable: false,
+    halfFloatType: 0
+};
+
+function createHandle(id: string): EngineHandle {
+    return {
+        id,
+        kind: 'shader',
+        getManager: () => null,
+        getState: () => ({
+            kind: 'shader',
+            id,
+            canvas: { renderWidth: 0, renderHeight: 0, displayWidth: 0, displayHeight: 0 },
+            programIds: [],
+            framebufferIds: [],
+            capabilities: emptyCapabilities,
+            floatFilterDowngraded: false
+        })
+    };
+}
+
+afterEach(() => {
+    setDevtoolsSink(null);
+    for (const handle of listEngines()) {
+        emitEngineUnmount(handle.id);
+    }
+});
+
+describe('beacon registry', () => {
+    it('mount adds the engine to listEngines, unmount removes it', () => {
+        const handle = createHandle('engine-a');
+        emitEngineMount(handle);
+
+        expect(listEngines()).toEqual([handle]);
+
+        emitEngineUnmount('engine-a');
+
+        expect(listEngines()).toEqual([]);
+    });
+
+    it('setDevtoolsSink replays already-mounted engines to a late-mounting sink', () => {
+        const handle = createHandle('engine-a');
+        emitEngineMount(handle);
+
+        const mounted: EngineHandle[] = [];
+        setDevtoolsSink({ onMount: h => { mounted.push(h) }, onUnmount: () => undefined });
+
+        expect(mounted).toEqual([handle]);
+    });
+
+    it('an attached sink receives onMount and onUnmount as engines register', () => {
+        const mounted: EngineHandle[] = [];
+        const unmounted: string[] = [];
+        setDevtoolsSink({
+            onMount: h => { mounted.push(h) },
+            onUnmount: id => { unmounted.push(id) }
+        });
+
+        const handle = createHandle('engine-a');
+        emitEngineMount(handle);
+        emitEngineUnmount('engine-a');
+
+        expect(mounted).toEqual([handle]);
+        expect(unmounted).toEqual(['engine-a']);
+    });
+
+    it('a late-mounting sink discovers engines mounted before it attached', () => {
+        emitEngineMount(createHandle('engine-a'));
+        emitEngineMount(createHandle('engine-b'));
+
+        const mountedIds: string[] = [];
+        setDevtoolsSink({ onMount: h => { mountedIds.push(h.id) }, onUnmount: () => undefined });
+
+        expect(mountedIds.sort()).toEqual(['engine-a', 'engine-b']);
+    });
+
+    it('double-unmount of the same id is safe and idempotent', () => {
+        emitEngineMount(createHandle('engine-a'));
+        emitEngineUnmount('engine-a');
+
+        expect(() => { emitEngineUnmount('engine-a') }).not.toThrow();
+        expect(listEngines()).toEqual([]);
+    });
+
+    it('unmounting an id that was never mounted is safe', () => {
+        expect(() => { emitEngineUnmount('never-mounted') }).not.toThrow();
+        expect(listEngines()).toEqual([]);
+    });
+
+    it('setDevtoolsSink(null) detaches the sink so later mounts are not observed', () => {
+        const mountedIds: string[] = [];
+        setDevtoolsSink({ onMount: h => { mountedIds.push(h.id) }, onUnmount: () => undefined });
+        setDevtoolsSink(null);
+
+        emitEngineMount(createHandle('engine-a'));
+
+        expect(mountedIds).toEqual([]);
+        expect(listEngines().map(h => h.id)).toEqual(['engine-a']);
+    });
+});

--- a/src/react/devtools/beacon.ts
+++ b/src/react/devtools/beacon.ts
@@ -1,0 +1,58 @@
+import type { WebGLManager } from '@/core';
+import type { TextureCapabilities } from '@/core/lib/textureCapabilities';
+import type { Frameloop } from '@/types';
+
+export interface EngineDebugState {
+    kind: 'shader' | 'pingpong';
+    id: string;
+    canvas: { renderWidth: number; renderHeight: number; displayWidth: number; displayHeight: number };
+    programIds: string[];
+    framebufferIds: string[];
+    capabilities: TextureCapabilities;
+    floatFilterDowngraded: boolean;
+    frameloop?: Frameloop;
+    paused?: boolean;
+    speed?: number;
+}
+
+export interface EngineHandle {
+    id: string;
+    kind: 'shader' | 'pingpong';
+    getManager: () => WebGLManager | null;
+    getState: () => EngineDebugState;
+    invalidate?: () => void;
+    setFrameloop?: (mode: Frameloop) => void;
+    setFrame?: (frame: number) => void;
+    getFrame?: () => number;
+}
+
+export interface DevtoolsSink {
+    onMount: (handle: EngineHandle) => void;
+    onUnmount: (id: string) => void;
+}
+
+let sink: DevtoolsSink | null = null;
+const engines = new Map<string, EngineHandle>();
+
+export function setDevtoolsSink(next: DevtoolsSink | null): void {
+    sink = next;
+    if (next) {
+        for (const handle of engines.values()) {
+            next.onMount(handle);
+        }
+    }
+}
+
+export function emitEngineMount(handle: EngineHandle): void {
+    engines.set(handle.id, handle);
+    sink?.onMount(handle);
+}
+
+export function emitEngineUnmount(id: string): void {
+    engines.delete(id);
+    sink?.onUnmount(id);
+}
+
+export function listEngines(): EngineHandle[] {
+    return [...engines.values()];
+}

--- a/src/react/devtools/index.ts
+++ b/src/react/devtools/index.ts
@@ -1,0 +1,4 @@
+/** @experimental */
+export type { DevtoolsSink, EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
+/** @experimental */
+export { listEngines, setDevtoolsSink } from '@/react/devtools/beacon';

--- a/src/react/lib/renderLoop.test.ts
+++ b/src/react/lib/renderLoop.test.ts
@@ -287,3 +287,41 @@ describe('RenderLoop speed and control', () => {
         }
     });
 });
+
+describe('RenderLoop introspection getters', () => {
+    it('reports the configured frameloop mode and reacts to setFrameloop', () => {
+        const h = harness({ frameloop: 'demand' });
+        expect(h.loop.getFrameloop()).toBe('demand');
+
+        h.loop.setFrameloop('always');
+        expect(h.loop.getFrameloop()).toBe('always');
+    });
+
+    it('reports the configured speed and reacts to setSpeed', () => {
+        const h = harness({ speed: 2 });
+        expect(h.loop.getSpeed()).toBe(2);
+
+        h.loop.setSpeed(0.5);
+        expect(h.loop.getSpeed()).toBe(0.5);
+    });
+
+    it('reports paused before start and while hidden, unpaused once started and visible', () => {
+        const h = harness({ frameloop: 'always' });
+        expect(h.loop.isPaused()).toBe(true);
+
+        h.loop.start();
+        expect(h.loop.isPaused()).toBe(false);
+
+        h.loop.setVisible(false);
+        expect(h.loop.isPaused()).toBe(true);
+
+        h.loop.setVisible(true);
+        expect(h.loop.isPaused()).toBe(false);
+    });
+
+    it('reports paused when speed is zero', () => {
+        const h = harness({ frameloop: 'always', speed: 0 });
+        h.loop.start();
+        expect(h.loop.isPaused()).toBe(true);
+    });
+});

--- a/src/react/lib/renderLoop.ts
+++ b/src/react/lib/renderLoop.ts
@@ -127,6 +127,18 @@ export class RenderLoop {
         return currentFrame(this.time);
     }
 
+    getFrameloop(): Frameloop {
+        return this.frameloop;
+    }
+
+    getSpeed(): number {
+        return this.time.speed;
+    }
+
+    isPaused(): boolean {
+        return this.paused();
+    }
+
     setSpeed(speed: number): void {
         const now = this.deps.now();
         const base = this.cold ? syncTime(this.time, now) : this.time;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2021.WeakRef", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "node",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
                 core:  resolve(__dirname, 'src/core/index.ts'),
                 react: resolve(__dirname, 'src/react/index.ts'),
                 testing: resolve(__dirname, 'src/testing/index.ts'),
+                devtools: resolve(__dirname, 'src/react/devtools/index.ts'),
             },
             formats: ['es','cjs'],
             fileName: (format, entry) =>


### PR DESCRIPTION
First slice of the devtools overlay (plan: testing-devtools Feature 2, §2.2–2.3, D1), plus the research-round amendment.

## What

- `src/react/devtools/beacon.ts` — the always-present registry: engines Map + swappable sink, `setDevtoolsSink` (replays already-mounted engines to a late-mounting panel), `emitEngineMount`/`emitEngineUnmount`, `listEngines`. React-free, DOM-free, ~40 LOC, type-only imports; zero per-frame code — the panel (D2) pulls on its own rAF.
- Engine integration: both engines register an `EngineHandle` in the existing content-keyed init effect (mount/unmount only — the render loop carries zero devtools code). Stable per-instance id (not contentKey, so re-inits read as a signal); `getManager` via `WeakRef` so a missed unmount can't pin GL resources; `getState()` reads capabilities/sizes/program+framebuffer ids/frameloop state live and never throws (returns last-known state on teardown races — sanctioned by plan §2.11 for this dev-only pull surface).
- Handle passthroughs: `invalidate`, `setFrameloop`, and — per the curve-editor research amendment — `setFrame`/`getFrame`, all reading `controllerRef.current` at call time (no stale captures).
- New small getters this needed: `RenderLoop.getFrameloop/getSpeed/isPaused`, `FBOManager.getFramebufferIds` (+tests).
- Packaging: `./devtools` export map entry + vite entry (skeleton — panel lands in D2); tsconfig `lib` += `ES2021.WeakRef` (target stays ES2020).

## Verification

- typecheck / lint / 192 tests / build (incl. treeshake guard) all green.
- `dist/devtools.mjs` pulls only the beacon — no React DOM, no panel code; `dist/core.*` completely free of devtools references.
- Bench comparison vs master baseline (counters project, all 5 scenes): contextsCreated identical, zero shader compiles/links everywhere, per-frame GL deltas within noise (<0.3% on rerender-storm, which stresses exactly the re-init path this touches; pingpong's −2.3% tracks a −2.3% frame-count difference — per-frame rate identical).
- Adversarial review: no defects; staleness (call-time ref reads), StrictMode double-mount, context-lost cleanup, sink-replacement, and aliasing probes all held.