### PR TITLE
devtools D2: shadow-DOM panel core (fps, GL counters, capabilities, frameloop)

### DIFF
--- a/bench/scenes.spec.ts
+++ b/bench/scenes.spec.ts
@@ -19,7 +19,8 @@ const specs: SceneSpec[] = [
     { name: 'pingpong-sim', query: '/?scene=pingpong-sim&iterations=4', iterations: 4, assertDrawArrays: true },
     { name: 'static-idle', query: '/?scene=static-idle', iterations: null, assertDrawArrays: false },
     { name: 'offscreen', query: '/?scene=offscreen', iterations: null, assertDrawArrays: false },
-    { name: 'many-canvases', query: '/?scene=many-canvases', iterations: null, assertDrawArrays: true }
+    { name: 'many-canvases', query: '/?scene=many-canvases', iterations: null, assertDrawArrays: true },
+    { name: 'many-canvases-devtools', query: '/?scene=many-canvases-devtools', iterations: null, assertDrawArrays: true }
 ];
 
 const readMetrics = async (session: CDPSession): Promise<Map<string, number>> => {

--- a/demo/scenes/DevtoolsDebug.tsx
+++ b/demo/scenes/DevtoolsDebug.tsx
@@ -1,0 +1,31 @@
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { vec2 } from '../../src/core/lib/vectorUtils';
+import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
+import type { UniformParam } from '../../src/types';
+import { PLASMA_FRAGMENT, QUAD_VERTEX } from './shaders';
+
+const config = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: PLASMA_FRAGMENT,
+    uniformNames: {
+        u_offset: 'vec2'
+    }
+});
+
+const uniforms: Record<string, UniformParam> = {
+    u_offset: { type: 'vec2', value: vec2([0, 0]) }
+};
+
+export const DevtoolsDebug = () => {
+    return (
+        <div style={{ width: '100vw', height: '100vh' }}>
+            <BaseShaderComponent
+                programId='devtools-debug'
+                shaderConfig={config}
+                uniforms={uniforms}
+                debug
+                style={{ width: '100%', height: '100%', display: 'block' }}
+            />
+        </div>
+    );
+};

--- a/demo/scenes/ManyCanvasesDevtools.tsx
+++ b/demo/scenes/ManyCanvasesDevtools.tsx
@@ -1,0 +1,44 @@
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
+import { MicuglDevtools } from '../../src/react/devtools';
+import type { UniformParam } from '../../src/types';
+import { QUAD_VERTEX, WAVE_FRAGMENT } from './shaders';
+
+const config = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: WAVE_FRAGMENT
+});
+
+const uniforms: Record<string, UniformParam> = {};
+
+const cells = [0, 1, 2, 3, 4, 5, 6, 7];
+
+export const ManyCanvasesDevtools = () => {
+    return (
+        <div
+            style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(4, 1fr)',
+                gap: '8px',
+                padding: '8px',
+                width: '100vw',
+                height: '100vh'
+            }}
+        >
+            {cells.map(index => (
+                <div key={index} style={{ width: '100%', height: '100%', minHeight: '0' }}>
+                    <BaseShaderComponent
+                        programId={`many-${String(index)}`}
+                        shaderConfig={config}
+                        uniforms={uniforms}
+                        width={160}
+                        height={160}
+                        pixelRatio={1}
+                        style={{ width: '100%', height: '100%', display: 'block' }}
+                    />
+                </div>
+            ))}
+            <MicuglDevtools defaultOpen={false} />
+        </div>
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -1,6 +1,8 @@
 import type { ComponentType } from 'react';
 
+import { DevtoolsDebug } from './DevtoolsDebug';
 import { ManyCanvases } from './ManyCanvases';
+import { ManyCanvasesDevtools } from './ManyCanvasesDevtools';
 import { Offscreen } from './Offscreen';
 import { PingPongSim } from './PingPongSim';
 import { getQueryString } from './query';
@@ -12,7 +14,9 @@ export const scenes: Record<string, ComponentType> = {
     'pingpong-sim': PingPongSim,
     'static-idle': StaticIdle,
     'offscreen': Offscreen,
-    'many-canvases': ManyCanvases
+    'many-canvases': ManyCanvases,
+    'many-canvases-devtools': ManyCanvasesDevtools,
+    'devtools-debug': DevtoolsDebug
 };
 
 export const getSceneComponent = (): ComponentType | null => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -122,7 +122,7 @@ export default tseslint.config(
   },
   {
     files: ['src/**/*.{ts,tsx}'],
-    ignores: ['src/testing/**', 'src/**/*.test.{ts,tsx}'],
+    ignores: ['src/testing/**', 'src/react/devtools/**', 'src/**/*.test.{ts,tsx}'],
     rules: {
       'no-restricted-imports': ['error', {
         paths: [],
@@ -133,7 +133,7 @@ export default tseslint.config(
           },
           {
             group: ['@/testing', '@/testing/*', '**/testing/**'],
-            message: 'micugl/testing is dev/test-only and must stay out of library source; only src/testing/** and *.test.* files may import it.'
+            message: 'micugl/testing is dev/test-only and must stay out of library source; only src/testing/**, src/react/devtools/** and *.test.* files may import it.'
           }
         ]
       }]

--- a/scripts/assertTreeshaken.mjs
+++ b/scripts/assertTreeshaken.mjs
@@ -1,28 +1,72 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
 
-const FORBIDDEN_SYMBOLS = ['installInstrumentation', 'createGLStub'];
-const TARGET_FILES = ['dist/index.mjs', 'dist/core.mjs', 'dist/react.mjs'];
+const distRoot = resolve(process.cwd(), process.argv[2] ?? 'dist');
+const ENTRIES = ['index.mjs', 'core.mjs', 'react.mjs'].map(name => resolve(distRoot, name));
 
-const failures = [];
+const FROM_SPECIFIER = /\bfrom\s*['"]([^'"]+)['"]/g;
+const BARE_IMPORT = /(?:^|[;\n])\s*import\s*['"]([^'"]+)['"]/g;
 
-for (const targetFile of TARGET_FILES) {
-    const path = resolve(process.cwd(), targetFile);
-    const contents = readFileSync(path, 'utf8');
-    for (const symbol of FORBIDDEN_SYMBOLS) {
-        if (contents.includes(symbol)) {
-            failures.push(`${targetFile} contains testing-only symbol "${symbol}"`);
+const resolveModule = (fromFile, specifier) => {
+    if (!specifier.startsWith('.')) {
+        return null;
+    }
+    const base = resolve(dirname(fromFile), specifier);
+    const candidates = [base, `${base}.mjs`, resolve(base, 'index.mjs')];
+    return candidates.find(candidate => existsSync(candidate)) ?? null;
+};
+
+const collectSpecifiers = source => {
+    const specifiers = [];
+    let match;
+    while ((match = FROM_SPECIFIER.exec(source)) !== null) {
+        specifiers.push(match[1]);
+    }
+    while ((match = BARE_IMPORT.exec(source)) !== null) {
+        specifiers.push(match[1]);
+    }
+    return specifiers;
+};
+
+const reachable = new Set();
+const queue = [...ENTRIES];
+
+while (queue.length > 0) {
+    const file = queue.pop();
+    if (reachable.has(file) || !existsSync(file)) {
+        continue;
+    }
+    reachable.add(file);
+    const source = readFileSync(file, 'utf8');
+    for (const specifier of collectSpecifiers(source)) {
+        const resolved = resolveModule(file, specifier);
+        if (resolved !== null && !reachable.has(resolved)) {
+            queue.push(resolved);
         }
     }
 }
 
+const DEVTOOLS_PREFIX = `react${sep}devtools${sep}`;
+const failures = [];
+
+for (const file of reachable) {
+    const rel = relative(distRoot, file);
+    if (rel.startsWith(DEVTOOLS_PREFIX) && !rel.endsWith(`${sep}beacon.mjs`)) {
+        failures.push(`devtools panel module reachable from a main bundle: ${rel}`);
+    }
+    if (rel === 'testing.mjs' || rel.startsWith(`testing${sep}`)) {
+        failures.push(`testing module reachable from a main bundle: ${rel}`);
+    }
+}
+
 if (failures.length > 0) {
-    console.error('assertTreeshaken: micugl/testing leaked into a main bundle:');
+    console.error('assertTreeshaken: static import graph of index/core/react leaked a dev-only module:');
     for (const failure of failures) {
         console.error(`  - ${failure}`);
     }
-    console.error('src/testing/** must never be imported by src/index.ts, src/core/index.ts, or src/react/index.ts.');
+    console.error('Only react/devtools/beacon.mjs may be statically reachable; the panel and testing');
+    console.error('chunks must be reached via dynamic import() or an explicit micugl/devtools import.');
     process.exit(1);
 }
 
-console.log('assertTreeshaken: main bundles are clean of testing-only symbols.');
+console.log(`assertTreeshaken: walked ${String(reachable.size)} modules from index/core/react; no devtools panel or testing module is statically reachable.`);

--- a/src/react/components/base/BasePingPongShaderComponent.tsx
+++ b/src/react/components/base/BasePingPongShaderComponent.tsx
@@ -20,6 +20,7 @@ export interface BasePingPongShaderProps extends RenderControlProps {
     style?: CSSProperties;
     renderWidth?: number;
     renderHeight?: number;
+    debug?: boolean;
     customPasses?: RenderPass[];
     renderOptions?: {
         clear?: boolean;
@@ -48,6 +49,7 @@ const BasePingPongShaderComponentImpl = forwardRef<ShaderHandle, BasePingPongSha
     height,
     renderWidth,
     renderHeight,
+    debug = false,
     pixelRatio,
     useDevicePixelRatio,
     frameloop,
@@ -93,6 +95,7 @@ const BasePingPongShaderComponentImpl = forwardRef<ShaderHandle, BasePingPongSha
             height={height}
             renderWidth={renderWidth}
             renderHeight={renderHeight}
+            debug={debug}
             pixelRatio={pixelRatio}
             useDevicePixelRatio={useDevicePixelRatio}
             frameloop={frameloop}

--- a/src/react/components/base/BaseShaderComponent.tsx
+++ b/src/react/components/base/BaseShaderComponent.tsx
@@ -11,6 +11,7 @@ export interface BaseShaderProps extends RenderControlProps {
     shaderConfig: ShaderProgramConfig;
     uniforms: Record<string, UniformParam>;
     skipDefaultUniforms?: boolean;
+    debug?: boolean;
     className?: string;
     style?: CSSProperties;
     renderOptions?: {
@@ -33,6 +34,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     shaderConfig,
     uniforms,
     skipDefaultUniforms = false,
+    debug = false,
     width,
     height,
     pixelRatio,
@@ -69,6 +71,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
             className={className}
             style={style}
             useFastPath={true}
+            debug={debug}
             renderOptions={renderOptions}
         />
     );

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -36,6 +36,7 @@ interface PingPongShaderEngineProps extends RenderControlProps {
     style?: CSSProperties;
     renderWidth?: number;
     renderHeight?: number;
+    debug?: boolean;
 }
 
 interface ObservedSize {
@@ -98,6 +99,7 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
     height,
     renderWidth,
     renderHeight,
+    debug = false,
     useDevicePixelRatio,
     pixelRatio,
     frameloop = 'always',
@@ -414,6 +416,17 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
         controller.setSpeed(speed);
         controller.setPauseWhenHidden(pauseWhenHidden);
     }, [frameloop, speed, pauseWhenHidden]);
+
+    useEffect(() => {
+        if (!debug) return;
+        let cancelled = false;
+        void import('@/react/devtools/attach').then(module => {
+            if (!cancelled) {
+                module.ensureDevtoolsMounted();
+            }
+        });
+        return () => { cancelled = true };
+    }, [debug]);
 
     useEffect(() => {
         const canvas = canvasRef.current;

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -43,6 +43,7 @@ interface ShaderEngineProps extends RenderControlProps {
     style?: CSSProperties;
     uniformUpdaters?: Record<string, UniformUpdaterEntry[]>;
     useFastPath?: boolean;
+    debug?: boolean;
 }
 
 interface ObservedSize {
@@ -107,6 +108,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     height,
     uniformUpdaters = DEFAULT_UNIFORM_UPDATERS,
     useFastPath = false,
+    debug = false,
     useDevicePixelRatio,
     pixelRatio,
     frameloop = 'always',
@@ -405,6 +407,17 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         controller.setSpeed(speed);
         controller.setPauseWhenHidden(pauseWhenHidden);
     }, [frameloop, speed, pauseWhenHidden]);
+
+    useEffect(() => {
+        if (!debug) return;
+        let cancelled = false;
+        void import('@/react/devtools/attach').then(module => {
+            if (!cancelled) {
+                module.ensureDevtoolsMounted();
+            }
+        });
+        return () => { cancelled = true };
+    }, [debug]);
 
     useEffect(() => {
         const canvas = canvasRef.current;

--- a/src/react/devtools/MicuglDevtools.tsx
+++ b/src/react/devtools/MicuglDevtools.tsx
@@ -1,0 +1,362 @@
+import type { CSSProperties, ReactElement, ReactNode, RefObject } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import type { DevtoolsSink, EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
+import { setDevtoolsSink } from '@/react/devtools/beacon';
+import { isEngineStateUnavailable } from '@/react/devtools/lib/engineState';
+import type { FrameStats } from '@/react/devtools/lib/frameStats';
+import { computeFrameStats, fpsFromMean, pushCapped } from '@/react/devtools/lib/frameStats';
+import { buttonStyle, COLORS, FONT, sectionStyle } from '@/react/devtools/lib/theme';
+import { CapabilitiesPanel } from '@/react/devtools/panels/CapabilitiesPanel';
+import { FpsPanel } from '@/react/devtools/panels/FpsPanel';
+import { FrameloopPanel } from '@/react/devtools/panels/FrameloopPanel';
+import { GlCountersPanel } from '@/react/devtools/panels/GlCountersPanel';
+import { diffCounters } from '@/testing/assertions';
+import type { GlCountersData, GlCountersHandle } from '@/testing/glCounters';
+import { installGlCounters } from '@/testing/glCounters';
+import type { Frameloop } from '@/types';
+
+export type DevtoolsPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+export interface MicuglDevtoolsProps {
+    position?: DevtoolsPosition;
+    defaultOpen?: boolean;
+}
+
+const MAX_SAMPLES = 180;
+const THROTTLE_MS = 100;
+
+let panelActive = false;
+
+const positionStyle = (position: DevtoolsPosition): CSSProperties => {
+    const style: CSSProperties = {
+        position: 'fixed',
+        zIndex: 2147483647,
+        margin: '8px',
+        fontFamily: FONT,
+        fontSize: '12px',
+        color: COLORS.text,
+        lineHeight: 1.4
+    };
+    if (position === 'top-left' || position === 'top-right') {
+        style.top = 0;
+    } else {
+        style.bottom = 0;
+    }
+    if (position === 'top-left' || position === 'bottom-left') {
+        style.left = 0;
+    } else {
+        style.right = 0;
+    }
+    return style;
+};
+
+const panelStyle: CSSProperties = {
+    background: COLORS.bg,
+    border: `1px solid ${COLORS.border}`,
+    borderRadius: '8px',
+    boxShadow: '0 8px 30px rgba(0,0,0,0.45)',
+    overflow: 'hidden'
+};
+
+const headerStyle: CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '8px 10px'
+};
+
+const collapsedButtonStyle: CSSProperties = {
+    ...buttonStyle,
+    fontSize: '11px',
+    padding: '5px 10px',
+    borderRadius: '6px',
+    background: COLORS.bg,
+    boxShadow: '0 4px 14px rgba(0,0,0,0.4)'
+};
+
+const warningBadgeStyle: CSSProperties = {
+    fontSize: '11px',
+    color: '#0b0d16',
+    background: COLORS.warn,
+    borderRadius: '4px',
+    padding: '4px 6px',
+    fontWeight: 600
+};
+
+const selectStyle: CSSProperties = {
+    width: '100%',
+    fontFamily: FONT,
+    fontSize: '11px',
+    padding: '3px 6px',
+    background: 'rgba(0,0,0,0.3)',
+    border: `1px solid ${COLORS.border}`,
+    borderRadius: '4px',
+    color: COLORS.text
+};
+
+const drawSparkline = (
+    canvas: HTMLCanvasElement | null,
+    values: readonly number[],
+    color: string
+): void => {
+    if (!canvas) {
+        return;
+    }
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+        return;
+    }
+    const width = canvas.width;
+    const height = canvas.height;
+    ctx.clearRect(0, 0, width, height);
+    if (values.length === 0) {
+        return;
+    }
+    let peak = 0;
+    for (const value of values) {
+        if (value > peak) {
+            peak = value;
+        }
+    }
+    if (peak <= 0) {
+        peak = 1;
+    }
+    const span = values.length > 1 ? values.length - 1 : 1;
+    ctx.beginPath();
+    values.forEach((value, index) => {
+        const x = (index / span) * width;
+        const y = height - (value / peak) * height;
+        if (index === 0) {
+            ctx.moveTo(x, y);
+        } else {
+            ctx.lineTo(x, y);
+        }
+    });
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1;
+    ctx.stroke();
+};
+
+interface DevtoolsPanelProps {
+    position: DevtoolsPosition;
+    defaultOpen: boolean;
+}
+
+const DevtoolsPanel = ({ position, defaultOpen }: DevtoolsPanelProps): ReactElement => {
+    const [open, setOpen] = useState(defaultOpen);
+    const [engines, setEngines] = useState<EngineHandle[]>([]);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    const [fpsStats, setFpsStats] = useState<FrameStats>({ count: 0, mean: 0, p50: 0, p95: 0 });
+    const [engineState, setEngineState] = useState<EngineDebugState | null>(null);
+    const [liveFrame, setLiveFrame] = useState(0);
+    const [glOn, setGlOn] = useState(false);
+    const [glDelta, setGlDelta] = useState<GlCountersData | null>(null);
+
+    const selected = engines.find(engine => engine.id === selectedId) ?? engines.at(0) ?? null;
+
+    const fpsCanvasRef: RefObject<HTMLCanvasElement | null> = useRef<HTMLCanvasElement | null>(null);
+    const glCanvasRef: RefObject<HTMLCanvasElement | null> = useRef<HTMLCanvasElement | null>(null);
+    const frameDeltasRef = useRef<number[]>([]);
+    const glHistoryRef = useRef<number[]>([]);
+    const lastTsRef = useRef(0);
+    const lastThrottleRef = useRef(0);
+    const glCountersRef = useRef<GlCountersHandle | null>(null);
+    const latestGlRef = useRef<GlCountersData | null>(null);
+    const prevGlRef = useRef<GlCountersData | null>(null);
+
+    const openRef = useRef(open);
+    const glOnRef = useRef(glOn);
+    const selectedRef = useRef<EngineHandle | null>(selected);
+    useEffect(() => {
+        openRef.current = open;
+        glOnRef.current = glOn;
+        selectedRef.current = selected;
+    });
+
+    useEffect(() => {
+        const sink: DevtoolsSink = {
+            onMount: handle => { setEngines(prev => [...prev.filter(engine => engine.id !== handle.id), handle]) },
+            onUnmount: id => { setEngines(prev => prev.filter(engine => engine.id !== id)) }
+        };
+        setDevtoolsSink(null);
+        setDevtoolsSink(sink);
+        return () => { setDevtoolsSink(null) };
+    }, []);
+
+    useEffect(() => {
+        let raf = 0;
+        const loop = (timestamp: number): void => {
+            raf = requestAnimationFrame(loop);
+            const last = lastTsRef.current;
+            lastTsRef.current = timestamp;
+            if (last !== 0) {
+                pushCapped(frameDeltasRef.current, timestamp - last, MAX_SAMPLES);
+            }
+            const opened = openRef.current;
+            if (opened) {
+                drawSparkline(fpsCanvasRef.current, frameDeltasRef.current, COLORS.good);
+                const counters = glCountersRef.current;
+                if (glOnRef.current && counters) {
+                    const snap = counters.snapshot();
+                    const prev = prevGlRef.current;
+                    prevGlRef.current = snap;
+                    if (prev) {
+                        const delta = diffCounters(prev, snap);
+                        latestGlRef.current = delta;
+                        pushCapped(glHistoryRef.current, delta.drawArrays + delta.drawElements, MAX_SAMPLES);
+                        drawSparkline(glCanvasRef.current, glHistoryRef.current, COLORS.accent);
+                    }
+                }
+            }
+            if (timestamp - lastThrottleRef.current >= THROTTLE_MS) {
+                lastThrottleRef.current = timestamp;
+                setFpsStats(computeFrameStats(frameDeltasRef.current));
+                if (opened) {
+                    const handle = selectedRef.current;
+                    if (handle) {
+                        setEngineState(handle.getState());
+                        if (handle.getFrame) {
+                            setLiveFrame(handle.getFrame());
+                        }
+                    }
+                    if (glOnRef.current) {
+                        setGlDelta(latestGlRef.current);
+                    }
+                }
+            }
+        };
+        raf = requestAnimationFrame(loop);
+        return () => { cancelAnimationFrame(raf) };
+    }, []);
+
+    const handleToggleGl = useCallback(() => {
+        const next = !glOnRef.current;
+        if (next) {
+            const counters = glCountersRef.current ?? installGlCounters();
+            glCountersRef.current = counters;
+            prevGlRef.current = counters.snapshot();
+            glHistoryRef.current.length = 0;
+        } else {
+            setGlDelta(null);
+        }
+        setGlOn(next);
+    }, []);
+
+    const handleInvalidate = useCallback(() => { selectedRef.current?.invalidate?.() }, []);
+    const handleSetFrameloop = useCallback((mode: Frameloop) => {
+        selectedRef.current?.setFrameloop?.(mode);
+        selectedRef.current?.invalidate?.();
+    }, []);
+    const handleStep = useCallback((delta: number) => {
+        const handle = selectedRef.current;
+        if (handle?.setFrame && handle.getFrame) {
+            handle.setFrame(handle.getFrame() + delta);
+        }
+    }, []);
+    const handleSetFrame = useCallback((frame: number) => { selectedRef.current?.setFrame?.(frame) }, []);
+
+    if (!open) {
+        return (
+            <div style={positionStyle(position)}>
+                <button type='button' onClick={() => { setOpen(true) }} style={collapsedButtonStyle}>
+                    micugl · {Math.round(fpsFromMean(fpsStats.mean))} fps
+                </button>
+            </div>
+        );
+    }
+
+    const unavailable = engineState !== null && isEngineStateUnavailable(engineState);
+
+    return (
+        <div style={{ ...positionStyle(position), width: '240px' }}>
+            <div style={panelStyle}>
+                <div style={headerStyle}>
+                    <span style={{ fontWeight: 600 }}>micugl devtools</span>
+                    <button type='button' onClick={() => { setOpen(false) }} style={buttonStyle}>collapse</button>
+                </div>
+                {engines.length === 0
+                    ? <div style={{ padding: '10px', color: COLORS.dim, fontSize: '11px' }}>no micugl engines mounted</div>
+                    : (
+                        <>
+                            {engines.length > 1
+                                ? (
+                                    <div style={sectionStyle}>
+                                        <select
+                                            value={selected?.id ?? ''}
+                                            onChange={event => { setSelectedId(event.target.value) }}
+                                            style={selectStyle}
+                                        >
+                                            {engines.map(engine => (
+                                                <option key={engine.id} value={engine.id}>
+                                                    {engine.kind} · {engine.id.slice(0, 8)}
+                                                </option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                )
+                                : null}
+                            {unavailable
+                                ? <div style={sectionStyle}><div style={warningBadgeStyle}>engine state unavailable</div></div>
+                                : null}
+                            <FpsPanel stats={fpsStats} canvasRef={fpsCanvasRef} />
+                            {engineState
+                                ? (
+                                    <>
+                                        <CapabilitiesPanel
+                                            capabilities={engineState.capabilities}
+                                            floatFilterDowngraded={engineState.floatFilterDowngraded}
+                                        />
+                                        <FrameloopPanel
+                                            frameloop={engineState.frameloop}
+                                            paused={engineState.paused}
+                                            speed={engineState.speed}
+                                            frame={liveFrame}
+                                            onInvalidate={handleInvalidate}
+                                            onSetFrameloop={handleSetFrameloop}
+                                            onStep={handleStep}
+                                            onSetFrame={handleSetFrame}
+                                        />
+                                    </>
+                                )
+                                : null}
+                            <GlCountersPanel on={glOn} onToggle={handleToggleGl} delta={glDelta} canvasRef={glCanvasRef} />
+                        </>
+                    )}
+            </div>
+        </div>
+    );
+};
+
+const MicuglDevtoolsComponent = ({ position = 'bottom-right', defaultOpen = false }: MicuglDevtoolsProps): ReactNode => {
+    const [mount, setMount] = useState<HTMLElement | null>(null);
+
+    useEffect(() => {
+        if (typeof document === 'undefined' || panelActive) {
+            return;
+        }
+        panelActive = true;
+
+        const host = document.createElement('div');
+        host.setAttribute('data-micugl-devtools', '');
+        const shadow = host.attachShadow({ mode: 'open' });
+        const container = document.createElement('div');
+        shadow.appendChild(container);
+        document.body.appendChild(host);
+        setMount(container);
+
+        return () => {
+            panelActive = false;
+            setMount(null);
+            host.remove();
+        };
+    }, []);
+
+    if (!mount) {
+        return null;
+    }
+    return createPortal(<DevtoolsPanel position={position} defaultOpen={defaultOpen} />, mount);
+};
+
+export const MicuglDevtools = memo(MicuglDevtoolsComponent);

--- a/src/react/devtools/attach.ts
+++ b/src/react/devtools/attach.ts
@@ -1,0 +1,41 @@
+import { createElement } from 'react';
+import type { Root } from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
+
+import { MicuglDevtools } from '@/react/devtools/MicuglDevtools';
+
+const ROOT_ATTRIBUTE = 'data-micugl-devtools-root';
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+export const ensureDevtoolsMounted = (): void => {
+    if (typeof document === 'undefined') {
+        return;
+    }
+    if (root) {
+        return;
+    }
+    if (document.querySelector(`[${ROOT_ATTRIBUTE}]`)) {
+        throw new Error(
+            'micugl devtools: a devtools root already exists but was not created by this module. '
+            + 'This usually means two copies of micugl/devtools were loaded.'
+        );
+    }
+    container = document.createElement('div');
+    container.setAttribute(ROOT_ATTRIBUTE, '');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    root.render(createElement(MicuglDevtools));
+};
+
+export const unmountDevtools = (): void => {
+    if (root) {
+        root.unmount();
+        root = null;
+    }
+    if (container) {
+        container.remove();
+        container = null;
+    }
+};

--- a/src/react/devtools/index.ts
+++ b/src/react/devtools/index.ts
@@ -2,3 +2,7 @@
 export type { DevtoolsSink, EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 /** @experimental */
 export { listEngines, setDevtoolsSink } from '@/react/devtools/beacon';
+/** @experimental */
+export type { DevtoolsPosition, MicuglDevtoolsProps } from '@/react/devtools/MicuglDevtools';
+/** @experimental */
+export { MicuglDevtools } from '@/react/devtools/MicuglDevtools';

--- a/src/react/devtools/lib/engineState.test.ts
+++ b/src/react/devtools/lib/engineState.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EngineDebugState } from '@/react/devtools/beacon';
+import { isEngineStateUnavailable } from '@/react/devtools/lib/engineState';
+
+const baseState = (): EngineDebugState => ({
+    kind: 'shader',
+    id: 'engine-a',
+    canvas: { renderWidth: 0, renderHeight: 0, displayWidth: 0, displayHeight: 0 },
+    programIds: [],
+    framebufferIds: [],
+    capabilities: {
+        floatRenderable: false,
+        halfFloatRenderable: false,
+        floatLinearFilterable: false,
+        halfFloatLinearFilterable: false,
+        halfFloatType: 0
+    },
+    floatFilterDowngraded: false
+});
+
+describe('isEngineStateUnavailable', () => {
+    it('flags the zeroed empty fallback as unavailable', () => {
+        expect(isEngineStateUnavailable(baseState())).toBe(true);
+    });
+
+    it('treats a state with programs as available', () => {
+        const state = baseState();
+        state.programIds = ['main'];
+        expect(isEngineStateUnavailable(state)).toBe(false);
+    });
+
+    it('treats a state with a sized canvas as available', () => {
+        const state = baseState();
+        state.canvas = { renderWidth: 320, renderHeight: 240, displayWidth: 320, displayHeight: 240 };
+        expect(isEngineStateUnavailable(state)).toBe(false);
+    });
+
+    it('treats a state with framebuffers as available', () => {
+        const state = baseState();
+        state.framebufferIds = ['ping'];
+        expect(isEngineStateUnavailable(state)).toBe(false);
+    });
+});

--- a/src/react/devtools/lib/engineState.ts
+++ b/src/react/devtools/lib/engineState.ts
@@ -1,0 +1,13 @@
+import type { EngineDebugState } from '@/react/devtools/beacon';
+
+export const isEngineStateUnavailable = (state: EngineDebugState): boolean => {
+    const { canvas, programIds, framebufferIds } = state;
+    return (
+        programIds.length === 0
+        && framebufferIds.length === 0
+        && canvas.renderWidth === 0
+        && canvas.renderHeight === 0
+        && canvas.displayWidth === 0
+        && canvas.displayHeight === 0
+    );
+};

--- a/src/react/devtools/lib/frameStats.test.ts
+++ b/src/react/devtools/lib/frameStats.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeFrameStats, fpsFromMean, pushCapped } from '@/react/devtools/lib/frameStats';
+
+describe('computeFrameStats', () => {
+    it('returns zeros for an empty ring buffer', () => {
+        expect(computeFrameStats([])).toEqual({ count: 0, mean: 0, p50: 0, p95: 0 });
+    });
+
+    it('computes mean over the samples', () => {
+        const stats = computeFrameStats([10, 20, 30]);
+        expect(stats.count).toBe(3);
+        expect(stats.mean).toBe(20);
+    });
+
+    it('computes p50 and p95 from the sorted samples', () => {
+        const deltas = [16, 16, 16, 16, 16, 16, 16, 16, 16, 100];
+        const stats = computeFrameStats(deltas);
+        expect(stats.p50).toBe(16);
+        expect(stats.p95).toBe(100);
+    });
+
+    it('does not mutate the input buffer while sorting', () => {
+        const deltas = [30, 10, 20];
+        computeFrameStats(deltas);
+        expect(deltas).toEqual([30, 10, 20]);
+    });
+});
+
+describe('fpsFromMean', () => {
+    it('converts a mean frame time in ms to frames per second', () => {
+        expect(fpsFromMean(16.6667)).toBeCloseTo(60, 1);
+        expect(fpsFromMean(33.3333)).toBeCloseTo(30, 1);
+    });
+
+    it('returns 0 for a non-positive mean', () => {
+        expect(fpsFromMean(0)).toBe(0);
+        expect(fpsFromMean(-5)).toBe(0);
+    });
+});
+
+describe('pushCapped', () => {
+    it('appends values and drops the oldest beyond the cap', () => {
+        const buffer: number[] = [];
+        for (let i = 1; i <= 5; i += 1) {
+            pushCapped(buffer, i, 3);
+        }
+        expect(buffer).toEqual([3, 4, 5]);
+    });
+});

--- a/src/react/devtools/lib/frameStats.ts
+++ b/src/react/devtools/lib/frameStats.ts
@@ -1,0 +1,46 @@
+export interface FrameStats {
+    count: number;
+    mean: number;
+    p50: number;
+    p95: number;
+}
+
+const percentile = (sorted: readonly number[], p: number): number => {
+    if (sorted.length === 0) {
+        return 0;
+    }
+    const index = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+    return sorted.find((_, valueIndex) => valueIndex === index) ?? 0;
+};
+
+export const computeFrameStats = (deltas: readonly number[]): FrameStats => {
+    const count = deltas.length;
+    if (count === 0) {
+        return { count: 0, mean: 0, p50: 0, p95: 0 };
+    }
+    let sum = 0;
+    for (const delta of deltas) {
+        sum += delta;
+    }
+    const sorted = [...deltas].sort((a, b) => a - b);
+    return {
+        count,
+        mean: sum / count,
+        p50: percentile(sorted, 50),
+        p95: percentile(sorted, 95)
+    };
+};
+
+export const fpsFromMean = (meanMs: number): number => {
+    if (meanMs <= 0) {
+        return 0;
+    }
+    return 1000 / meanMs;
+};
+
+export const pushCapped = (buffer: number[], value: number, cap: number): void => {
+    buffer.push(value);
+    while (buffer.length > cap) {
+        buffer.shift();
+    }
+};

--- a/src/react/devtools/lib/theme.ts
+++ b/src/react/devtools/lib/theme.ts
@@ -1,0 +1,55 @@
+import type { CSSProperties } from 'react';
+
+export const COLORS = {
+    bg: 'rgba(15,17,26,0.94)',
+    panel: 'rgba(24,27,38,0.9)',
+    border: '#2a2f42',
+    text: '#c9cee2',
+    dim: '#828aa6',
+    accent: '#5b8def',
+    good: '#3ecf8e',
+    warn: '#e9a23b',
+    danger: '#e94560'
+};
+
+export const FONT = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+
+export const sectionStyle: CSSProperties = {
+    borderTop: `1px solid ${COLORS.border}`,
+    padding: '8px 10px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px'
+};
+
+export const sectionTitleStyle: CSSProperties = {
+    fontSize: '10px',
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: COLORS.dim
+};
+
+export const rowStyle: CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: '8px'
+};
+
+export const buttonStyle: CSSProperties = {
+    fontFamily: FONT,
+    fontSize: '11px',
+    padding: '3px 7px',
+    background: COLORS.panel,
+    border: `1px solid ${COLORS.border}`,
+    borderRadius: '4px',
+    color: COLORS.text,
+    cursor: 'pointer'
+};
+
+export const activeButtonStyle: CSSProperties = {
+    ...buttonStyle,
+    background: COLORS.accent,
+    border: `1px solid ${COLORS.accent}`,
+    color: '#0b0d16'
+};

--- a/src/react/devtools/panels/CapabilitiesPanel.tsx
+++ b/src/react/devtools/panels/CapabilitiesPanel.tsx
@@ -1,0 +1,49 @@
+import type { ReactElement } from 'react';
+
+import type { TextureCapabilities } from '@/core/lib/textureCapabilities';
+import { COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
+
+interface CapabilitiesPanelProps {
+    capabilities: TextureCapabilities;
+    floatFilterDowngraded: boolean;
+}
+
+const bool = (value: boolean): ReactElement => (
+    <span style={{ color: value ? COLORS.good : COLORS.danger }}>{value ? 'yes' : 'no'}</span>
+);
+
+const capRow = (label: string, value: boolean): ReactElement => (
+    <div key={label} style={rowStyle}>
+        <span style={{ color: COLORS.dim }}>{label}</span>
+        {bool(value)}
+    </div>
+);
+
+export const CapabilitiesPanel = ({ capabilities, floatFilterDowngraded }: CapabilitiesPanelProps): ReactElement => {
+    return (
+        <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>capabilities</div>
+            <div style={{ fontSize: '11px', display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                {capRow('float renderable', capabilities.floatRenderable)}
+                {capRow('half-float renderable', capabilities.halfFloatRenderable)}
+                {capRow('float linear', capabilities.floatLinearFilterable)}
+                {capRow('half-float linear', capabilities.halfFloatLinearFilterable)}
+                {capRow('half-float type set', capabilities.halfFloatType !== 0)}
+            </div>
+            {floatFilterDowngraded
+                ? (
+                    <div style={{
+                        fontSize: '11px',
+                        color: '#0b0d16',
+                        background: COLORS.warn,
+                        borderRadius: '4px',
+                        padding: '4px 6px',
+                        fontWeight: 600
+                    }}>
+                        float filter downgraded to NEAREST
+                    </div>
+                )
+                : null}
+        </div>
+    );
+};

--- a/src/react/devtools/panels/FpsPanel.tsx
+++ b/src/react/devtools/panels/FpsPanel.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement, RefObject } from 'react';
+
+import type { FrameStats } from '@/react/devtools/lib/frameStats';
+import { fpsFromMean } from '@/react/devtools/lib/frameStats';
+import { COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
+
+interface FpsPanelProps {
+    stats: FrameStats;
+    canvasRef: RefObject<HTMLCanvasElement | null>;
+}
+
+export const FpsPanel = ({ stats, canvasRef }: FpsPanelProps): ReactElement => {
+    const fps = Math.round(fpsFromMean(stats.mean));
+    return (
+        <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>frame timing</div>
+            <div style={rowStyle}>
+                <span style={{ fontSize: '20px', fontWeight: 600, color: COLORS.good }}>
+                    {fps} fps
+                </span>
+                <span style={{ fontSize: '10px', color: COLORS.dim, textAlign: 'right' }}>
+                    mean {stats.mean.toFixed(1)}ms<br />
+                    p50 {stats.p50.toFixed(1)} · p95 {stats.p95.toFixed(1)}
+                </span>
+            </div>
+            <canvas
+                ref={canvasRef}
+                width={220}
+                height={32}
+                style={{ width: '100%', height: '32px', display: 'block', background: 'rgba(0,0,0,0.25)', borderRadius: '3px' }}
+            />
+        </div>
+    );
+};

--- a/src/react/devtools/panels/FrameloopPanel.tsx
+++ b/src/react/devtools/panels/FrameloopPanel.tsx
@@ -1,0 +1,105 @@
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+
+import { activeButtonStyle, buttonStyle, COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
+import type { Frameloop } from '@/types';
+
+interface FrameloopPanelProps {
+    frameloop?: Frameloop;
+    paused?: boolean;
+    speed?: number;
+    frame: number;
+    onInvalidate: () => void;
+    onSetFrameloop: (mode: Frameloop) => void;
+    onStep: (delta: number) => void;
+    onSetFrame: (frame: number) => void;
+}
+
+const MODES: Frameloop[] = ['always', 'demand', 'never'];
+const STEPS = [-10, -1, 1, 10];
+
+export const FrameloopPanel = ({
+    frameloop,
+    paused,
+    speed,
+    frame,
+    onInvalidate,
+    onSetFrameloop,
+    onStep,
+    onSetFrame
+}: FrameloopPanelProps): ReactElement => {
+    const [draft, setDraft] = useState('');
+
+    const applyDraft = (): void => {
+        const parsed = Number.parseInt(draft, 10);
+        if (!Number.isNaN(parsed)) {
+            onSetFrame(parsed);
+        }
+        setDraft('');
+    };
+
+    return (
+        <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>frameloop</div>
+            <div style={rowStyle}>
+                <span style={{ color: COLORS.dim }}>mode</span>
+                <div style={{ display: 'flex', gap: '4px' }}>
+                    {MODES.map(mode => (
+                        <button
+                            key={mode}
+                            type='button'
+                            onClick={() => { onSetFrameloop(mode) }}
+                            style={frameloop === mode ? activeButtonStyle : buttonStyle}
+                        >
+                            {mode}
+                        </button>
+                    ))}
+                </div>
+            </div>
+            <div style={rowStyle}>
+                <span style={{ color: COLORS.dim }}>state</span>
+                <span style={{ color: paused === true ? COLORS.warn : COLORS.good }}>
+                    {paused === true ? 'paused' : 'running'} · {(speed ?? 1).toFixed(2)}x
+                </span>
+            </div>
+            <div style={rowStyle}>
+                <span style={{ color: COLORS.dim }}>frame</span>
+                <span>{frame}</span>
+            </div>
+            <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+                <button type='button' onClick={onInvalidate} style={buttonStyle}>invalidate</button>
+                {STEPS.map(step => (
+                    <button
+                        key={step}
+                        type='button'
+                        onClick={() => { onStep(step) }}
+                        style={buttonStyle}
+                    >
+                        {step > 0 ? `+${String(step)}` : String(step)}
+                    </button>
+                ))}
+            </div>
+            <div style={{ display: 'flex', gap: '4px' }}>
+                <input
+                    type='number'
+                    value={draft}
+                    placeholder='jump to frame'
+                    onChange={e => { setDraft(e.target.value) }}
+                    onKeyDown={e => { if (e.key === 'Enter') { applyDraft() } }}
+                    style={{
+                        flex: 1,
+                        minWidth: 0,
+                        fontFamily: 'inherit',
+                        fontSize: '11px',
+                        padding: '3px 6px',
+                        background: 'rgba(0,0,0,0.3)',
+                        border: `1px solid ${COLORS.border}`,
+                        borderRadius: '4px',
+                        color: COLORS.text
+                    }}
+                />
+                <button type='button' onClick={applyDraft} style={buttonStyle}>set</button>
+            </div>
+        </div>
+    );
+};

--- a/src/react/devtools/panels/GlCountersPanel.tsx
+++ b/src/react/devtools/panels/GlCountersPanel.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement, RefObject } from 'react';
+
+import { activeButtonStyle, buttonStyle, COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
+import type { GlCountersData } from '@/testing/glCounters';
+
+interface GlCountersPanelProps {
+    on: boolean;
+    onToggle: () => void;
+    delta: GlCountersData | null;
+    canvasRef: RefObject<HTMLCanvasElement | null>;
+}
+
+const counterRow = (label: string, value: number): ReactElement => (
+    <div key={label} style={rowStyle}>
+        <span style={{ color: COLORS.dim }}>{label}</span>
+        <span>{value}</span>
+    </div>
+);
+
+export const GlCountersPanel = ({ on, onToggle, delta, canvasRef }: GlCountersPanelProps): ReactElement => {
+    return (
+        <div style={sectionStyle}>
+            <div style={rowStyle}>
+                <span style={sectionTitleStyle}>gl calls / frame</span>
+                <button type='button' onClick={onToggle} style={on ? activeButtonStyle : buttonStyle}>
+                    {on ? 'on' : 'off'}
+                </button>
+            </div>
+            <div style={{ fontSize: '10px', color: COLORS.warn }}>
+                measures all contexts; wrapping adds per-call overhead while on
+            </div>
+            {on && delta
+                ? (
+                    <>
+                        <div style={{ fontSize: '11px', display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                            {counterRow('draws', delta.drawArrays + delta.drawElements)}
+                            {counterRow('uniform uploads', delta.uniformCalls)}
+                            {counterRow('texImage2D', delta.texImage2D)}
+                            {counterRow('compiles', delta.compileShader + delta.linkProgram)}
+                        </div>
+                        <canvas
+                            ref={canvasRef}
+                            width={220}
+                            height={28}
+                            style={{ width: '100%', height: '28px', display: 'block', background: 'rgba(0,0,0,0.25)', borderRadius: '3px' }}
+                        />
+                    </>
+                )
+                : null}
+        </div>
+    );
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         `${entry}.${format === 'es' ? 'mjs' : 'js'}`
         },
         rollupOptions: {
-            external: ['react','react-dom','react/jsx-runtime',/^react\/.*/],
+            external: ['react','react-dom','react/jsx-runtime',/^react\/.*/,/^react-dom\/.*/],
             output: {
                 preserveModules:       true,
                 preserveModulesRoot:   'src',


### PR DESCRIPTION
Second devtools slice (plan: testing-devtools §2.4–2.5, §2.8–2.9, D2).

## What

- `<MicuglDevtools/>` — Shadow-DOM overlay rendered via `createPortal` into a host div on `document.body`. Client-only, SSR-safe; own rAF loop and own React state with numbers throttled to 10 Hz and sparklines drawn imperatively — zero re-render coupling to the host app. Collapsible (collapsed default), position prop, engine selector when multiple engines are live. Shows a visible "engine state unavailable" badge instead of rendering zeroed state as if real.
- Panels: FPS + frame-time sparkline (local pure stats helper, unit-tested); GL counters (default OFF, labeled all-contexts + overhead; **non-destructive** deltas via kept-snapshot `diffCounters` so the shared instrumentation handle keeps counting for concurrent observers); capabilities report with prominent float-filter-downgrade flag; frameloop controls (mode switch, invalidate, deterministic frame stepping via the D1 `setFrame`/`getFrame` passthroughs).
- `attach.ts` — `ensureDevtoolsMounted()` singleton (`createRoot`), null-then-set sink swap per the D1 review note; `debug` prop on both engines dynamic-imports it, keeping the panel chunk out of the main bundle.
- `scripts/assertTreeshaken.mjs` rewritten from a 3-file grep to a static-import-graph walker (dynamic imports not followed) — asserts nothing under `dist/react/devtools/` except `beacon.mjs`, and no `dist/testing*`, is statically reachable from the three main entries. Poison-tested both directly and via the beacon-exemption path.
- Measure story: `many-canvases-devtools` demo+bench scene (panel present-but-collapsed) — makes the zero-cost claim a permanent counter-level regression guard.

## Verification

- typecheck / lint / 203 tests / build (import-graph walker green) — run once post-fix per the new check-economy discipline.
- Headless browser click-through (first UI slice): expand/collapse, FPS live, frameloop `never` freezes frame + draws→0, step +1 advances exactly one frame, GL counters show 1 draw/frame on the single-canvas scene, 8-engine discovery via sink replay.
- Full bench vs master baseline: 5 original scenes unchanged (contexts identical, 0 compiles, per-frame rates equal); `many-canvases-devtools` vs `many-canvases`: 8.013 vs 8.006 drawArrays/frame — collapsed panel adds zero per-frame GL work.
- Adversarial review fixed 2 confirmed bugs: destructive `reset()` on the shared counter handle; a React CSS-shorthand warning that logged to the consumer console on every button toggle.