### PR TITLE
devtools D3+D4: uniform inspector (override port, scrub controls, vector/color), FBO thumbnails

### DIFF
--- a/demo/scenes/DevtoolsDebug.tsx
+++ b/demo/scenes/DevtoolsDebug.tsx
@@ -1,19 +1,46 @@
 import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
-import { vec2 } from '../../src/core/lib/vectorUtils';
+import { vec2, vec3 } from '../../src/core/lib/vectorUtils';
 import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
 import type { UniformParam } from '../../src/types';
-import { PLASMA_FRAGMENT, QUAD_VERTEX } from './shaders';
+import { QUAD_VERTEX } from './shaders';
+
+const DEVTOOLS_FRAGMENT = `
+    precision highp float;
+    uniform float u_time;
+    uniform vec2 u_resolution;
+    uniform float u_speed;
+    uniform float u_scale;
+    uniform float u_intensity;
+    uniform vec2 u_offset;
+    uniform vec3 u_color;
+    varying vec2 v_uv;
+    void main() {
+        vec2 p = (v_uv - 0.5 + u_offset) * u_scale;
+        float t = u_time * u_speed;
+        float v = sin(p.x * 6.0 + t) + cos(p.y * 6.0 - t) + sin((p.x + p.y) * 4.0 + t * 0.5);
+        vec3 col = (0.5 + 0.5 * cos(vec3(0.0, 2.0, 4.0) + v)) * u_intensity * u_color;
+        gl_FragColor = vec4(col, 1.0);
+    }
+`;
 
 const config = createShaderConfig({
     vertexShader: QUAD_VERTEX,
-    fragmentShader: PLASMA_FRAGMENT,
+    fragmentShader: DEVTOOLS_FRAGMENT,
     uniformNames: {
-        u_offset: 'vec2'
+        u_speed: 'float',
+        u_scale: 'float',
+        u_intensity: 'float',
+        u_offset: 'vec2',
+        u_color: 'vec3'
     }
 });
 
 const uniforms: Record<string, UniformParam> = {
-    u_offset: { type: 'vec2', value: vec2([0, 0]) }
+    u_speed: { type: 'float', value: 1 },
+    u_scale: { type: 'float', value: 3 },
+    u_intensity: { type: 'float', value: 1 },
+    u_offset: { type: 'vec2', value: vec2([0, 0]) },
+    u_color: { type: 'vec3', value: vec3([1, 1, 1]) }
 };
 
 export const DevtoolsDebug = () => {

--- a/demo/scenes/PingPongSim.tsx
+++ b/demo/scenes/PingPongSim.tsx
@@ -57,6 +57,7 @@ export const PingPongSim = () => {
             programConfigs={programConfigs}
             passes={passes}
             framebuffers={framebuffers}
+            debug
             style={{ width: '100vw', height: '100vh', display: 'block' }}
         />
     );

--- a/src/core/managers/FBOManager.test.ts
+++ b/src/core/managers/FBOManager.test.ts
@@ -149,6 +149,106 @@ describe('FBOManager viewport cache', () => {
     });
 });
 
+describe('FBOManager debugReadFramebuffer', () => {
+    it('throws for an unknown id', () => {
+        const { gl } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
+        const manager = new FBOManager(gl);
+
+        expect(() => manager.debugReadFramebuffer('missing')).toThrow(/not found/);
+    });
+
+    it('reads a zeroed pixel buffer for a normal UNSIGNED_BYTE framebuffer', () => {
+        const { gl } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
+        const manager = new FBOManager(gl);
+        manager.createFramebuffer('a', { width: 4, height: 4, textureCount: 1 });
+
+        const result = manager.debugReadFramebuffer('a');
+
+        if ('unreadable' in result) {
+            throw new Error(`expected a readable result, got: ${result.unreadable}`);
+        }
+        expect(result.width).toBe(4);
+        expect(result.height).toBe(4);
+        expect(result.pixels).toHaveLength(4 * 4 * 4);
+        expect(result.pixels.every(value => value === 0)).toBe(true);
+    });
+
+    it('returns unreadable for a zero-size framebuffer', () => {
+        const { gl } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
+        const manager = new FBOManager(gl);
+        manager.createFramebuffer('a', { width: 0, height: 0, textureCount: 1 });
+
+        const result = manager.debugReadFramebuffer('a');
+
+        expect(result).toEqual({ unreadable: 'framebuffer has zero size' });
+    });
+
+    it('returns unreadable when the framebuffer exceeds maxSize', () => {
+        const { gl } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
+        const manager = new FBOManager(gl);
+        manager.createFramebuffer('a', { width: 16, height: 16, textureCount: 1 });
+
+        const result = manager.debugReadFramebuffer('a', 8);
+
+        expect('unreadable' in result).toBe(true);
+    });
+
+    it('returns unreadable when the framebuffer becomes incomplete at read time', () => {
+        let calls = 0;
+        const { gl } = createGLStub({
+            renderableTypes: [GL_UNSIGNED_BYTE],
+            overrides: {
+                checkFramebufferStatus: (): number => {
+                    calls += 1;
+                    return calls === 1 ? gl.FRAMEBUFFER_COMPLETE : gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT;
+                }
+            }
+        });
+        const manager = new FBOManager(gl);
+        manager.createFramebuffer('a', { width: 4, height: 4, textureCount: 1 });
+
+        const result = manager.debugReadFramebuffer('a');
+
+        expect('unreadable' in result).toBe(true);
+    });
+
+    it('returns unreadable for a FLOAT framebuffer when the implementation cannot read UNSIGNED_BYTE', () => {
+        const { gl } = createGLStub({
+            extensions: { OES_texture_float: true },
+            renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT],
+            colorReadType: GL_FLOAT
+        });
+        const manager = new FBOManager(gl);
+        manager.createFramebuffer('a', {
+            width: 4,
+            height: 4,
+            textureCount: 1,
+            textureOptions: { type: GL_FLOAT }
+        });
+
+        const result = manager.debugReadFramebuffer('a');
+
+        expect(result).toEqual({ unreadable: 'float framebuffer readback unsupported' });
+    });
+
+    it('restores the previous framebuffer binding and viewport after reading', () => {
+        const { gl } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });
+        const manager = new FBOManager(gl);
+        manager.createFramebuffer('a', { width: 4, height: 4, textureCount: 1 });
+        manager.createFramebuffer('b', { width: 8, height: 8, textureCount: 1 });
+
+        manager.bindFramebuffer('b');
+
+        const boundBefore = gl.getParameter(gl.FRAMEBUFFER_BINDING) as unknown;
+        const viewportBefore = gl.getParameter(gl.VIEWPORT) as unknown;
+
+        manager.debugReadFramebuffer('a');
+
+        expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBe(boundBefore);
+        expect(gl.getParameter(gl.VIEWPORT)).toEqual(viewportBefore);
+    });
+});
+
 describe('FBOManager getFramebufferIds', () => {
     it('lists created framebuffer ids and reflects destroy', () => {
         const { gl } = createGLStub({ renderableTypes: [GL_UNSIGNED_BYTE] });

--- a/src/core/managers/FBOManager.ts
+++ b/src/core/managers/FBOManager.ts
@@ -8,6 +8,16 @@ import { GL_HALF_FLOAT_OES } from '@/core/lib/glConstants';
 import type { TextureCapabilities } from '@/core/lib/textureCapabilities';
 import { resolveTextureType } from '@/core/lib/textureCapabilities';
 
+export interface FramebufferReadResult {
+    width: number;
+    height: number;
+    pixels: Uint8ClampedArray;
+}
+
+export interface FramebufferUnreadable {
+    unreadable: string;
+}
+
 export class FBOManager {
     private gl: WebGLRenderingContext;
     private resources = new Map<string, FramebufferResources>();
@@ -311,6 +321,54 @@ export class FBOManager {
         });
         this.lastViewportWidth = -1;
         this.lastViewportHeight = -1;
+    }
+
+    debugReadFramebuffer(id: string, maxSize?: number): FramebufferReadResult | FramebufferUnreadable {
+        const resources = this.resources.get(id);
+        if (!resources) {
+            throw new Error(`Framebuffer with id ${id} not found`);
+        }
+
+        const { width, height } = resources;
+        if (width <= 0 || height <= 0) {
+            return { unreadable: 'framebuffer has zero size' };
+        }
+        if (maxSize !== undefined && (width > maxSize || height > maxSize)) {
+            return { unreadable: `framebuffer ${width}x${height} exceeds capture maxSize ${maxSize}` };
+        }
+
+        const gl = this.gl;
+        const previousFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null;
+        const previousViewport = gl.getParameter(gl.VIEWPORT) as ArrayLike<number>;
+
+        const restore = (): void => {
+            gl.bindFramebuffer(gl.FRAMEBUFFER, previousFramebuffer);
+            gl.viewport(previousViewport[0], previousViewport[1], previousViewport[2], previousViewport[3]);
+        };
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, resources.framebuffer);
+
+        const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+        if (status !== gl.FRAMEBUFFER_COMPLETE) {
+            restore();
+            return { unreadable: `framebuffer incomplete: ${status}` };
+        }
+
+        if (resources.textureOptions.type !== gl.UNSIGNED_BYTE) {
+            const readType = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE) as number;
+            const readFormat = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT) as number;
+            if (readType !== gl.UNSIGNED_BYTE || readFormat !== gl.RGBA) {
+                restore();
+                return { unreadable: 'float framebuffer readback unsupported' };
+            }
+        }
+
+        const pixels = new Uint8ClampedArray(width * height * 4);
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+        restore();
+
+        return { width, height, pixels };
     }
 
     getCapabilities(): TextureCapabilities {

--- a/src/react/components/base/BasePingPongShaderComponent.tsx
+++ b/src/react/components/base/BasePingPongShaderComponent.tsx
@@ -1,9 +1,10 @@
 import type { CSSProperties } from 'react';
-import { forwardRef, memo } from 'react';
+import { forwardRef, memo, useRef } from 'react';
 
 import type { FramebufferOptions, RenderOptions, RenderPass, ShaderProgramConfig } from '@/core';
 import { PingPongShaderEngine } from '@/react/components/engine/PingPongShaderEngine';
 import { usePingPongPasses } from '@/react/hooks/usePingPongPasses';
+import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import type { RenderControlProps, ShaderHandle, UniformParam } from '@/types';
 
 export interface BasePingPongShaderProps extends RenderControlProps {
@@ -71,7 +72,7 @@ const BasePingPongShaderComponentImpl = forwardRef<ShaderHandle, BasePingPongSha
         programConfigs[actualSecondaryProgramId] = secondaryShaderConfig;
     }
 
-    const { passes, framebuffers } = usePingPongPasses({
+    const { passes, framebuffers, port } = usePingPongPasses({
         programId,
         secondaryProgramId: secondaryShaderConfig ? actualSecondaryProgramId : undefined,
         iterations,
@@ -82,6 +83,8 @@ const BasePingPongShaderComponentImpl = forwardRef<ShaderHandle, BasePingPongSha
         customPasses,
         framebuffers: framebuffersOverride
     });
+    const debugPortRef = useRef<UniformDebugPort | null>(null);
+    debugPortRef.current = port;
 
     return (
         <PingPongShaderEngine
@@ -89,6 +92,7 @@ const BasePingPongShaderComponentImpl = forwardRef<ShaderHandle, BasePingPongSha
             programConfigs={programConfigs}
             passes={passes}
             framebuffers={framebuffers}
+            debugPortRef={debugPortRef}
             className={className}
             style={style}
             width={width}

--- a/src/react/components/base/BaseShaderComponent.tsx
+++ b/src/react/components/base/BaseShaderComponent.tsx
@@ -1,9 +1,10 @@
 import type { CSSProperties } from 'react';
-import { forwardRef, memo } from 'react';
+import { forwardRef, memo, useRef } from 'react';
 
 import type { RenderOptions, ShaderProgramConfig, ShaderRenderCallback } from '@/core';
 import { ShaderEngine } from '@/react';
 import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
+import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import type { RenderControlProps, ShaderHandle, UniformParam } from '@/types';
 
 export interface BaseShaderProps extends RenderControlProps {
@@ -50,14 +51,17 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     renderOptions = RENDER_OPTIONS
 }, ref) => {
     const programConfigs = { [programId]: shaderConfig };
-    const uniformUpdaters = useUniformUpdaters(programId, uniforms, { skipDefaultUniforms });
+    const { updaters, port } = useUniformUpdaters(programId, uniforms, { skipDefaultUniforms });
+    const debugPortRef = useRef<UniformDebugPort | null>(null);
+    debugPortRef.current = port;
 
     return (
         <ShaderEngine
             ref={ref}
             programConfigs={programConfigs}
             renderCallback={renderFullscreenQuad}
-            uniformUpdaters={uniformUpdaters}
+            uniformUpdaters={updaters}
+            debugPortRef={debugPortRef}
             width={width}
             height={height}
             pixelRatio={pixelRatio}

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -2,6 +2,7 @@ import {
     type CSSProperties,
     forwardRef,
     memo,
+    type RefObject,
     useCallback,
     useEffect,
     useImperativeHandle,
@@ -19,6 +20,7 @@ import { Passes } from '@/core/systems/Passes';
 import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
 import { framebuffersContentKey, programConfigsContentKey } from '@/react/lib/contentKeys';
+import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import {
     DEFAULT_DPR,
@@ -37,6 +39,7 @@ interface PingPongShaderEngineProps extends RenderControlProps {
     renderWidth?: number;
     renderHeight?: number;
     debug?: boolean;
+    debugPortRef?: RefObject<UniformDebugPort | null>;
 }
 
 interface ObservedSize {
@@ -100,6 +103,7 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
     renderWidth,
     renderHeight,
     debug = false,
+    debugPortRef,
     useDevicePixelRatio,
     pixelRatio,
     frameloop = 'always',
@@ -303,7 +307,8 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
                 invalidate: () => { controllerRef.current?.invalidate() },
                 setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
                 getFrame: () => controllerRef.current?.getFrame() ?? 0,
-                setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) }
+                setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) },
+                uniforms: debugPortRef?.current ?? undefined
             };
             emitEngineMount(handle);
         }
@@ -315,7 +320,7 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
             passSystemRef.current = null;
             emitEngineUnmount(engineIdRef.current);
         };
-    }, [contentKey, epoch]);
+    }, [contentKey, epoch, debugPortRef]);
 
     useEffect(() => {
         applySize();

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -2,6 +2,7 @@ import {
     type CSSProperties,
     forwardRef,
     memo,
+    type RefObject,
     useCallback,
     useEffect,
     useImperativeHandle,
@@ -20,6 +21,7 @@ import { WebGLManager } from '@/core/managers/WebGLManager';
 import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
 import { programConfigContentKey, singleProgramEntry } from '@/react/lib/contentKeys';
+import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import {
     DEFAULT_DPR,
@@ -44,6 +46,7 @@ interface ShaderEngineProps extends RenderControlProps {
     uniformUpdaters?: Record<string, UniformUpdaterEntry[]>;
     useFastPath?: boolean;
     debug?: boolean;
+    debugPortRef?: RefObject<UniformDebugPort | null>;
 }
 
 interface ObservedSize {
@@ -109,6 +112,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     uniformUpdaters = DEFAULT_UNIFORM_UPDATERS,
     useFastPath = false,
     debug = false,
+    debugPortRef,
     useDevicePixelRatio,
     pixelRatio,
     frameloop = 'always',
@@ -311,7 +315,8 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
                 invalidate: () => { controllerRef.current?.invalidate() },
                 setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
                 getFrame: () => controllerRef.current?.getFrame() ?? 0,
-                setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) }
+                setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) },
+                uniforms: debugPortRef?.current ?? undefined
             };
             emitEngineMount(handle);
         }
@@ -323,7 +328,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             activeProgram.current = null;
             emitEngineUnmount(engineIdRef.current);
         };
-    }, [contentKey, epoch]);
+    }, [contentKey, epoch, debugPortRef]);
 
     useEffect(() => {
         applySize();

--- a/src/react/devtools/MicuglDevtools.tsx
+++ b/src/react/devtools/MicuglDevtools.tsx
@@ -10,8 +10,10 @@ import { computeFrameStats, fpsFromMean, pushCapped } from '@/react/devtools/lib
 import { buttonStyle, COLORS, FONT, sectionStyle } from '@/react/devtools/lib/theme';
 import { CapabilitiesPanel } from '@/react/devtools/panels/CapabilitiesPanel';
 import { FpsPanel } from '@/react/devtools/panels/FpsPanel';
+import { FramebuffersPanel } from '@/react/devtools/panels/FramebuffersPanel';
 import { FrameloopPanel } from '@/react/devtools/panels/FrameloopPanel';
 import { GlCountersPanel } from '@/react/devtools/panels/GlCountersPanel';
+import { UniformsPanel } from '@/react/devtools/panels/UniformsPanel';
 import { diffCounters } from '@/testing/assertions';
 import type { GlCountersData, GlCountersHandle } from '@/testing/glCounters';
 import { installGlCounters } from '@/testing/glCounters';
@@ -26,6 +28,7 @@ export interface MicuglDevtoolsProps {
 
 const MAX_SAMPLES = 180;
 const THROTTLE_MS = 100;
+const CAPTURE_THROTTLE_MS = 333;
 
 let panelActive = false;
 
@@ -153,6 +156,7 @@ const DevtoolsPanel = ({ position, defaultOpen }: DevtoolsPanelProps): ReactElem
     const [liveFrame, setLiveFrame] = useState(0);
     const [glOn, setGlOn] = useState(false);
     const [glDelta, setGlDelta] = useState<GlCountersData | null>(null);
+    const [captureTick, setCaptureTick] = useState(0);
 
     const selected = engines.find(engine => engine.id === selectedId) ?? engines.at(0) ?? null;
 
@@ -162,6 +166,7 @@ const DevtoolsPanel = ({ position, defaultOpen }: DevtoolsPanelProps): ReactElem
     const glHistoryRef = useRef<number[]>([]);
     const lastTsRef = useRef(0);
     const lastThrottleRef = useRef(0);
+    const captureThrottleRef = useRef(0);
     const glCountersRef = useRef<GlCountersHandle | null>(null);
     const latestGlRef = useRef<GlCountersData | null>(null);
     const prevGlRef = useRef<GlCountersData | null>(null);
@@ -209,6 +214,10 @@ const DevtoolsPanel = ({ position, defaultOpen }: DevtoolsPanelProps): ReactElem
                         drawSparkline(glCanvasRef.current, glHistoryRef.current, COLORS.accent);
                     }
                 }
+            }
+            if (opened && timestamp - captureThrottleRef.current >= CAPTURE_THROTTLE_MS) {
+                captureThrottleRef.current = timestamp;
+                setCaptureTick(tick => tick + 1);
             }
             if (timestamp - lastThrottleRef.current >= THROTTLE_MS) {
                 lastThrottleRef.current = timestamp;
@@ -318,6 +327,16 @@ const DevtoolsPanel = ({ position, defaultOpen }: DevtoolsPanelProps): ReactElem
                                             onStep={handleStep}
                                             onSetFrame={handleSetFrame}
                                         />
+                                        <UniformsPanel engine={selected} />
+                                        {engineState.framebufferIds.length > 0
+                                            ? (
+                                                <FramebuffersPanel
+                                                    framebufferIds={engineState.framebufferIds}
+                                                    manager={selected?.getManager() ?? null}
+                                                    captureTick={captureTick}
+                                                />
+                                            )
+                                            : null}
                                     </>
                                 )
                                 : null}

--- a/src/react/devtools/beacon.ts
+++ b/src/react/devtools/beacon.ts
@@ -1,5 +1,6 @@
 import type { WebGLManager } from '@/core';
 import type { TextureCapabilities } from '@/core/lib/textureCapabilities';
+import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import type { Frameloop } from '@/types';
 
 export interface EngineDebugState {
@@ -24,6 +25,7 @@ export interface EngineHandle {
     setFrameloop?: (mode: Frameloop) => void;
     setFrame?: (frame: number) => void;
     getFrame?: () => number;
+    uniforms?: UniformDebugPort;
 }
 
 export interface DevtoolsSink {

--- a/src/react/devtools/controls/ColorField.tsx
+++ b/src/react/devtools/controls/ColorField.tsx
@@ -1,0 +1,65 @@
+import type { ChangeEvent, ReactElement } from 'react';
+
+import { VectorField } from '@/react/devtools/controls/VectorField';
+import { componentsToHex, hexToComponents, isOutOfGamut } from '@/react/devtools/lib/colorHex';
+import { COLORS } from '@/react/devtools/lib/theme';
+
+export interface ColorFieldProps {
+    value: Float32Array | readonly number[];
+    type: 'vec3' | 'vec4';
+    onChange: (next: Float32Array) => void;
+    ariaLabelPrefix: string;
+}
+
+const COLOR_LABELS = ['r', 'g', 'b', 'a'] as const;
+
+export const ColorField = ({ value, type, onChange, ariaLabelPrefix }: ColorFieldProps): ReactElement => {
+    const length = type === 'vec4' ? 4 : 3;
+    const components = Array.from({ length }, (_, i) => value[i] ?? 0);
+    const rgb = components.slice(0, 3);
+    const hex = componentsToHex(rgb);
+    const hdr = isOutOfGamut(rgb);
+
+    const handlePick = (event: ChangeEvent<HTMLInputElement>): void => {
+        const [r, g, b] = hexToComponents(event.target.value);
+        const next = new Float32Array(length);
+        next[0] = r;
+        next[1] = g;
+        next[2] = b;
+        if (length === 4) {
+            next[3] = components[3];
+        }
+        onChange(next);
+    };
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', width: '100%' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                <input
+                    type='color'
+                    value={hex}
+                    onChange={handlePick}
+                    aria-label={`${ariaLabelPrefix} color picker`}
+                    style={{
+                        width: '22px',
+                        height: '22px',
+                        padding: 0,
+                        border: `1px solid ${hdr ? COLORS.warn : COLORS.border}`,
+                        borderRadius: '4px',
+                        background: 'none',
+                        cursor: 'pointer'
+                    }}
+                />
+                {hdr ? <span style={{ fontSize: '9px', color: COLORS.warn }}>HDR, clamped preview</span> : null}
+            </div>
+            <VectorField
+                value={value}
+                length={length}
+                type={type}
+                labels={COLOR_LABELS}
+                onChange={onChange}
+                ariaLabelPrefix={ariaLabelPrefix}
+            />
+        </div>
+    );
+};

--- a/src/react/devtools/controls/NumberField.tsx
+++ b/src/react/devtools/controls/NumberField.tsx
@@ -1,0 +1,216 @@
+import type { ChangeEvent, KeyboardEvent, WheelEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import { ensureControlStyleInjected, NUMBER_FIELD_CLASS, NUMBER_FIELD_FLASH_CLASS } from '@/react/devtools/controls/controlStyles';
+import type { ScrubModifiers } from '@/react/devtools/controls/useScrub';
+import { normalizeZero, useScrub } from '@/react/devtools/controls/useScrub';
+import { evaluate } from '@/react/devtools/lib/evaluate';
+import { formatValue } from '@/react/devtools/lib/step';
+import { COLORS, FONT } from '@/react/devtools/lib/theme';
+
+export interface NumberFieldProps {
+    value: number;
+    step: number;
+    onChange: (value: number, modifiers?: ScrubModifiers) => void;
+    ariaLabel: string;
+}
+
+const FLASH_MS = 150;
+
+const fieldStyle = {
+    fontFamily: FONT,
+    fontSize: '11px',
+    padding: '3px 6px',
+    background: 'rgba(0,0,0,0.3)',
+    border: `1px solid ${COLORS.border}`,
+    borderRadius: '4px',
+    color: COLORS.text,
+    width: '100%',
+    boxSizing: 'border-box' as const
+};
+
+export const NumberField = ({ value, step, onChange, ariaLabel }: NumberFieldProps) => {
+    const [editing, setEditing] = useState(false);
+    const [draft, setDraft] = useState('');
+    const [dragValue, setDragValue] = useState<number | null>(null);
+    const [hovered, setHovered] = useState(false);
+    const [flash, setFlash] = useState(false);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const handleScrubChange = (next: number, modifiers?: ScrubModifiers): void => {
+        setDragValue(next);
+        onChange(next, modifiers);
+    };
+
+    const { dragging, onPointerDown, onPointerMove, onPointerUp, negate } = useScrub({
+        value,
+        step,
+        onChange: handleScrubChange
+    });
+
+    useEffect(() => {
+        ensureControlStyleInjected(inputRef.current?.getRootNode());
+    }, []);
+
+    useEffect(() => {
+        if (!dragging) {
+            setDragValue(null);
+        }
+    }, [dragging]);
+
+    useEffect(() => {
+        if (editing) {
+            inputRef.current?.select();
+        }
+    }, [editing]);
+
+    useEffect(() => () => {
+        if (flashTimerRef.current !== null) {
+            clearTimeout(flashTimerRef.current);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!hovered || editing || dragging) {
+            return;
+        }
+        const onWindowKeyDown = (event: globalThis.KeyboardEvent): void => {
+            if (event.key !== '-' && event.key !== 'Subtract') {
+                return;
+            }
+            if (document.activeElement === inputRef.current) {
+                return;
+            }
+            event.preventDefault();
+            onChange(normalizeZero(-value));
+        };
+        window.addEventListener('keydown', onWindowKeyDown);
+        return () => { window.removeEventListener('keydown', onWindowKeyDown) };
+    }, [hovered, editing, dragging, value, onChange]);
+
+    const triggerFlash = (): void => {
+        setFlash(true);
+        if (flashTimerRef.current !== null) {
+            clearTimeout(flashTimerRef.current);
+        }
+        flashTimerRef.current = setTimeout(() => { setFlash(false) }, FLASH_MS);
+    };
+
+    const enterEditing = (): void => {
+        setDraft(formatValue(value, step));
+        setEditing(true);
+    };
+
+    const commitDraft = (): void => {
+        try {
+            onChange(evaluate(draft));
+        } catch {
+            triggerFlash();
+        }
+        setEditing(false);
+    };
+
+    const revertDraft = (): void => {
+        setEditing(false);
+    };
+
+    const applyKeyboardStep = (multiplier: number): void => {
+        onChange(normalizeZero(value + step * multiplier));
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+        if (editing) {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                commitDraft();
+            } else if (event.key === 'Escape') {
+                event.preventDefault();
+                revertDraft();
+            }
+            return;
+        }
+        if (event.key === '-' || event.key === 'Subtract') {
+            event.preventDefault();
+            if (!negate()) {
+                onChange(normalizeZero(-value));
+            }
+            return;
+        }
+        if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+            event.preventDefault();
+            const sign = event.key === 'ArrowUp' ? 1 : -1;
+            const precision = event.shiftKey ? 0.1 : (event.ctrlKey || event.metaKey) ? 10 : 1;
+            applyKeyboardStep(sign * precision);
+            return;
+        }
+        if (event.key === 'PageUp' || event.key === 'PageDown') {
+            event.preventDefault();
+            applyKeyboardStep(event.key === 'PageUp' ? 10 : -10);
+            return;
+        }
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            enterEditing();
+        }
+    };
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+        setDraft(event.target.value);
+    };
+
+    const handleBlur = (): void => {
+        if (editing) {
+            commitDraft();
+        }
+    };
+
+    const handlePointerUp: typeof onPointerUp = event => {
+        const outcome = onPointerUp(event);
+        if (outcome === 'tap') {
+            enterEditing();
+        }
+        return outcome;
+    };
+
+    const handleWheel = (event: WheelEvent<HTMLInputElement>): void => {
+        if (editing) {
+            return;
+        }
+        const precision = event.shiftKey ? 0.1 : 1;
+        const delta = event.deltaY > 0 ? -1 : 1;
+        onChange(normalizeZero(value + step * precision * delta));
+    };
+
+    const displayValue = editing
+        ? draft
+        : formatValue(dragging && dragValue !== null ? dragValue : value, step);
+
+    const className = flash ? `${NUMBER_FIELD_CLASS} ${NUMBER_FIELD_FLASH_CLASS}` : NUMBER_FIELD_CLASS;
+
+    return (
+        <input
+            ref={inputRef}
+            className={className}
+            role='spinbutton'
+            aria-label={ariaLabel}
+            aria-valuenow={value}
+            tabIndex={0}
+            readOnly={!editing}
+            value={displayValue}
+            style={{
+                ...fieldStyle,
+                cursor: dragging ? 'none' : 'ew-resize'
+            }}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerEnter={() => { setHovered(true) }}
+            onPointerLeave={() => { setHovered(false) }}
+            onKeyDown={handleKeyDown}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            onWheel={handleWheel}
+        />
+    );
+};

--- a/src/react/devtools/controls/VectorField.tsx
+++ b/src/react/devtools/controls/VectorField.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from 'react';
+
+import { NumberField } from '@/react/devtools/controls/NumberField';
+import type { ScrubModifiers } from '@/react/devtools/controls/useScrub';
+import { stepForType } from '@/react/devtools/lib/step';
+import type { UniformType } from '@/types';
+
+export interface VectorFieldProps {
+    value: Float32Array | readonly number[];
+    length: number;
+    type: UniformType;
+    labels: readonly string[];
+    onChange: (next: Float32Array) => void;
+    ariaLabelPrefix: string;
+}
+
+export const DEFAULT_VECTOR_LABELS = ['x', 'y', 'z', 'w'] as const;
+
+const toComponents = (value: Float32Array | readonly number[], length: number): Float32Array => {
+    const out = new Float32Array(length);
+    for (let i = 0; i < length; i++) {
+        out[i] = value[i] ?? 0;
+    }
+    return out;
+};
+
+export const VectorField = ({ value, length, type, labels, onChange, ariaLabelPrefix }: VectorFieldProps): ReactElement => {
+    const components = toComponents(value, length);
+
+    const handleLaneChange = (index: number, next: number, modifiers?: ScrubModifiers): void => {
+        const updated = new Float32Array(components);
+        if (modifiers?.altKey) {
+            const delta = next - components[index];
+            for (let i = 0; i < length; i++) {
+                updated[i] = components[i] + delta;
+            }
+        } else {
+            updated[index] = next;
+        }
+        onChange(updated);
+    };
+
+    return (
+        <div style={{ display: 'flex', gap: '4px' }}>
+            {Array.from({ length }, (_, index) => (
+                <div key={index} style={{ flex: 1, minWidth: '40px' }}>
+                    <NumberField
+                        value={components[index]}
+                        step={stepForType(type, components[index])}
+                        ariaLabel={`${ariaLabelPrefix} ${labels[index] ?? String(index)}`}
+                        onChange={(next, modifiers) => { handleLaneChange(index, next, modifiers) }}
+                    />
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/src/react/devtools/controls/controlStyles.ts
+++ b/src/react/devtools/controls/controlStyles.ts
@@ -1,0 +1,49 @@
+import { COLORS } from '@/react/devtools/lib/theme';
+
+export const NUMBER_FIELD_CLASS = 'micugl-numberfield';
+export const NUMBER_FIELD_FLASH_CLASS = 'micugl-numberfield-flash';
+const STYLE_MARKER = 'data-micugl-numberfield-style';
+
+export const CONTROL_STYLE_CSS = `
+.${NUMBER_FIELD_CLASS}:focus-visible {
+    outline: 2px solid ${COLORS.accent};
+    outline-offset: 1px;
+}
+.${NUMBER_FIELD_CLASS}::selection {
+    background: ${COLORS.accent};
+    color: #0b0d16;
+}
+.${NUMBER_FIELD_CLASS}.${NUMBER_FIELD_FLASH_CLASS} {
+    animation: micugl-numberfield-flash 150ms ease-out;
+}
+@keyframes micugl-numberfield-flash {
+    from { background: ${COLORS.danger}; }
+    to { background: transparent; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .${NUMBER_FIELD_CLASS}.${NUMBER_FIELD_FLASH_CLASS} {
+        animation: none;
+        background: ${COLORS.danger};
+    }
+}
+`;
+
+const injectedRoots = new WeakSet<Node>();
+
+export function ensureControlStyleInjected(root: Node | null | undefined): void {
+    if (!root || injectedRoots.has(root)) {
+        return;
+    }
+    if (!(root instanceof ShadowRoot) && !(root instanceof Document)) {
+        return;
+    }
+    if (root.querySelector(`style[${STYLE_MARKER}]`)) {
+        injectedRoots.add(root);
+        return;
+    }
+    const style = document.createElement('style');
+    style.setAttribute(STYLE_MARKER, '');
+    style.textContent = CONTROL_STYLE_CSS;
+    root.appendChild(style);
+    injectedRoots.add(root);
+}

--- a/src/react/devtools/controls/useScrub.test.ts
+++ b/src/react/devtools/controls/useScrub.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    accumulateMovement,
+    computeDragValue,
+    crossesThreshold,
+    DEFAULT_PX_PER_STEP,
+    DEFAULT_THRESHOLD_PX,
+    IDLE_SCRUB_STATE,
+    negateDrag,
+    normalizeZero,
+    promoteToDragging,
+    resetScrub,
+    type ScrubModifiers,
+    startMaybeDrag
+} from '@/react/devtools/controls/useScrub';
+
+const NO_MODIFIERS: ScrubModifiers = { shiftKey: false, ctrlKey: false, metaKey: false, altKey: false };
+
+describe('normalizeZero', () => {
+    it('collapses negative zero to zero', () => {
+        expect(Object.is(normalizeZero(-0), -0)).toBe(false);
+        expect(normalizeZero(-0)).toBe(0);
+    });
+
+    it('leaves other values untouched', () => {
+        expect(normalizeZero(3.5)).toBe(3.5);
+        expect(normalizeZero(-3.5)).toBe(-3.5);
+    });
+});
+
+describe('startMaybeDrag', () => {
+    it('enters maybe-drag with a zero accumulator', () => {
+        const state = startMaybeDrag(100, 5);
+        expect(state).toEqual({ mode: 'maybe-drag', startClientX: 100, startValue: 5, accumPx: 0 });
+    });
+});
+
+describe('crossesThreshold', () => {
+    it('is false below the threshold', () => {
+        const state = startMaybeDrag(100, 5);
+        expect(crossesThreshold(state, 102, DEFAULT_THRESHOLD_PX)).toBe(false);
+    });
+
+    it('is true once movement exceeds the threshold', () => {
+        const state = startMaybeDrag(100, 5);
+        expect(crossesThreshold(state, 104, DEFAULT_THRESHOLD_PX)).toBe(true);
+        expect(crossesThreshold(state, 96, DEFAULT_THRESHOLD_PX)).toBe(true);
+    });
+
+    it('is false outside of maybe-drag mode', () => {
+        expect(crossesThreshold(IDLE_SCRUB_STATE, 999, DEFAULT_THRESHOLD_PX)).toBe(false);
+    });
+});
+
+describe('promoteToDragging', () => {
+    it('seeds accumPx from the crossing distance', () => {
+        const maybeDrag = startMaybeDrag(100, 5);
+        const dragging = promoteToDragging(maybeDrag, 108);
+        expect(dragging.mode).toBe('dragging');
+        expect(dragging.accumPx).toBe(8);
+        expect(dragging.startValue).toBe(5);
+    });
+});
+
+describe('accumulateMovement', () => {
+    it('adds movementX while dragging', () => {
+        const dragging = promoteToDragging(startMaybeDrag(0, 0), 4);
+        const next = accumulateMovement(dragging, 10);
+        expect(next.accumPx).toBe(14);
+    });
+
+    it('is a no-op outside dragging mode', () => {
+        expect(accumulateMovement(IDLE_SCRUB_STATE, 10)).toBe(IDLE_SCRUB_STATE);
+        const maybeDrag = startMaybeDrag(0, 0);
+        expect(accumulateMovement(maybeDrag, 10)).toBe(maybeDrag);
+    });
+});
+
+describe('computeDragValue', () => {
+    it('applies continuous movement at the base rate', () => {
+        const state = { mode: 'dragging' as const, startClientX: 0, startValue: 10, accumPx: DEFAULT_PX_PER_STEP };
+        const value = computeDragValue(state, 1, DEFAULT_PX_PER_STEP, NO_MODIFIERS);
+        expect(value).toBeCloseTo(11);
+    });
+
+    it('shift scales the rate by 0.1 (precision mode)', () => {
+        const state = { mode: 'dragging' as const, startClientX: 0, startValue: 10, accumPx: DEFAULT_PX_PER_STEP };
+        const value = computeDragValue(state, 1, DEFAULT_PX_PER_STEP, { ...NO_MODIFIERS, shiftKey: true });
+        expect(value).toBeCloseTo(10.1);
+    });
+
+    it('ctrl/cmd snaps the result to the effective step grid', () => {
+        const state = { mode: 'dragging' as const, startClientX: 0, startValue: 10, accumPx: DEFAULT_PX_PER_STEP * 2.4 };
+        const value = computeDragValue(state, 1, DEFAULT_PX_PER_STEP, { ...NO_MODIFIERS, ctrlKey: true });
+        expect(value).toBeCloseTo(12);
+    });
+
+    it('shift+ctrl snaps to the fine grid', () => {
+        const state = { mode: 'dragging' as const, startClientX: 0, startValue: 10, accumPx: DEFAULT_PX_PER_STEP * 2.3 };
+        const value = computeDragValue(state, 1, DEFAULT_PX_PER_STEP, { shiftKey: true, ctrlKey: true, metaKey: false, altKey: false });
+        expect(value).toBeCloseTo(10.2);
+    });
+
+    it('metaKey behaves the same as ctrlKey for snapping', () => {
+        const state = { mode: 'dragging' as const, startClientX: 0, startValue: 0, accumPx: DEFAULT_PX_PER_STEP * 2.4 };
+        const ctrl = computeDragValue(state, 1, DEFAULT_PX_PER_STEP, { ...NO_MODIFIERS, ctrlKey: true });
+        const meta = computeDragValue(state, 1, DEFAULT_PX_PER_STEP, { ...NO_MODIFIERS, metaKey: true });
+        expect(meta).toBe(ctrl);
+    });
+
+    it('negative movement decreases the value', () => {
+        const state = { mode: 'dragging' as const, startClientX: 0, startValue: 10, accumPx: -DEFAULT_PX_PER_STEP };
+        const value = computeDragValue(state, 1, DEFAULT_PX_PER_STEP, NO_MODIFIERS);
+        expect(value).toBeCloseTo(9);
+    });
+});
+
+describe('negateDrag', () => {
+    it('negates the in-progress value and resets the accumulator', () => {
+        const dragging = { mode: 'dragging' as const, startClientX: 0, startValue: 10, accumPx: 12 };
+        const negated = negateDrag(dragging, 11);
+        expect(negated.startValue).toBe(-11);
+        expect(negated.accumPx).toBe(0);
+        expect(negated.mode).toBe('dragging');
+    });
+
+    it('is a no-op outside dragging mode', () => {
+        expect(negateDrag(IDLE_SCRUB_STATE, 5)).toBe(IDLE_SCRUB_STATE);
+    });
+});
+
+describe('resetScrub', () => {
+    it('returns the idle state', () => {
+        expect(resetScrub()).toEqual(IDLE_SCRUB_STATE);
+    });
+});
+
+describe('threshold-then-drag integration (plain-object events)', () => {
+    it('does not cross into dragging until movement exceeds the pixel threshold', () => {
+        const pointerDown = { clientX: 200 };
+        let state = startMaybeDrag(pointerDown.clientX, 3);
+
+        const smallMove = { clientX: 201 };
+        expect(crossesThreshold(state, smallMove.clientX)).toBe(false);
+
+        const bigMove = { clientX: 206 };
+        expect(crossesThreshold(state, bigMove.clientX)).toBe(true);
+        state = promoteToDragging(state, bigMove.clientX);
+        expect(state.mode).toBe('dragging');
+    });
+});

--- a/src/react/devtools/controls/useScrub.ts
+++ b/src/react/devtools/controls/useScrub.ts
@@ -1,0 +1,247 @@
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type ScrubMode = 'idle' | 'maybe-drag' | 'dragging';
+
+export interface ScrubModifiers {
+    shiftKey: boolean;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    altKey: boolean;
+}
+
+export interface ScrubState {
+    mode: ScrubMode;
+    startClientX: number;
+    startValue: number;
+    accumPx: number;
+}
+
+export const DEFAULT_THRESHOLD_PX = 3;
+export const DEFAULT_PX_PER_STEP = 6;
+
+export const IDLE_SCRUB_STATE: ScrubState = {
+    mode: 'idle',
+    startClientX: 0,
+    startValue: 0,
+    accumPx: 0
+};
+
+export function normalizeZero(value: number): number {
+    return value === 0 ? 0 : value;
+}
+
+export function startMaybeDrag(clientX: number, value: number): ScrubState {
+    return { mode: 'maybe-drag', startClientX: clientX, startValue: value, accumPx: 0 };
+}
+
+export function crossesThreshold(
+    state: ScrubState,
+    clientX: number,
+    threshold: number = DEFAULT_THRESHOLD_PX
+): boolean {
+    return state.mode === 'maybe-drag' && Math.abs(clientX - state.startClientX) > threshold;
+}
+
+export function promoteToDragging(state: ScrubState, clientX: number): ScrubState {
+    return { ...state, mode: 'dragging', accumPx: clientX - state.startClientX };
+}
+
+export function accumulateMovement(state: ScrubState, movementX: number): ScrubState {
+    return state.mode === 'dragging' ? { ...state, accumPx: state.accumPx + movementX } : state;
+}
+
+export function computeDragValue(
+    state: ScrubState,
+    step: number,
+    pxPerStep: number,
+    modifiers: ScrubModifiers
+): number {
+    const precision = modifiers.shiftKey ? 0.1 : 1;
+    const effStep = step * precision;
+    let next = state.startValue + (state.accumPx / pxPerStep) * effStep;
+    if ((modifiers.ctrlKey || modifiers.metaKey) && effStep !== 0) {
+        next = Math.round(next / effStep) * effStep;
+    }
+    return normalizeZero(next);
+}
+
+export function negateDrag(state: ScrubState, currentValue: number): ScrubState {
+    return state.mode === 'dragging'
+        ? { ...state, startValue: normalizeZero(-currentValue), accumPx: 0 }
+        : state;
+}
+
+export function resetScrub(): ScrubState {
+    return IDLE_SCRUB_STATE;
+}
+
+export type ScrubPointerUpOutcome = 'commit' | 'tap' | 'none';
+
+export interface UseScrubOptions {
+    value: number;
+    step: number;
+    onChange: (value: number, modifiers?: ScrubModifiers) => void;
+    pxPerStep?: number;
+    threshold?: number;
+}
+
+export interface UseScrubResult {
+    dragging: boolean;
+    onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+    onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
+    onPointerUp: (event: ReactPointerEvent<HTMLElement>) => ScrubPointerUpOutcome;
+    negate: () => boolean;
+}
+
+export function useScrub({
+    value,
+    step,
+    onChange,
+    pxPerStep = DEFAULT_PX_PER_STEP,
+    threshold = DEFAULT_THRESHOLD_PX
+}: UseScrubOptions): UseScrubResult {
+    const [dragging, setDragging] = useState(false);
+    const stateRef = useRef<ScrubState>(IDLE_SCRUB_STATE);
+    const valueRef = useRef(value);
+    const stepRef = useRef(step);
+    const currentValueRef = useRef(value);
+    const originalValueRef = useRef(value);
+    const lockedRef = useRef(false);
+    const elementRef = useRef<HTMLElement | null>(null);
+
+    valueRef.current = value;
+    stepRef.current = step;
+
+    const applyValue = useCallback((modifiers: ScrubModifiers): void => {
+        const next = computeDragValue(stateRef.current, stepRef.current, pxPerStep, modifiers);
+        currentValueRef.current = next;
+        onChange(next, modifiers);
+    }, [onChange, pxPerStep]);
+
+    const endDrag = useCallback((): void => {
+        if (lockedRef.current && typeof document !== 'undefined') {
+            document.exitPointerLock();
+        }
+        lockedRef.current = false;
+        elementRef.current = null;
+        stateRef.current = resetScrub();
+        setDragging(false);
+    }, []);
+
+    const requestLock = useCallback((element: HTMLElement): void => {
+        if (typeof element.requestPointerLock !== 'function') {
+            return;
+        }
+        try {
+            const result = element.requestPointerLock({ unadjustedMovement: true }) as Promise<void> | undefined;
+            if (typeof result !== 'undefined') {
+                void result
+                    .then(() => {
+                        lockedRef.current = document.pointerLockElement === element;
+                    })
+                    .catch((error: unknown) => {
+                        if (error instanceof DOMException && error.name === 'NotSupportedError') {
+                            try {
+                                void element.requestPointerLock()
+                                    .then(() => {
+                                        lockedRef.current = document.pointerLockElement === element;
+                                    })
+                                    .catch(() => {
+                                        lockedRef.current = false;
+                                    });
+                            } catch {
+                                lockedRef.current = false;
+                            }
+                        } else {
+                            lockedRef.current = false;
+                        }
+                    });
+            } else {
+                lockedRef.current = document.pointerLockElement === element;
+            }
+        } catch {
+            lockedRef.current = false;
+        }
+    }, []);
+
+    const onPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>): void => {
+        if (event.button !== 0) {
+            return;
+        }
+        const target = event.currentTarget;
+        elementRef.current = target;
+        target.setPointerCapture(event.pointerId);
+        stateRef.current = startMaybeDrag(event.clientX, valueRef.current);
+        originalValueRef.current = valueRef.current;
+        currentValueRef.current = valueRef.current;
+    }, []);
+
+    const onPointerMove = useCallback((event: ReactPointerEvent<HTMLElement>): void => {
+        const state = stateRef.current;
+        const modifiers: ScrubModifiers = {
+            shiftKey: event.shiftKey,
+            ctrlKey: event.ctrlKey,
+            metaKey: event.metaKey,
+            altKey: event.altKey
+        };
+        if (state.mode === 'idle') {
+            return;
+        }
+        if (state.mode === 'maybe-drag') {
+            if (crossesThreshold(state, event.clientX, threshold)) {
+                stateRef.current = promoteToDragging(state, event.clientX);
+                setDragging(true);
+                requestLock(event.currentTarget);
+                applyValue(modifiers);
+            }
+            return;
+        }
+        stateRef.current = accumulateMovement(state, event.movementX);
+        applyValue(modifiers);
+    }, [applyValue, requestLock, threshold]);
+
+    const onPointerUp = useCallback((event: ReactPointerEvent<HTMLElement>): ScrubPointerUpOutcome => {
+        const state = stateRef.current;
+        if (state.mode === 'dragging') {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+            endDrag();
+            return 'commit';
+        }
+        if (state.mode === 'maybe-drag') {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+            stateRef.current = resetScrub();
+            return 'tap';
+        }
+        return 'none';
+    }, [endDrag]);
+
+    const negate = useCallback((): boolean => {
+        if (stateRef.current.mode !== 'dragging') {
+            return false;
+        }
+        stateRef.current = negateDrag(stateRef.current, currentValueRef.current);
+        const negated = normalizeZero(-currentValueRef.current);
+        currentValueRef.current = negated;
+        onChange(negated);
+        return true;
+    }, [onChange]);
+
+    useEffect(() => {
+        if (!dragging || typeof document === 'undefined') {
+            return;
+        }
+        const onLockChange = (): void => {
+            const element = elementRef.current;
+            if (element && lockedRef.current && document.pointerLockElement !== element) {
+                lockedRef.current = false;
+                onChange(originalValueRef.current);
+                endDrag();
+            }
+        };
+        document.addEventListener('pointerlockchange', onLockChange);
+        return () => { document.removeEventListener('pointerlockchange', onLockChange) };
+    }, [dragging, endDrag, onChange]);
+
+    return { dragging, onPointerDown, onPointerMove, onPointerUp, negate };
+}

--- a/src/react/devtools/index.ts
+++ b/src/react/devtools/index.ts
@@ -6,3 +6,5 @@ export { listEngines, setDevtoolsSink } from '@/react/devtools/beacon';
 export type { DevtoolsPosition, MicuglDevtoolsProps } from '@/react/devtools/MicuglDevtools';
 /** @experimental */
 export { MicuglDevtools } from '@/react/devtools/MicuglDevtools';
+/** @experimental */
+export type { UniformDebugPort, UniformListEntry } from '@/react/lib/liveUniformUpdaters';

--- a/src/react/devtools/lib/colorHex.test.ts
+++ b/src/react/devtools/lib/colorHex.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { componentsToHex, hexToComponents, isOutOfGamut } from '@/react/devtools/lib/colorHex';
+
+describe('componentsToHex', () => {
+    it('converts unit-range components to an rgb hex string', () => {
+        expect(componentsToHex([1, 0, 0])).toBe('#ff0000');
+        expect(componentsToHex([0, 0, 0])).toBe('#000000');
+        expect(componentsToHex([1, 1, 1])).toBe('#ffffff');
+    });
+
+    it('clamps out-of-gamut components', () => {
+        expect(componentsToHex([2, -1, 0.5])).toBe('#ff0080');
+    });
+});
+
+describe('hexToComponents', () => {
+    it('round-trips a hex string back to unit-range components', () => {
+        expect(hexToComponents('#ff0000')).toEqual([1, 0, 0]);
+        expect(hexToComponents('00ff00')).toEqual([0, 1, 0]);
+    });
+
+    it('throws on an invalid hex string', () => {
+        expect(() => hexToComponents('not-a-color')).toThrow(/invalid color hex/);
+    });
+});
+
+describe('isOutOfGamut', () => {
+    it('is false for components within [0,1]', () => {
+        expect(isOutOfGamut([0, 0.5, 1])).toBe(false);
+    });
+
+    it('is true when a component exceeds the unit range', () => {
+        expect(isOutOfGamut([0, 1.5, 0])).toBe(true);
+    });
+
+    it('is true for a negative component', () => {
+        expect(isOutOfGamut([-0.1, 0, 0])).toBe(true);
+    });
+});

--- a/src/react/devtools/lib/colorHex.ts
+++ b/src/react/devtools/lib/colorHex.ts
@@ -1,0 +1,31 @@
+const HEX_PATTERN = /^#?([0-9a-fA-F]{6})$/;
+
+export function clampUnit(value: number): number {
+    if (!Number.isFinite(value)) {
+        return 0;
+    }
+    return Math.min(1, Math.max(0, value));
+}
+
+export function isOutOfGamut(components: readonly number[]): boolean {
+    return components.some(component => !Number.isFinite(component) || component < 0 || component > 1);
+}
+
+export function componentsToHex(components: readonly number[]): string {
+    const toByte = (component: number): string =>
+        Math.round(clampUnit(component) * 255).toString(16).padStart(2, '0');
+    return `#${components.slice(0, 3).map(toByte).join('')}`;
+}
+
+export function hexToComponents(hex: string): [number, number, number] {
+    const match = HEX_PATTERN.exec(hex);
+    if (!match) {
+        throw new Error(`micugl devtools: invalid color hex "${hex}"`);
+    }
+    const value = match[1];
+    return [
+        parseInt(value.slice(0, 2), 16) / 255,
+        parseInt(value.slice(2, 4), 16) / 255,
+        parseInt(value.slice(4, 6), 16) / 255
+    ];
+}

--- a/src/react/devtools/lib/detectColor.test.ts
+++ b/src/react/devtools/lib/detectColor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { isColorUniform } from '@/react/devtools/lib/detectColor';
+
+describe('isColorUniform', () => {
+    it('matches the u_color convention', () => {
+        expect(isColorUniform('u_color')).toBe(true);
+    });
+
+    it('matches names with a color suffix', () => {
+        expect(isColorUniform('u_tintColor')).toBe(true);
+    });
+
+    it('matches names with a color-prefixed suffix', () => {
+        expect(isColorUniform('u_colorA')).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+        expect(isColorUniform('U_COLOR')).toBe(true);
+    });
+
+    it('does not match unrelated names', () => {
+        expect(isColorUniform('u_scale')).toBe(false);
+    });
+
+    it('does not match the empty string', () => {
+        expect(isColorUniform('')).toBe(false);
+    });
+});

--- a/src/react/devtools/lib/detectColor.ts
+++ b/src/react/devtools/lib/detectColor.ts
@@ -1,0 +1,3 @@
+export function isColorUniform(name: string): boolean {
+    return name.toLowerCase().includes('color');
+}

--- a/src/react/devtools/lib/evaluate.test.ts
+++ b/src/react/devtools/lib/evaluate.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluate } from '@/react/devtools/lib/evaluate';
+
+describe('evaluate', () => {
+    it('parses a plain number', () => {
+        expect(evaluate('42')).toBe(42);
+        expect(evaluate('3.14')).toBeCloseTo(3.14);
+    });
+
+    it('handles unary minus', () => {
+        expect(evaluate('-5')).toBe(-5);
+        expect(evaluate('-3.5')).toBeCloseTo(-3.5);
+    });
+
+    it('respects operator precedence (multiplication before addition)', () => {
+        expect(evaluate('2+3*4')).toBe(14);
+        expect(evaluate('3*4+2')).toBe(14);
+    });
+
+    it('respects operator precedence (division before subtraction)', () => {
+        expect(evaluate('10-4/2')).toBe(8);
+    });
+
+    it('supports exponentiation', () => {
+        expect(evaluate('2^3')).toBe(8);
+    });
+
+    it('supports parentheses to override precedence', () => {
+        expect(evaluate('(2+3)*4')).toBe(20);
+        expect(evaluate('2*(3+4)')).toBe(14);
+    });
+
+    it('supports nested parentheses', () => {
+        expect(evaluate('((1+2)*(3+4))')).toBe(21);
+    });
+
+    it('supports a common tuning expression', () => {
+        expect(evaluate('3.14159/2')).toBeCloseTo(1.570795);
+    });
+
+    it('supports subtracting a negative number', () => {
+        expect(evaluate('3--2')).toBe(5);
+    });
+
+    it('ignores surrounding whitespace', () => {
+        expect(evaluate(' 2 + 3 ')).toBe(5);
+    });
+
+    it('throws on garbage input', () => {
+        expect(() => evaluate('abc')).toThrow();
+    });
+
+    it('throws on a dangling operator', () => {
+        expect(() => evaluate('3+')).toThrow();
+    });
+
+    it('throws on an empty expression', () => {
+        expect(() => evaluate('')).toThrow();
+        expect(() => evaluate('   ')).toThrow();
+    });
+
+    it('throws on unbalanced parentheses', () => {
+        expect(() => evaluate('(1+2')).toThrow();
+    });
+});

--- a/src/react/devtools/lib/evaluate.ts
+++ b/src/react/devtools/lib/evaluate.ts
@@ -1,0 +1,36 @@
+const PARENS = /\(([^()]+)\)/;
+const EXPONENT = /(-?\d+(?:\.\d+)?)\s*\^\s*(-?\d+(?:\.\d+)?)/;
+const MULDIV = /(-?\d+(?:\.\d+)?)\s*([*/])\s*(-?\d+(?:\.\d+)?)/;
+const ADDSUB = /(-?\d+(?:\.\d+)?)\s*([+-])\s*(-?\d+(?:\.\d+)?)/;
+
+function reduce(expression: string): string {
+    if (PARENS.test(expression)) {
+        return reduce(expression.replace(PARENS, (_match, inner: string) => String(Number(reduce(inner)))));
+    }
+    if (EXPONENT.test(expression)) {
+        return reduce(expression.replace(EXPONENT, (_match, a: string, b: string) =>
+            String(Math.pow(Number(a), Number(b)))));
+    }
+    if (MULDIV.test(expression)) {
+        return reduce(expression.replace(MULDIV, (_match, a: string, op: string, b: string) =>
+            String(op === '*' ? Number(a) * Number(b) : Number(a) / Number(b))));
+    }
+    if (ADDSUB.test(expression)) {
+        return reduce(expression.replace(ADDSUB, (_match, a: string, op: string, b: string) =>
+            String(op === '+' ? Number(a) + Number(b) : Number(a) - Number(b))));
+    }
+    return expression;
+}
+
+export function evaluate(expression: string): number {
+    const cleaned = expression.replace(/\s+/g, '');
+    if (cleaned.length === 0) {
+        throw new Error('micugl devtools: cannot evaluate an empty expression');
+    }
+    const reduced = reduce(cleaned);
+    const value = Number(reduced);
+    if (!Number.isFinite(value)) {
+        throw new Error(`micugl devtools: cannot evaluate expression "${expression}"`);
+    }
+    return value;
+}

--- a/src/react/devtools/lib/flipRows.test.ts
+++ b/src/react/devtools/lib/flipRows.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { flipImageRows } from '@/react/devtools/lib/flipRows';
+
+describe('flipImageRows', () => {
+    it('reverses row order for a 2x2 image', () => {
+        const pixels = new Uint8ClampedArray([
+            1, 1, 1, 1, 2, 2, 2, 2,
+            3, 3, 3, 3, 4, 4, 4, 4
+        ]);
+
+        const flipped = flipImageRows(pixels, 2, 2);
+
+        expect(Array.from(flipped)).toEqual([
+            3, 3, 3, 3, 4, 4, 4, 4,
+            1, 1, 1, 1, 2, 2, 2, 2
+        ]);
+    });
+
+    it('is a no-op for a single row', () => {
+        const pixels = new Uint8ClampedArray([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        expect(Array.from(flipImageRows(pixels, 2, 1))).toEqual(Array.from(pixels));
+    });
+
+    it('throws when the buffer length does not match the given dimensions', () => {
+        expect(() => flipImageRows(new Uint8ClampedArray(4), 2, 2)).toThrow(/does not match/);
+    });
+});

--- a/src/react/devtools/lib/flipRows.ts
+++ b/src/react/devtools/lib/flipRows.ts
@@ -1,0 +1,15 @@
+export function flipImageRows(pixels: Uint8ClampedArray, width: number, height: number): Uint8ClampedArray {
+    const rowBytes = width * 4;
+    if (pixels.length !== rowBytes * height) {
+        throw new Error(
+            `micugl devtools: pixel buffer length ${String(pixels.length)} does not match ${String(width)}x${String(height)}x4`
+        );
+    }
+    const flipped = new Uint8ClampedArray(pixels.length);
+    for (let row = 0; row < height; row++) {
+        const srcStart = row * rowBytes;
+        const destStart = (height - 1 - row) * rowBytes;
+        flipped.set(pixels.subarray(srcStart, srcStart + rowBytes), destStart);
+    }
+    return flipped;
+}

--- a/src/react/devtools/lib/step.test.ts
+++ b/src/react/devtools/lib/step.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatValue, getStep, padFor, stepForType } from '@/react/devtools/lib/step';
+
+describe('getStep', () => {
+    it('matches the documented worked values', () => {
+        expect(getStep(0)).toBeCloseTo(0.01);
+        expect(getStep(0.5)).toBeCloseTo(0.01);
+        expect(getStep(0.05)).toBeCloseTo(0.001);
+        expect(getStep(1)).toBeCloseTo(0.1);
+        expect(getStep(3)).toBeCloseTo(0.1);
+        expect(getStep(10)).toBeCloseTo(1);
+        expect(getStep(100)).toBeCloseTo(10);
+        expect(getStep(150)).toBeCloseTo(1);
+        expect(getStep(1000)).toBeCloseTo(100);
+        expect(getStep(3.14159)).toBeCloseTo(0.001);
+    });
+
+    it('never returns below the 0.001 floor', () => {
+        expect(getStep(0.0000001)).toBeGreaterThanOrEqual(0.001);
+    });
+
+    it('falls back to the default step for non-finite input', () => {
+        expect(getStep(Number.NaN)).toBe(0.01);
+        expect(getStep(Number.POSITIVE_INFINITY)).toBe(0.01);
+    });
+
+    it('is sign-independent', () => {
+        expect(getStep(-3)).toBeCloseTo(getStep(3));
+    });
+});
+
+describe('stepForType', () => {
+    it('is always 1 for int', () => {
+        expect(stepForType('int', 42)).toBe(1);
+        expect(stepForType('int', 0.4)).toBe(1);
+    });
+
+    it('is always 1 for sampler2D', () => {
+        expect(stepForType('sampler2D', 7)).toBe(1);
+    });
+
+    it('delegates to getStep for float', () => {
+        expect(stepForType('float', 1)).toBeCloseTo(getStep(1));
+    });
+});
+
+describe('padFor', () => {
+    it('clamps between 0 and 2', () => {
+        expect(padFor(100)).toBe(0);
+        expect(padFor(1)).toBe(0);
+        expect(padFor(0.1)).toBe(1);
+        expect(padFor(0.001)).toBe(2);
+        expect(padFor(0.0000001)).toBe(2);
+    });
+});
+
+describe('formatValue', () => {
+    it('formats with the precision implied by step', () => {
+        expect(formatValue(3.14159, 0.001)).toBe('3.14');
+        expect(formatValue(42, 1)).toBe('42');
+        expect(formatValue(1.5, 0.1)).toBe('1.5');
+    });
+});

--- a/src/react/devtools/lib/step.ts
+++ b/src/react/devtools/lib/step.ts
@@ -1,0 +1,44 @@
+import type { UniformType } from '@/types';
+
+const LOG10 = Math.log(10);
+const MIN_STEP = 0.001;
+const DEFAULT_STEP = 0.01;
+const MAX_PAD = 2;
+
+export function getStep(value: number): number {
+    if (!Number.isFinite(value)) {
+        return DEFAULT_STEP;
+    }
+    let magnitude = Math.abs(Number(String(value).replace('.', '')));
+    if (magnitude === 0 || !Number.isFinite(magnitude)) {
+        return DEFAULT_STEP;
+    }
+    while (magnitude !== 0 && magnitude % 10 === 0) {
+        magnitude /= 10;
+    }
+    const significantDigits = Math.floor(Math.log(magnitude) / LOG10) + 1;
+    const numberLog = Math.floor(Math.log10(Math.abs(value)));
+    return Math.max(Math.pow(10, numberLog - significantDigits), MIN_STEP);
+}
+
+export function stepForType(type: UniformType, value: number): number {
+    if (type === 'int' || type === 'sampler2D') {
+        return 1;
+    }
+    return getStep(value);
+}
+
+export function padFor(step: number): number {
+    if (!Number.isFinite(step) || step <= 0) {
+        return 0;
+    }
+    const pad = Math.round(Math.log10(1 / step));
+    return Math.min(Math.max(pad, 0), MAX_PAD);
+}
+
+export function formatValue(value: number, step: number): string {
+    if (!Number.isFinite(value)) {
+        return '0';
+    }
+    return value.toFixed(padFor(step));
+}

--- a/src/react/devtools/panels/FramebuffersPanel.tsx
+++ b/src/react/devtools/panels/FramebuffersPanel.tsx
@@ -1,0 +1,156 @@
+import type { ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import type { WebGLManager } from '@/core';
+import { flipImageRows } from '@/react/devtools/lib/flipRows';
+import { activeButtonStyle, buttonStyle, COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
+
+interface FramebuffersPanelProps {
+    framebufferIds: string[];
+    manager: WebGLManager | null;
+    captureTick: number;
+}
+
+const THUMBNAIL_WIDTH = 96;
+const THUMBNAIL_HEIGHT = 96;
+const CAPTURE_MAX_SIZE = 1024;
+
+const placeholderStyle = {
+    width: `${THUMBNAIL_WIDTH}px`,
+    height: `${THUMBNAIL_HEIGHT}px`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center' as const,
+    fontSize: '9px',
+    color: COLORS.warn,
+    border: `1px dashed ${COLORS.border}`,
+    borderRadius: '4px',
+    padding: '4px',
+    boxSizing: 'border-box' as const
+};
+
+const thumbnailCanvasStyle = {
+    width: `${THUMBNAIL_WIDTH}px`,
+    height: `${THUMBNAIL_HEIGHT}px`,
+    display: 'block',
+    background: 'rgba(0,0,0,0.25)',
+    borderRadius: '4px'
+};
+
+export const FramebuffersPanel = ({ framebufferIds, manager, captureTick }: FramebuffersPanelProps): ReactElement | null => {
+    const [captureOn, setCaptureOn] = useState<Record<string, boolean>>({});
+    const [unreadableById, setUnreadableById] = useState<Record<string, string>>({});
+    const canvasRefs = useRef<Map<string, HTMLCanvasElement>>(new Map());
+    const scratchRef = useRef<HTMLCanvasElement | null>(null);
+    const captureOnRef = useRef(captureOn);
+    const framebufferIdsRef = useRef(framebufferIds);
+    const managerRef = useRef(manager);
+
+    useEffect(() => {
+        captureOnRef.current = captureOn;
+        framebufferIdsRef.current = framebufferIds;
+        managerRef.current = manager;
+    });
+
+    useEffect(() => {
+        const currentManager = managerRef.current;
+        if (!currentManager) {
+            return;
+        }
+        for (const id of framebufferIdsRef.current) {
+            if (!captureOnRef.current[id]) {
+                continue;
+            }
+            const result = currentManager.fbo.debugReadFramebuffer(id, CAPTURE_MAX_SIZE);
+            if ('unreadable' in result) {
+                setUnreadableById(prev => (prev[id] === result.unreadable ? prev : { ...prev, [id]: result.unreadable }));
+                continue;
+            }
+            setUnreadableById(prev => {
+                if (!(id in prev)) {
+                    return prev;
+                }
+                const next = { ...prev };
+                Reflect.deleteProperty(next, id);
+                return next;
+            });
+            const canvas = canvasRefs.current.get(id);
+            if (!canvas) {
+                continue;
+            }
+            const flipped = flipImageRows(result.pixels, result.width, result.height);
+            let scratch = scratchRef.current;
+            if (!scratch) {
+                scratch = document.createElement('canvas');
+                scratchRef.current = scratch;
+            }
+            scratch.width = result.width;
+            scratch.height = result.height;
+            const scratchCtx = scratch.getContext('2d');
+            if (!scratchCtx) {
+                continue;
+            }
+            scratchCtx.putImageData(new ImageData(flipped, result.width, result.height), 0, 0);
+            const ctx = canvas.getContext('2d');
+            if (!ctx) {
+                continue;
+            }
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(scratch, 0, 0, result.width, result.height, 0, 0, canvas.width, canvas.height);
+        }
+    }, [captureTick]);
+
+    if (framebufferIds.length === 0) {
+        return null;
+    }
+
+    const toggle = (id: string): void => {
+        setCaptureOn(prev => ({ ...prev, [id]: !prev[id] }));
+    };
+
+    return (
+        <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>framebuffers</div>
+            <div style={{ fontSize: '10px', color: COLORS.warn }}>
+                capture stalls the GPU pipeline — perturbs timing
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                {framebufferIds.map(id => (
+                    <div key={id} style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                        <div style={rowStyle}>
+                            <span style={{ fontSize: '11px', color: COLORS.dim }}>{id}</span>
+                            <button
+                                type='button'
+                                onClick={() => { toggle(id) }}
+                                style={captureOn[id] ? activeButtonStyle : buttonStyle}
+                            >
+                                {captureOn[id] ? 'capturing' : 'capture'}
+                            </button>
+                        </div>
+                        {captureOn[id]
+                            ? (
+                                unreadableById[id]
+                                    ? <div style={placeholderStyle}>{unreadableById[id]}</div>
+                                    : (
+                                        <canvas
+                                            ref={el => {
+                                                if (el) {
+                                                    canvasRefs.current.set(id, el);
+                                                } else {
+                                                    canvasRefs.current.delete(id);
+                                                }
+                                            }}
+                                            width={THUMBNAIL_WIDTH}
+                                            height={THUMBNAIL_HEIGHT}
+                                            style={thumbnailCanvasStyle}
+                                        />
+                                    )
+                            )
+                            : null}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/src/react/devtools/panels/FrameloopPanel.tsx
+++ b/src/react/devtools/panels/FrameloopPanel.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
-import { useState } from 'react';
 
+import { NumberField } from '@/react/devtools/controls/NumberField';
+import { stepForType } from '@/react/devtools/lib/step';
 import { activeButtonStyle, buttonStyle, COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
 import type { Frameloop } from '@/types';
 
@@ -28,16 +29,6 @@ export const FrameloopPanel = ({
     onStep,
     onSetFrame
 }: FrameloopPanelProps): ReactElement => {
-    const [draft, setDraft] = useState('');
-
-    const applyDraft = (): void => {
-        const parsed = Number.parseInt(draft, 10);
-        if (!Number.isNaN(parsed)) {
-            onSetFrame(parsed);
-        }
-        setDraft('');
-    };
-
     return (
         <div style={sectionStyle}>
             <div style={sectionTitleStyle}>frameloop</div>
@@ -64,7 +55,14 @@ export const FrameloopPanel = ({
             </div>
             <div style={rowStyle}>
                 <span style={{ color: COLORS.dim }}>frame</span>
-                <span>{frame}</span>
+                <div style={{ width: '96px' }}>
+                    <NumberField
+                        value={frame}
+                        step={stepForType('int', frame)}
+                        ariaLabel='frame'
+                        onChange={onSetFrame}
+                    />
+                </div>
             </div>
             <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
                 <button type='button' onClick={onInvalidate} style={buttonStyle}>invalidate</button>
@@ -78,27 +76,6 @@ export const FrameloopPanel = ({
                         {step > 0 ? `+${String(step)}` : String(step)}
                     </button>
                 ))}
-            </div>
-            <div style={{ display: 'flex', gap: '4px' }}>
-                <input
-                    type='number'
-                    value={draft}
-                    placeholder='jump to frame'
-                    onChange={e => { setDraft(e.target.value) }}
-                    onKeyDown={e => { if (e.key === 'Enter') { applyDraft() } }}
-                    style={{
-                        flex: 1,
-                        minWidth: 0,
-                        fontFamily: 'inherit',
-                        fontSize: '11px',
-                        padding: '3px 6px',
-                        background: 'rgba(0,0,0,0.3)',
-                        border: `1px solid ${COLORS.border}`,
-                        borderRadius: '4px',
-                        color: COLORS.text
-                    }}
-                />
-                <button type='button' onClick={applyDraft} style={buttonStyle}>set</button>
             </div>
         </div>
     );

--- a/src/react/devtools/panels/UniformsPanel.tsx
+++ b/src/react/devtools/panels/UniformsPanel.tsx
@@ -1,0 +1,265 @@
+import type { ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import type { EngineHandle } from '@/react/devtools/beacon';
+import { listEngines } from '@/react/devtools/beacon';
+import { ColorField } from '@/react/devtools/controls/ColorField';
+import { NumberField } from '@/react/devtools/controls/NumberField';
+import { DEFAULT_VECTOR_LABELS, VectorField } from '@/react/devtools/controls/VectorField';
+import { isColorUniform } from '@/react/devtools/lib/detectColor';
+import { stepForType } from '@/react/devtools/lib/step';
+import { activeButtonStyle, buttonStyle, COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
+import type { UniformDebugPort, UniformListEntry } from '@/react/lib/liveUniformUpdaters';
+
+interface UniformsPanelProps {
+    engine: EngineHandle | null;
+}
+
+type ColorMode = 'auto' | 'color' | 'number';
+
+const formatReadonlyValue = (value: unknown): string => {
+    if (typeof value === 'function') {
+        return 'ƒ()';
+    }
+    if (typeof value === 'number') {
+        return value.toFixed(3);
+    }
+    if (ArrayBuffer.isView(value)) {
+        return Array.from(value as unknown as ArrayLike<number>)
+            .map(component => component.toFixed(2))
+            .join(', ');
+    }
+    return String(value);
+};
+
+const toComponentArray = (value: unknown, length: number): Float32Array => {
+    const out = new Float32Array(length);
+    if (ArrayBuffer.isView(value)) {
+        const view = value as unknown as ArrayLike<number>;
+        for (let i = 0; i < length; i++) {
+            out[i] = view[i] ?? 0;
+        }
+    } else if (Array.isArray(value)) {
+        for (let i = 0; i < length; i++) {
+            out[i] = typeof value[i] === 'number' ? value[i] as number : 0;
+        }
+    }
+    return out;
+};
+
+interface UniformRowProps {
+    entry: UniformListEntry;
+    mode: ColorMode;
+    error?: string;
+    onToggleMode: (name: string) => void;
+    onSetOverride: (name: string, value: number | ArrayLike<number>) => void;
+    onClearOverride: (name: string) => void;
+}
+
+const UniformRow = ({ entry, mode, error, onToggleMode, onSetOverride, onClearOverride }: UniformRowProps): ReactElement => {
+    const resetButton = entry.overridden
+        ? (
+            <button type='button' onClick={() => { onClearOverride(entry.name) }} style={buttonStyle}>
+                reset
+            </button>
+        )
+        : null;
+
+    let control: ReactElement;
+    let modeToggle: ReactElement | null = null;
+
+    if (entry.type === 'float' || entry.type === 'int') {
+        control = (
+            <div style={{ width: '96px' }}>
+                <NumberField
+                    value={typeof entry.value === 'number' ? entry.value : 0}
+                    step={stepForType(entry.type, typeof entry.value === 'number' ? entry.value : 0)}
+                    ariaLabel={entry.name}
+                    onChange={value => { onSetOverride(entry.name, value) }}
+                />
+            </div>
+        );
+    } else if (entry.type === 'vec2') {
+        control = (
+            <VectorField
+                value={toComponentArray(entry.value, 2)}
+                length={2}
+                type={entry.type}
+                labels={DEFAULT_VECTOR_LABELS}
+                ariaLabelPrefix={entry.name}
+                onChange={next => { onSetOverride(entry.name, next) }}
+            />
+        );
+    } else if (entry.type === 'vec3' || entry.type === 'vec4') {
+        const length = entry.type === 'vec4' ? 4 : 3;
+        const colorEligible = mode === 'color' || (mode === 'auto' && isColorUniform(entry.name));
+        control = colorEligible
+            ? (
+                <ColorField
+                    value={toComponentArray(entry.value, length)}
+                    type={entry.type}
+                    ariaLabelPrefix={entry.name}
+                    onChange={next => { onSetOverride(entry.name, next) }}
+                />
+            )
+            : (
+                <VectorField
+                    value={toComponentArray(entry.value, length)}
+                    length={length}
+                    type={entry.type}
+                    labels={DEFAULT_VECTOR_LABELS}
+                    ariaLabelPrefix={entry.name}
+                    onChange={next => { onSetOverride(entry.name, next) }}
+                />
+            );
+        modeToggle = (
+            <button type='button' onClick={() => { onToggleMode(entry.name) }} style={buttonStyle}>
+                {colorEligible ? 'as vector' : 'as color'}
+            </button>
+        );
+    } else {
+        control = (
+            <span style={{ fontSize: '11px', color: COLORS.dim }}>
+                {entry.type} · {formatReadonlyValue(entry.value)}
+            </span>
+        );
+    }
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            <div style={rowStyle}>
+                <span style={{ color: entry.overridden ? COLORS.accent : COLORS.dim, fontSize: '11px' }}>
+                    {entry.overridden ? '● ' : ''}{entry.name}
+                </span>
+                {modeToggle}
+            </div>
+            <div style={{ display: 'flex', gap: '4px', alignItems: 'flex-start' }}>
+                {control}
+                {resetButton}
+            </div>
+            {error ? <div style={{ fontSize: '10px', color: COLORS.danger }}>{error}</div> : null}
+        </div>
+    );
+};
+
+export const UniformsPanel = ({ engine }: UniformsPanelProps): ReactElement | null => {
+    const [errorsByName, setErrorsByName] = useState<Record<string, string>>({});
+    const [colorModeByName, setColorModeByName] = useState<Record<string, ColorMode>>({});
+    const trackedRef = useRef<Map<string, Set<string>>>(new Map());
+
+    useEffect(() => () => {
+        for (const [engineId, names] of trackedRef.current) {
+            const handle = listEngines().find(candidate => candidate.id === engineId);
+            if (!handle?.uniforms) {
+                continue;
+            }
+            for (const name of names) {
+                if (handle.uniforms.list().some(entry => entry.name === name && entry.overridden)) {
+                    handle.uniforms.clearOverride(name);
+                }
+            }
+        }
+        trackedRef.current = new Map();
+    }, []);
+
+    if (!engine?.uniforms) {
+        return null;
+    }
+
+    const port: UniformDebugPort = engine.uniforms;
+    const engineId = engine.id;
+    const entries = port.list();
+
+    const track = (name: string): void => {
+        const names = trackedRef.current.get(engineId) ?? new Set<string>();
+        names.add(name);
+        trackedRef.current.set(engineId, names);
+    };
+
+    const clearError = (name: string): void => {
+        setErrorsByName(prev => {
+            if (!(name in prev)) {
+                return prev;
+            }
+            const next = { ...prev };
+            Reflect.deleteProperty(next, name);
+            return next;
+        });
+    };
+
+    const setError = (name: string, message: string): void => {
+        setErrorsByName(prev => ({ ...prev, [name]: message }));
+    };
+
+    const handleSetOverride = (name: string, value: number | ArrayLike<number>): void => {
+        try {
+            port.setOverride(name, value);
+            track(name);
+            clearError(name);
+        } catch (error) {
+            setError(name, error instanceof Error ? error.message : String(error));
+        }
+    };
+
+    const handleClearOverride = (name: string): void => {
+        try {
+            port.clearOverride(name);
+            clearError(name);
+        } catch (error) {
+            setError(name, error instanceof Error ? error.message : String(error));
+        }
+    };
+
+    const handleResetAll = (): void => {
+        for (const entry of entries) {
+            if (entry.overridden) {
+                handleClearOverride(entry.name);
+            }
+        }
+    };
+
+    const handleToggleMode = (name: string): void => {
+        setColorModeByName(prev => {
+            const entry = entries.find(candidate => candidate.name === name);
+            const current = prev[name] ?? 'auto';
+            const currentlyColor = current === 'color' || (current === 'auto' && isColorUniform(name));
+            const next: ColorMode = currentlyColor ? 'number' : 'color';
+            return entry ? { ...prev, [name]: next } : prev;
+        });
+    };
+
+    const anyOverridden = entries.some(entry => entry.overridden);
+
+    return (
+        <div style={sectionStyle}>
+            <div style={rowStyle}>
+                <span style={sectionTitleStyle}>uniforms</span>
+                <button
+                    type='button'
+                    onClick={handleResetAll}
+                    disabled={!anyOverridden}
+                    style={anyOverridden ? activeButtonStyle : buttonStyle}
+                >
+                    reset all
+                </button>
+            </div>
+            {entries.length === 0
+                ? <div style={{ fontSize: '11px', color: COLORS.dim }}>no uniforms</div>
+                : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                        {entries.map(entry => (
+                            <UniformRow
+                                key={entry.name}
+                                entry={entry}
+                                mode={colorModeByName[entry.name] ?? 'auto'}
+                                error={errorsByName[entry.name]}
+                                onToggleMode={handleToggleMode}
+                                onSetOverride={handleSetOverride}
+                                onClearOverride={handleClearOverride}
+                            />
+                        ))}
+                    </div>
+                )}
+        </div>
+    );
+};

--- a/src/react/hooks/usePingPongPasses.ts
+++ b/src/react/hooks/usePingPongPasses.ts
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 
 import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
+import { combineUniformDebugPorts, type UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import {
     buildPasses,
     DEFAULT_FRAMEBUFFER_OPTIONS,
     DEFAULT_RENDER_OPTIONS,
+    type PingPongPassesResult,
     type PingPongRenderOptions,
     serializeFramebufferOptions,
     serializeRenderOptions
@@ -25,6 +27,10 @@ interface PingPongPassesOptions {
 
 const EMPTY_UNIFORMS: Record<string, UniformParam> = {};
 
+export interface PingPongPassesWithPort extends PingPongPassesResult {
+    port: UniformDebugPort;
+}
+
 export const usePingPongPasses = ({
     programId,
     secondaryProgramId,
@@ -35,9 +41,9 @@ export const usePingPongPasses = ({
     renderOptions = DEFAULT_RENDER_OPTIONS,
     customPasses,
     framebuffers
-}: PingPongPassesOptions) => {
-    const primaryUniforms = useUniformUpdaters(programId, uniforms);
-    const secondaryUniformsConverted = useUniformUpdaters(
+}: PingPongPassesOptions): PingPongPassesWithPort => {
+    const primary = useUniformUpdaters(programId, uniforms);
+    const secondary = useUniformUpdaters(
         secondaryProgramId ?? `${programId}-secondary`,
         secondaryUniforms
     );
@@ -46,7 +52,7 @@ export const usePingPongPasses = ({
     const renderKey = serializeRenderOptions(renderOptions);
     const overrideKey = framebuffers ? JSON.stringify(framebuffers) : '';
 
-    return useMemo(() => {
+    const passesResult = useMemo(() => {
         const framebufferOpts = JSON.parse(framebufferKey) as FramebufferOptions;
         const renderOpts = JSON.parse(renderKey) as PingPongRenderOptions;
         const override = overrideKey
@@ -56,8 +62,8 @@ export const usePingPongPasses = ({
             programId,
             secondaryProgramId,
             iterations,
-            primaryUniforms,
-            secondaryUniformsConverted,
+            primary.updaters,
+            secondary.updaters,
             framebufferOpts,
             renderOpts,
             customPasses,
@@ -67,11 +73,18 @@ export const usePingPongPasses = ({
         programId,
         secondaryProgramId,
         iterations,
-        primaryUniforms,
-        secondaryUniformsConverted,
+        primary.updaters,
+        secondary.updaters,
         framebufferKey,
         renderKey,
         customPasses,
         overrideKey
     ]);
+
+    const port = useMemo(
+        () => combineUniformDebugPorts([primary.port, secondary.port]),
+        [primary.port, secondary.port]
+    );
+
+    return { ...passesResult, port };
 };

--- a/src/react/hooks/useUniformUpdaters.ts
+++ b/src/react/hooks/useUniformUpdaters.ts
@@ -3,28 +3,52 @@ import { useEffect, useMemo, useRef } from 'react';
 import {
     buildLiveUpdaters,
     collectLiveValues,
+    createUniformDebugPort,
     type LiveValues,
+    mergeOverrides,
     parseUniformStructureKey,
+    type UniformDebugPort,
+    type UniformDescriptor,
     uniformDescriptors,
     uniformStructureKey
 } from '@/react/lib/liveUniformUpdaters';
 import type { UniformParam, UniformUpdaterDef } from '@/types';
 
+export interface UniformUpdatersResult {
+    updaters: Record<string, UniformUpdaterDef[]>;
+    port: UniformDebugPort;
+}
+
 export const useUniformUpdaters = (
     programId: string,
     uniforms: Record<string, UniformParam>,
     options?: { skipDefaultUniforms?: boolean }
-): Record<string, UniformUpdaterDef[]> => {
+): UniformUpdatersResult => {
     const skipDefaults = options?.skipDefaultUniforms ?? false;
-    const structureKey = uniformStructureKey(uniformDescriptors(uniforms), skipDefaults);
+    const descriptors = uniformDescriptors(uniforms);
+    const structureKey = uniformStructureKey(descriptors, skipDefaults);
 
+    const baseValuesRef = useRef<LiveValues>({});
+    const overridesRef = useRef<LiveValues>({});
     const valuesRef = useRef<LiveValues>({});
+    const descriptorsRef = useRef<UniformDescriptor[]>(descriptors);
+    descriptorsRef.current = descriptors;
+
     useEffect(() => {
-        valuesRef.current = collectLiveValues(uniforms);
+        const base = collectLiveValues(uniforms);
+        baseValuesRef.current = base;
+        valuesRef.current = mergeOverrides(base, overridesRef.current);
     });
 
-    return useMemo(() => {
+    const port = useMemo(
+        () => createUniformDebugPort({ descriptorsRef, baseValuesRef, overridesRef, valuesRef }),
+        []
+    );
+
+    const updaters = useMemo(() => {
         const parsed = parseUniformStructureKey(structureKey);
         return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef) };
     }, [programId, structureKey]);
+
+    return { updaters, port };
 };

--- a/src/react/lib/liveUniformUpdaters.test.ts
+++ b/src/react/lib/liveUniformUpdaters.test.ts
@@ -4,12 +4,17 @@ import { vec2, vec3 } from '@/core/lib/vectorUtils';
 import {
     buildLiveUpdaters,
     collectLiveValues,
+    combineUniformDebugPorts,
+    createUniformDebugPort,
     type LiveValues,
+    mergeOverrides,
     normalizeUniformName,
     parseUniformStructureKey,
+    type UniformDebugPortRefs,
     type UniformDescriptor,
     uniformDescriptors,
-    uniformStructureKey
+    uniformStructureKey,
+    validateOverrideValue
 } from '@/react/lib/liveUniformUpdaters';
 import type { UniformParam } from '@/types';
 
@@ -148,5 +153,202 @@ describe('collectLiveValues', () => {
             u_color: vec3([1, 2, 3]),
             u_strength: 0.5
         });
+    });
+});
+
+describe('mergeOverrides', () => {
+    it('returns the base object by identity when overrides is empty', () => {
+        const base: LiveValues = { u_a: 1 };
+        expect(mergeOverrides(base, {})).toBe(base);
+    });
+
+    it('override wins over base for a shared key', () => {
+        const merged = mergeOverrides({ u_a: 1, u_b: 2 }, { u_a: 99 });
+        expect(merged).toEqual({ u_a: 99, u_b: 2 });
+    });
+
+    it('clearing overrides (empty object) restores base identity again', () => {
+        const base: LiveValues = { u_a: 1 };
+        const withOverride = mergeOverrides(base, { u_a: 2 });
+        expect(withOverride).not.toBe(base);
+
+        const restored = mergeOverrides(base, {});
+        expect(restored).toBe(base);
+    });
+});
+
+describe('validateOverrideValue', () => {
+    it('coerces a valid float value', () => {
+        expect(validateOverrideValue('float', '1.5')).toBe(1.5);
+    });
+
+    it('rejects NaN for float', () => {
+        expect(() => validateOverrideValue('float', 'not-a-number')).toThrow(/finite number/);
+    });
+
+    it('rejects Infinity for float', () => {
+        expect(() => validateOverrideValue('float', Infinity)).toThrow(/finite number/);
+    });
+
+    it('truncates int values', () => {
+        expect(validateOverrideValue('int', 3.9)).toBe(3);
+    });
+
+    it('truncates sampler2D values', () => {
+        expect(validateOverrideValue('sampler2D', 2.7)).toBe(2);
+    });
+
+    it('accepts a vec3 of the right length', () => {
+        const result = validateOverrideValue('vec3', [1, 2, 3]) as Float32Array;
+        expect(Array.from(result)).toEqual([1, 2, 3]);
+    });
+
+    it('rejects a vec3 of the wrong length', () => {
+        expect(() => validateOverrideValue('vec3', [1, 2])).toThrow(/expects 3 components/);
+    });
+
+    it('rejects a non-array-like value for a vector type', () => {
+        expect(() => validateOverrideValue('vec2', 5)).toThrow(/expects 2 components/);
+    });
+
+    it('rejects a vector containing a non-finite component', () => {
+        expect(() => validateOverrideValue('vec2', [1, NaN])).toThrow(/finite number/);
+    });
+
+    it('accepts a mat4 of the right length', () => {
+        const result = validateOverrideValue('mat4', new Array(16).fill(0)) as Float32Array;
+        expect(result.length).toBe(16);
+    });
+});
+
+function createPortRefs(descriptors: UniformDescriptor[], base: LiveValues): UniformDebugPortRefs {
+    const baseValuesRef = { current: base };
+    const overridesRef: { current: LiveValues } = { current: {} };
+    const valuesRef: { current: LiveValues } = { current: { ...base } };
+    const descriptorsRef = { current: descriptors };
+    return { descriptorsRef, baseValuesRef, overridesRef, valuesRef };
+}
+
+describe('createUniformDebugPort', () => {
+    it('lists uniforms with current value and overridden flag', () => {
+        const refs = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const port = createUniformDebugPort(refs);
+
+        expect(port.list()).toEqual([{ name: 'u_a', type: 'float', value: 1, overridden: false }]);
+    });
+
+    it('setOverride writes both overridesRef and valuesRef immediately', () => {
+        const refs = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const port = createUniformDebugPort(refs);
+
+        port.setOverride('u_a', 5);
+
+        expect(refs.overridesRef.current.u_a).toBe(5);
+        expect(refs.valuesRef.current.u_a).toBe(5);
+        expect(port.list()[0]).toEqual({ name: 'u_a', type: 'float', value: 5, overridden: true });
+    });
+
+    it('clearOverride restores the base value and removes the override', () => {
+        const refs = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const port = createUniformDebugPort(refs);
+
+        port.setOverride('u_a', 5);
+        port.clearOverride('u_a');
+
+        expect(refs.overridesRef.current.u_a).toBeUndefined();
+        expect(refs.valuesRef.current.u_a).toBe(1);
+        expect(port.list()[0].overridden).toBe(false);
+    });
+
+    it('clearOverride restores the base value when valuesRef aliases baseValuesRef (fast path)', () => {
+        const base: LiveValues = { u_a: 1 };
+        const baseValuesRef = { current: base };
+        const overridesRef: { current: LiveValues } = { current: {} };
+        const valuesRef = { current: mergeOverrides(base, {}) };
+        const descriptorsRef = { current: [{ name: 'u_a', type: 'float' } as UniformDescriptor] };
+        const port = createUniformDebugPort({ descriptorsRef, baseValuesRef, overridesRef, valuesRef });
+
+        expect(valuesRef.current).toBe(baseValuesRef.current);
+
+        port.setOverride('u_a', 5);
+        expect(baseValuesRef.current.u_a).toBe(1);
+
+        port.clearOverride('u_a');
+        expect(valuesRef.current.u_a).toBe(1);
+        expect(port.list()[0].overridden).toBe(false);
+    });
+
+    it('setOverride throws a descriptive error for an unknown uniform', () => {
+        const refs = createPortRefs([], {});
+        const port = createUniformDebugPort(refs);
+
+        expect(() => { port.setOverride('u_missing', 1) }).toThrow(/unknown uniform/);
+    });
+
+    it('setOverride throws and leaves state untouched when validation fails', () => {
+        const refs = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const port = createUniformDebugPort(refs);
+
+        expect(() => { port.setOverride('u_a', NaN) }).toThrow(/finite number/);
+        expect(refs.overridesRef.current.u_a).toBeUndefined();
+        expect(refs.valuesRef.current.u_a).toBe(1);
+    });
+
+    it('int type override is truncated through the port', () => {
+        const refs = createPortRefs([{ name: 'u_i', type: 'int' }], { u_i: 0 });
+        const port = createUniformDebugPort(refs);
+
+        port.setOverride('u_i', 4.8);
+
+        expect(refs.valuesRef.current.u_i).toBe(4);
+    });
+});
+
+describe('combineUniformDebugPorts', () => {
+    it('list concatenates entries from every port', () => {
+        const refsA = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const refsB = createPortRefs([{ name: 'u_b', type: 'float' }], { u_b: 2 });
+        const combined = combineUniformDebugPorts([
+            createUniformDebugPort(refsA),
+            createUniformDebugPort(refsB)
+        ]);
+
+        expect(combined.list().map(entry => entry.name)).toEqual(['u_a', 'u_b']);
+    });
+
+    it('setOverride routes to the port that owns the uniform', () => {
+        const refsA = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const refsB = createPortRefs([{ name: 'u_b', type: 'float' }], { u_b: 2 });
+        const combined = combineUniformDebugPorts([
+            createUniformDebugPort(refsA),
+            createUniformDebugPort(refsB)
+        ]);
+
+        combined.setOverride('u_b', 9);
+
+        expect(refsB.valuesRef.current.u_b).toBe(9);
+        expect(refsA.valuesRef.current.u_a).toBe(1);
+    });
+
+    it('setOverride applies to every port sharing a uniform name', () => {
+        const refsA = createPortRefs([{ name: 'u_time', type: 'float' }], { u_time: 1 });
+        const refsB = createPortRefs([{ name: 'u_time', type: 'float' }], { u_time: 1 });
+        const combined = combineUniformDebugPorts([
+            createUniformDebugPort(refsA),
+            createUniformDebugPort(refsB)
+        ]);
+
+        combined.setOverride('u_time', 7);
+
+        expect(refsA.valuesRef.current.u_time).toBe(7);
+        expect(refsB.valuesRef.current.u_time).toBe(7);
+    });
+
+    it('throws for a uniform unknown to every port', () => {
+        const refsA = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const combined = combineUniformDebugPorts([createUniformDebugPort(refsA)]);
+
+        expect(() => { combined.setOverride('u_missing', 1) }).toThrow(/unknown uniform/);
+        expect(() => { combined.clearOverride('u_missing') }).toThrow(/unknown uniform/);
     });
 });

--- a/src/react/lib/liveUniformUpdaters.ts
+++ b/src/react/lib/liveUniformUpdaters.ts
@@ -2,6 +2,7 @@ import { createCommonUpdaters } from '@/react/lib/createUniformUpdater';
 import type {
     UniformParam,
     UniformType,
+    UniformTypeMap,
     UniformUpdaterDef,
     UniformValue
 } from '@/types';
@@ -16,6 +17,130 @@ export interface UniformDescriptor {
 }
 
 export type LiveValues = Record<string, UniformValue<UniformType>>;
+
+export interface UniformListEntry {
+    name: string;
+    type: UniformType;
+    value: unknown;
+    overridden: boolean;
+}
+
+export interface UniformDebugPort {
+    list: () => UniformListEntry[];
+    setOverride: (name: string, value: unknown) => void;
+    clearOverride: (name: string) => void;
+}
+
+export interface UniformDebugPortRefs {
+    descriptorsRef: { current: UniformDescriptor[] };
+    baseValuesRef: { current: LiveValues };
+    overridesRef: { current: LiveValues };
+    valuesRef: { current: LiveValues };
+}
+
+const VEC_LENGTHS: Partial<Record<UniformType, number>> = {
+    vec2: 2,
+    vec3: 3,
+    vec4: 4,
+    mat2: 4,
+    mat3: 9,
+    mat4: 16
+};
+
+function coerceFiniteNumber(type: UniformType, value: unknown): number {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+        throw new Error(
+            `micugl devtools: override for "${type}" uniform must be a finite number, received ${JSON.stringify(value)}`
+        );
+    }
+    return parsed;
+}
+
+function isArrayLikeValue(value: unknown): value is ArrayLike<unknown> {
+    return typeof value === 'object' && value !== null && 'length' in value;
+}
+
+export function validateOverrideValue(type: UniformType, value: unknown): UniformTypeMap[UniformType] {
+    if (type === 'float') {
+        return coerceFiniteNumber(type, value);
+    }
+    if (type === 'int' || type === 'sampler2D') {
+        return Math.trunc(coerceFiniteNumber(type, value));
+    }
+    const length = VEC_LENGTHS[type];
+    if (length === undefined) {
+        throw new Error(`micugl devtools: unsupported uniform type "${type}" for override`);
+    }
+    if (!isArrayLikeValue(value) || value.length !== length) {
+        const gotLength = isArrayLikeValue(value) ? value.length : typeof value;
+        throw new Error(
+            `micugl devtools: override for "${type}" uniform expects ${length} components, received ${String(gotLength)}`
+        );
+    }
+    const buffer = new Float32Array(length);
+    for (let i = 0; i < length; i++) {
+        buffer[i] = coerceFiniteNumber(type, value[i]);
+    }
+    return buffer as UniformTypeMap[UniformType];
+}
+
+export function mergeOverrides(base: LiveValues, overrides: LiveValues): LiveValues {
+    return Object.keys(overrides).length === 0 ? base : { ...base, ...overrides };
+}
+
+export function createUniformDebugPort(refs: UniformDebugPortRefs): UniformDebugPort {
+    const findDescriptor = (name: string): UniformDescriptor => {
+        const found = refs.descriptorsRef.current.find(descriptor => descriptor.name === name);
+        if (!found) {
+            throw new Error(`micugl devtools: unknown uniform "${name}"`);
+        }
+        return found;
+    };
+
+    return {
+        list: () => refs.descriptorsRef.current.map(descriptor => ({
+            name: descriptor.name,
+            type: descriptor.type,
+            value: refs.valuesRef.current[descriptor.name],
+            overridden: Object.prototype.hasOwnProperty.call(refs.overridesRef.current, descriptor.name)
+        })),
+        setOverride: (name, value) => {
+            const descriptor = findDescriptor(name);
+            const validated = validateOverrideValue(descriptor.type, value);
+            refs.overridesRef.current[name] = validated;
+            refs.valuesRef.current = mergeOverrides(refs.baseValuesRef.current, refs.overridesRef.current);
+        },
+        clearOverride: name => {
+            findDescriptor(name);
+            Reflect.deleteProperty(refs.overridesRef.current, name);
+            refs.valuesRef.current[name] = refs.baseValuesRef.current[name];
+        }
+    };
+}
+
+export function combineUniformDebugPorts(ports: UniformDebugPort[]): UniformDebugPort {
+    const portsWithName = (name: string): UniformDebugPort[] =>
+        ports.filter(port => port.list().some(entry => entry.name === name));
+
+    return {
+        list: () => ports.flatMap(port => port.list()),
+        setOverride: (name, value) => {
+            const targets = portsWithName(name);
+            if (targets.length === 0) {
+                throw new Error(`micugl devtools: unknown uniform "${name}"`);
+            }
+            targets.forEach(port => { port.setOverride(name, value) });
+        },
+        clearOverride: name => {
+            const targets = portsWithName(name);
+            if (targets.length === 0) {
+                throw new Error(`micugl devtools: unknown uniform "${name}"`);
+            }
+            targets.forEach(port => { port.clearOverride(name) });
+        }
+    };
+}
 
 export function normalizeUniformName(name: string): string {
     return name.startsWith('u_') ? name : `u_${name}`;

--- a/src/testing/glStub.test.ts
+++ b/src/testing/glStub.test.ts
@@ -167,6 +167,53 @@ describe('createGLStub call log ordering and typed views', () => {
     });
 });
 
+describe('createGLStub readPixels', () => {
+    it('zeroes the provided buffer and records the call', () => {
+        const { gl, calls, readPixelsCalls } = createGLStub();
+        const buffer = new Uint8ClampedArray(16).fill(255);
+
+        gl.readPixels(0, 0, 2, 2, gl.RGBA, gl.UNSIGNED_BYTE, buffer);
+
+        expect(buffer.every(value => value === 0)).toBe(true);
+        expect(readPixelsCalls).toEqual([
+            { x: 0, y: 0, width: 2, height: 2, format: gl.RGBA, type: gl.UNSIGNED_BYTE }
+        ]);
+        expect(calls.some(call => call.name === 'readPixels')).toBe(true);
+    });
+});
+
+describe('createGLStub getParameter', () => {
+    it('defaults IMPLEMENTATION_COLOR_READ_TYPE/FORMAT to UNSIGNED_BYTE/RGBA', () => {
+        const { gl } = createGLStub();
+
+        expect(gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE)).toBe(gl.UNSIGNED_BYTE);
+        expect(gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT)).toBe(gl.RGBA);
+    });
+
+    it('reflects configured colorReadType/colorReadFormat', () => {
+        const { gl } = createGLStub({ colorReadType: GL_FLOAT });
+
+        expect(gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE)).toBe(GL_FLOAT);
+    });
+
+    it('exposes the currently bound framebuffer and viewport', () => {
+        const { gl } = createGLStub();
+        const framebuffer = gl.createFramebuffer();
+
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.viewport(1, 2, 3, 4);
+
+        expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBe(framebuffer);
+        expect(gl.getParameter(gl.VIEWPORT)).toEqual([1, 2, 3, 4]);
+    });
+
+    it('throws for an unmodeled pname', () => {
+        const { gl } = createGLStub();
+
+        expect(() => { gl.getParameter(0x9999) }).toThrow(/unstubbed getParameter/);
+    });
+});
+
 describe('createGLStub uniform-location identity', () => {
     it('returns the same location object for repeated lookups of the same name', () => {
         const { gl } = createGLStub();
@@ -191,7 +238,7 @@ describe('createGLStub uniform-location identity', () => {
 
 describe('createGLStub reset', () => {
     it('clears all recorded call logs but preserves gl identity', () => {
-        const { gl, calls, texImage2DCalls, viewportCalls, useProgramCalls, uniformCalls, reset } = createGLStub();
+        const { gl, calls, texImage2DCalls, viewportCalls, useProgramCalls, uniformCalls, readPixelsCalls, reset } = createGLStub();
         const program = gl.createProgram();
         const texture = gl.createTexture();
 
@@ -200,6 +247,7 @@ describe('createGLStub reset', () => {
         gl.viewport(0, 0, 4, 4);
         gl.useProgram(program);
         gl.uniform1f(gl.getUniformLocation(program, 'u_x'), 1);
+        gl.readPixels(0, 0, 4, 4, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8ClampedArray(64));
 
         const glBefore = gl;
         reset();
@@ -209,6 +257,7 @@ describe('createGLStub reset', () => {
         expect(viewportCalls).toHaveLength(0);
         expect(useProgramCalls).toHaveLength(0);
         expect(uniformCalls).toHaveLength(0);
+        expect(readPixelsCalls).toHaveLength(0);
         expect(gl).toBe(glBefore);
     });
 });

--- a/src/testing/glStub.ts
+++ b/src/testing/glStub.ts
@@ -16,8 +16,11 @@ const GL_COLOR_BUFFER_BIT = 0x4000;
 const GL_COMPILE_STATUS = 0x8b81;
 const GL_FRAGMENT_SHADER = 0x8b30;
 const GL_FRAMEBUFFER = 0x8d40;
+const GL_FRAMEBUFFER_BINDING = 0x8ca6;
 const GL_FRAMEBUFFER_COMPLETE = 0x8cd5;
 const GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT = 0x8cd6;
+const GL_IMPLEMENTATION_COLOR_READ_FORMAT = 0x8b9b;
+const GL_IMPLEMENTATION_COLOR_READ_TYPE = 0x8b9a;
 const GL_LINK_STATUS = 0x8b82;
 const GL_SHORT = 0x1402;
 const GL_STATIC_DRAW = 0x88e4;
@@ -30,6 +33,7 @@ const GL_TEXTURE0 = 0x84c0;
 const GL_TRIANGLE_STRIP = 0x0005;
 const GL_UNSIGNED_SHORT = 0x1403;
 const GL_VERTEX_SHADER = 0x8b31;
+const GL_VIEWPORT = 0x0ba2;
 
 const ENUM_CONSTANTS = {
     ARRAY_BUFFER: GL_ARRAY_BUFFER,
@@ -41,8 +45,11 @@ const ENUM_CONSTANTS = {
     FLOAT: GL_FLOAT,
     FRAGMENT_SHADER: GL_FRAGMENT_SHADER,
     FRAMEBUFFER: GL_FRAMEBUFFER,
+    FRAMEBUFFER_BINDING: GL_FRAMEBUFFER_BINDING,
     FRAMEBUFFER_COMPLETE: GL_FRAMEBUFFER_COMPLETE,
     FRAMEBUFFER_INCOMPLETE_ATTACHMENT: GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT,
+    IMPLEMENTATION_COLOR_READ_FORMAT: GL_IMPLEMENTATION_COLOR_READ_FORMAT,
+    IMPLEMENTATION_COLOR_READ_TYPE: GL_IMPLEMENTATION_COLOR_READ_TYPE,
     LINEAR: GL_LINEAR,
     LINK_STATUS: GL_LINK_STATUS,
     NEAREST: GL_NEAREST,
@@ -58,7 +65,8 @@ const ENUM_CONSTANTS = {
     TRIANGLE_STRIP: GL_TRIANGLE_STRIP,
     UNSIGNED_BYTE: GL_UNSIGNED_BYTE,
     UNSIGNED_SHORT: GL_UNSIGNED_SHORT,
-    VERTEX_SHADER: GL_VERTEX_SHADER
+    VERTEX_SHADER: GL_VERTEX_SHADER,
+    VIEWPORT: GL_VIEWPORT
 } as const;
 
 const ENUM_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
@@ -94,6 +102,15 @@ export interface UniformCallRecord {
     value: unknown;
 }
 
+export interface ReadPixelsCallRecord {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    format: number;
+    type: number;
+}
+
 export interface GLStubConfig {
     extensions?: Partial<Record<WebGLExtensionName, boolean>>;
     renderableTypes?: number[];
@@ -101,6 +118,8 @@ export interface GLStubConfig {
     compileFails?: boolean;
     linkFails?: boolean;
     missingAttributes?: string[];
+    colorReadType?: number;
+    colorReadFormat?: number;
     overrides?: Partial<WebGLRenderingContext>;
 }
 
@@ -111,6 +130,7 @@ export interface GLStubHandle {
     viewportCalls: readonly [number, number, number, number][];
     useProgramCalls: readonly WebGLProgram[];
     uniformCalls: readonly UniformCallRecord[];
+    readPixelsCalls: readonly ReadPixelsCallRecord[];
     reset: () => void;
     config: Readonly<GLStubConfig>;
 }
@@ -135,11 +155,16 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
     const viewportCalls: [number, number, number, number][] = [];
     const useProgramCalls: WebGLProgram[] = [];
     const uniformCalls: UniformCallRecord[] = [];
+    const readPixelsCalls: ReadPixelsCallRecord[] = [];
+
+    const colorReadType = config.colorReadType ?? GL_UNSIGNED_BYTE;
+    const colorReadFormat = config.colorReadFormat ?? GL_RGBA;
 
     let boundTexture: WebGLTexture | null = null;
     let boundFramebuffer: WebGLFramebuffer | null = null;
     let boundBuffer: WebGLBuffer | null = null;
     let currentProgram: WebGLProgram | null = null;
+    let currentViewport: [number, number, number, number] = [0, 0, canvasSize.width, canvasSize.height];
 
     const textureTypes = new Map<WebGLTexture, number>();
     const fbAttachment = new Map<WebGLFramebuffer, WebGLTexture>();
@@ -233,6 +258,7 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
         viewport: (x: number, y: number, width: number, height: number): void => {
             record('viewport', [x, y, width, height]);
             viewportCalls.push([x, y, width, height]);
+            currentViewport = [x, y, width, height];
         },
         deleteTexture: (texture: WebGLTexture | null): void => {
             record('deleteTexture', [texture]);
@@ -409,6 +435,39 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
         },
         uniformMatrix4fv: (location: WebGLUniformLocation | null, transpose: boolean, value: Float32Array | number[]): void => {
             recordUniform('uniformMatrix4fv', location, value, [location, transpose, value]);
+        },
+        readPixels: (
+            x: number,
+            y: number,
+            width: number,
+            height: number,
+            format: number,
+            type: number,
+            pixels: ArrayBufferView | null
+        ): void => {
+            record('readPixels', [x, y, width, height, format, type, pixels]);
+            readPixelsCalls.push({ x, y, width, height, format, type });
+            if (pixels && typeof (pixels as unknown as { fill?: unknown }).fill === 'function') {
+                (pixels as unknown as { fill: (value: number) => void }).fill(0);
+            }
+        },
+        getParameter: (pname: number): unknown => {
+            record('getParameter', [pname]);
+            if (pname === GL_FRAMEBUFFER_BINDING) {
+                return boundFramebuffer;
+            }
+            if (pname === GL_VIEWPORT) {
+                return currentViewport;
+            }
+            if (pname === GL_IMPLEMENTATION_COLOR_READ_TYPE) {
+                return colorReadType;
+            }
+            if (pname === GL_IMPLEMENTATION_COLOR_READ_FORMAT) {
+                return colorReadFormat;
+            }
+            throw new Error(
+                `micugl test stub: unstubbed getParameter pname ${pname}. ${UNSTUBBED_METHOD_MESSAGE_SUFFIX}`
+            );
         }
     };
 
@@ -447,12 +506,14 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
         viewportCalls,
         useProgramCalls,
         uniformCalls,
+        readPixelsCalls,
         reset: (): void => {
             calls.length = 0;
             texImage2DCalls.length = 0;
             viewportCalls.length = 0;
             useProgramCalls.length = 0;
             uniformCalls.length = 0;
+            readPixelsCalls.length = 0;
         },
         config: resolvedConfig
     };


### PR DESCRIPTION
Final devtools slices (plan: testing-devtools §2.6/§2.7 + the devtools-input-controls interaction spec), completing the feature.

## What

- **Override layer** in `useUniformUpdaters`: `baseValuesRef`/`overridesRef` with override-wins merge; the no-override fast path assigns the base by identity — per-render and per-frame behavior identical to before for every consumer not using devtools. Overrides compose with dirty-checking for free (one upload on set, one restore on clear).
- **`UniformDebugPort`** (`list`/`setOverride`/`clearOverride`): validates writes (finite numbers, int truncation, vec/mat length checks) and throws descriptive errors; threaded base component → engine → `EngineHandle.uniforms`; ping-pong's two uniform sets combine via `combineUniformDebugPorts`.
- **NumberField** (Blender model): one surface for scrub and type — 3px threshold gates drag vs click-to-type; pointer lock after threshold (`unadjustedMovement` retry, `setPointerCapture` fallback); Shift=×0.1 precision, Ctrl/Cmd=snap; minus key negates; Enter commit / ESC revert; eval-free expression parser (`1+2*3` → 7); `role=spinbutton`. Drag state machine is a pure tested module.
- **VectorField** (vec2–4 lanes, Alt = linked drag) and **ColorField** (`*color*`-name detection with per-row as-vector escape hatch; native picker; numeric lanes authoritative; clamped-preview badge for HDR).
- **UniformsPanel**: 10 Hz live values, per-row overridden badge + reset, reset-all, unmount clears every override it set. Inline error surface for port validation failures.
- **FBO thumbnails**: `FBOManager.debugReadFramebuffer(id, maxSize)` (unknown id throws; zero-size/incomplete/float-incompatible/oversize return honest `unreadable` reasons; framebuffer binding saved/restored; not exported from core). FramebuffersPanel captures opt-in per FBO at ~3 Hz, labeled "capture stalls the GPU pipeline"; row-flip via pure tested helper; hoisted scratch canvas.
- GL stub extended (`readPixels`, configurable `getParameter`) so the readback helper has real unit tests.

## BREAKING (pre-1.0)

`useUniformUpdaters` (exported from `micugl` and `micugl/react`) now returns `{ updaters, port }` instead of the bare updater record — direct callers must read `.updaters`. `usePingPongPasses` is non-breaking (adds `port` to its existing result).

## Verification

- 297 tests / 25 files, typecheck, lint, build + import-graph treeshake walker all green.
- Full bench vs master baseline: static-idle uniformCalls Δ0 (dirty-check intact), rerender-storm 0 compiles / 1 context, per-frame rates within noise on all scenes; many-canvases-devtools ≈ many-canvases (collapsed panel still zero per-frame GL).
- Adversarial review found and fixed 1 hot-path bug: `setOverride` wrote through the fast path's base aliasing, corrupting the pristine base so clear/reset never restored and function-driven uniforms stayed frozen after release. Fixed by rebuilding the merged values object (base never mutated); regression test models the real aliasing.
- Verified by code-trace/probe (browser click-through skipped this round): drag-local display value can't be clobbered by the 10 Hz poll; ping-pong demo FBOs are UNSIGNED_BYTE → live thumbnails (oversize placeholder above 1024px). **Runtime-unverified**: pointer-lock feel, minus-key modes, color swatch → canvas, visual restore on panel unmount — worth a manual pass on `?scene=devtools-debug` and `?scene=pingpong-sim`.