### PR TITLE
Reduced motion + Save-Data honored by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,25 @@ export default function App() {
 - **useUniformUpdaters(programId, uniforms)** → React memoized uniform updaters
 - **usePingPongPasses(options)** → { passes, framebuffers } for engine
 - **useDarkMode()** → boolean dark‑mode flag
+- **useReducedMotion()** → boolean, live `prefers-reduced-motion: reduce` state
+- **useSaveData()** → boolean, live `navigator.connection.saveData` state
+
+## Reduced motion & Save-Data
+
+Both engines respect `prefers-reduced-motion` and the Save-Data hint **on by default**
+(`reducedMotion="static-frame"`, `saveData="static-frame"`). This is a pre-1.0 behavior
+change: a canvas rendered for a user with either preference active now freezes on a single
+deterministic frame instead of animating continuously.
+
+- `reducedMotion` / `saveData`: `'static-frame' | 'pause' | 'ignore'` (default `'static-frame'`
+  for both). When either axis is active, the most restrictive configured policy wins.
+- `'static-frame'` draws one poster frame (at `staticFrame`, default `0`) and stops the
+  continuous render loop entirely; `invalidate()` calls are ignored.
+- `'pause'` freezes the clock at its current value but keeps responding to `invalidate()` —
+  useful for content that should stay interactive (theme changes, resize) without
+  autonomous time-driven motion.
+- `'ignore'` opts the axis out entirely: `<BaseShaderComponent reducedMotion="ignore" saveData="ignore" />`
+  restores unconditional animation regardless of OS/network preference.
+- `staticFrame` (default `0`) is the poster frame number, on the same 60fps timebase as
+  `setFrame`/`ShaderHandle`. Pick a frame that looks good as a static image for shaders
+  that are dull at frame 0.

--- a/bench/motion.spec.ts
+++ b/bench/motion.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+import { instrumentationInitScript } from './instrument';
+
+const SETTLE_MS = 500;
+
+test('prefers-reduced-motion freezes the loop without tearing down the engine', async ({ page }) => {
+    await page.addInitScript({ content: instrumentationInitScript });
+
+    await page.goto('/?scene=reduced-motion', { waitUntil: 'networkidle' });
+    await page.waitForSelector('canvas', { state: 'attached' });
+    await page.waitForFunction(() => window.__micuglInstrumentation.counters.snapshot().contextsCreated > 0);
+    await page.waitForTimeout(SETTLE_MS);
+
+    const contextsBefore = (await page.evaluate(() => window.__micuglInstrumentation.counters.snapshot())).contextsCreated;
+
+    const activeBefore = await page.evaluate(() => window.__micuglInstrumentation.counters.snapshot().drawArrays);
+    await page.waitForTimeout(SETTLE_MS);
+    const activeAfter = await page.evaluate(() => window.__micuglInstrumentation.counters.snapshot().drawArrays);
+    expect(activeAfter).toBeGreaterThan(activeBefore);
+
+    const session = await page.context().newCDPSession(page);
+    await session.send('Emulation.setEmulatedMedia', {
+        features: [{ name: 'prefers-reduced-motion', value: 'reduce' }]
+    });
+
+    await page.waitForTimeout(SETTLE_MS);
+
+    const contextsAfter = (await page.evaluate(() => window.__micuglInstrumentation.counters.snapshot())).contextsCreated;
+    expect(contextsAfter).toBe(contextsBefore);
+
+    const gatedBefore = await page.evaluate(() => window.__micuglInstrumentation.counters.snapshot().drawArrays);
+    await page.waitForTimeout(SETTLE_MS);
+    const gatedAfter = await page.evaluate(() => window.__micuglInstrumentation.counters.snapshot().drawArrays);
+    expect(gatedAfter).toBe(gatedBefore);
+});

--- a/demo/scenes/ReducedMotion.tsx
+++ b/demo/scenes/ReducedMotion.tsx
@@ -1,0 +1,63 @@
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
+import { useReducedMotion } from '../../src/react/hooks/useReducedMotion';
+import { useSaveData } from '../../src/react/hooks/useSaveData';
+import type { MotionPolicy, UniformParam } from '../../src/types';
+import { getIntQuery, getQueryString } from './query';
+import { QUAD_VERTEX, WAVE_FRAGMENT } from './shaders';
+
+const config = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: WAVE_FRAGMENT
+});
+
+const uniforms: Record<string, UniformParam> = {};
+
+const MOTION_POLICIES: MotionPolicy[] = ['static-frame', 'pause', 'ignore'];
+
+const readPolicy = (): MotionPolicy => {
+    const raw = getQueryString('policy');
+    if (raw !== null && (MOTION_POLICIES as string[]).includes(raw)) {
+        return raw as MotionPolicy;
+    }
+    return 'static-frame';
+};
+
+export const ReducedMotion = () => {
+    const reducedMotionActive = useReducedMotion();
+    const saveDataActive = useSaveData();
+    const policy = readPolicy();
+    const staticFrame = getIntQuery('staticFrame', 0);
+
+    return (
+        <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
+            <BaseShaderComponent
+                programId='reduced-motion'
+                shaderConfig={config}
+                uniforms={uniforms}
+                reducedMotion={policy}
+                staticFrame={staticFrame}
+                style={{ width: '100%', height: '100%', display: 'block' }}
+            />
+            <div
+                style={{
+                    position: 'absolute',
+                    top: '12px',
+                    left: '12px',
+                    padding: '8px 12px',
+                    background: 'rgba(0, 0, 0, 0.6)',
+                    color: '#fff',
+                    fontFamily: 'monospace',
+                    fontSize: '12px',
+                    borderRadius: '4px',
+                    lineHeight: 1.6
+                }}
+            >
+                <div>useReducedMotion(): {String(reducedMotionActive)}</div>
+                <div>useSaveData(): {String(saveDataActive)}</div>
+                <div>reducedMotion policy: {policy}</div>
+                <div>staticFrame: {staticFrame}</div>
+            </div>
+        </div>
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -6,6 +6,7 @@ import { ManyCanvasesDevtools } from './ManyCanvasesDevtools';
 import { Offscreen } from './Offscreen';
 import { PingPongSim } from './PingPongSim';
 import { getQueryString } from './query';
+import { ReducedMotion } from './ReducedMotion';
 import { RerenderStorm } from './RerenderStorm';
 import { StaticIdle } from './StaticIdle';
 
@@ -16,7 +17,8 @@ export const scenes: Record<string, ComponentType> = {
     'offscreen': Offscreen,
     'many-canvases': ManyCanvases,
     'many-canvases-devtools': ManyCanvasesDevtools,
-    'devtools-debug': DevtoolsDebug
+    'devtools-debug': DevtoolsDebug,
+    'reduced-motion': ReducedMotion
 };
 
 export const getSceneComponent = (): ComponentType | null => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ export {
     ShaderEngine,
     useDarkMode,
     usePingPongPasses,
+    useReducedMotion,
+    useSaveData,
     useUniformUpdaters
 } from './react';
 export type {
@@ -48,6 +50,7 @@ export type {
     Mat2,
     Mat3,
     Mat4,
+    MotionPolicy,
     PingPongState,
     RenderControlProps,
     RenderOptions,

--- a/src/micugl.d.ts
+++ b/src/micugl.d.ts
@@ -2,3 +2,13 @@ declare module 'micugl' {
     export * from './index';
     export * from './types';
   }
+
+interface NetworkInformation {
+    saveData?: boolean;
+    addEventListener?: (type: 'change', listener: () => void) => void;
+    removeEventListener?: (type: 'change', listener: () => void) => void;
+}
+
+interface Navigator {
+    connection?: NetworkInformation;
+}

--- a/src/react/components/base/BasePingPongShaderComponent.tsx
+++ b/src/react/components/base/BasePingPongShaderComponent.tsx
@@ -59,6 +59,9 @@ const BasePingPongShaderComponentImpl = forwardRef<ShaderHandle, BasePingPongSha
     dpr,
     maxPixelCount,
     fit,
+    reducedMotion,
+    saveData,
+    staticFrame,
     customPasses,
     renderOptions = RENDER_OPTIONS
 }, ref) => {
@@ -108,6 +111,9 @@ const BasePingPongShaderComponentImpl = forwardRef<ShaderHandle, BasePingPongSha
             dpr={dpr}
             maxPixelCount={maxPixelCount}
             fit={fit}
+            reducedMotion={reducedMotion}
+            saveData={saveData}
+            staticFrame={staticFrame}
         />
     );
 });

--- a/src/react/components/base/BaseShaderComponent.tsx
+++ b/src/react/components/base/BaseShaderComponent.tsx
@@ -46,6 +46,9 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     dpr,
     maxPixelCount,
     fit,
+    reducedMotion,
+    saveData,
+    staticFrame,
     className = '',
     style,
     renderOptions = RENDER_OPTIONS
@@ -72,6 +75,9 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
             dpr={dpr}
             maxPixelCount={maxPixelCount}
             fit={fit}
+            reducedMotion={reducedMotion}
+            saveData={saveData}
+            staticFrame={staticFrame}
             className={className}
             style={style}
             useFastPath={true}

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -19,8 +19,11 @@ import { WebGLManager } from '@/core/managers/WebGLManager';
 import { Passes } from '@/core/systems/Passes';
 import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
+import { useReducedMotion } from '@/react/hooks/useReducedMotion';
+import { useSaveData } from '@/react/hooks/useSaveData';
 import { framebuffersContentKey, programConfigsContentKey } from '@/react/lib/contentKeys';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
+import { resolveMotionGate } from '@/react/lib/motionPolicy';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import {
     DEFAULT_DPR,
@@ -111,8 +114,15 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
     pauseWhenHidden = true,
     dpr = DEFAULT_DPR,
     maxPixelCount = DEFAULT_MAX_PIXEL_COUNT,
-    fit = 'window'
+    fit = 'window',
+    reducedMotion = 'static-frame',
+    saveData = 'static-frame',
+    staticFrame = 0
 }, ref) => {
+    const reducedMotionActive = useReducedMotion();
+    const saveDataActive = useSaveData();
+    const motionGate = resolveMotionGate({ reducedMotionActive, saveDataActive, reducedMotion, saveData });
+
     const contentKey = `${programConfigsContentKey(programConfigs)}\u0002${framebuffersContentKey(framebuffers)}`;
 
     const engineIdRef = useRef<string>('');
@@ -421,6 +431,16 @@ const PingPongShaderEngineComponent = forwardRef<ShaderHandle, PingPongShaderEng
         controller.setSpeed(speed);
         controller.setPauseWhenHidden(pauseWhenHidden);
     }, [frameloop, speed, pauseWhenHidden]);
+
+    useEffect(() => {
+        const controller = controllerRef.current;
+        if (!controller) return;
+
+        controller.setMotionGate(motionGate);
+        if (motionGate === 'static') {
+            controller.setFrame(staticFrame);
+        }
+    }, [motionGate, staticFrame]);
 
     useEffect(() => {
         if (!debug) return;

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -20,8 +20,11 @@ import type {
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
+import { useReducedMotion } from '@/react/hooks/useReducedMotion';
+import { useSaveData } from '@/react/hooks/useSaveData';
 import { programConfigContentKey, singleProgramEntry } from '@/react/lib/contentKeys';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
+import { resolveMotionGate } from '@/react/lib/motionPolicy';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import {
     DEFAULT_DPR,
@@ -120,8 +123,15 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     pauseWhenHidden = true,
     dpr = DEFAULT_DPR,
     maxPixelCount = DEFAULT_MAX_PIXEL_COUNT,
-    fit = 'window'
+    fit = 'window',
+    reducedMotion = 'static-frame',
+    saveData = 'static-frame',
+    staticFrame = 0
 }, ref) => {
+    const reducedMotionActive = useReducedMotion();
+    const saveDataActive = useSaveData();
+    const motionGate = resolveMotionGate({ reducedMotionActive, saveDataActive, reducedMotion, saveData });
+
     const [keyProgramId, keyProgramConfig] = singleProgramEntry(programConfigs);
     const contentKey = programConfigContentKey(keyProgramId, keyProgramConfig);
 
@@ -412,6 +422,16 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         controller.setSpeed(speed);
         controller.setPauseWhenHidden(pauseWhenHidden);
     }, [frameloop, speed, pauseWhenHidden]);
+
+    useEffect(() => {
+        const controller = controllerRef.current;
+        if (!controller) return;
+
+        controller.setMotionGate(motionGate);
+        if (motionGate === 'static') {
+            controller.setFrame(staticFrame);
+        }
+    }, [motionGate, staticFrame]);
 
     useEffect(() => {
         if (!debug) return;

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -1,3 +1,5 @@
 export { useDarkMode } from './useDarkMode';
 export { usePingPongPasses } from './usePingPongPasses';
+export { useReducedMotion } from './useReducedMotion';
+export { useSaveData } from './useSaveData';
 export { useUniformUpdaters } from './useUniformUpdaters';

--- a/src/react/hooks/useReducedMotion.ts
+++ b/src/react/hooks/useReducedMotion.ts
@@ -1,0 +1,44 @@
+import { useSyncExternalStore } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+interface LegacyMediaQueryList {
+    addListener: (listener: () => void) => void;
+    removeListener: (listener: () => void) => void;
+}
+
+function getServerSnapshot(): boolean {
+    return false;
+}
+
+function getSnapshot(): boolean {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return false;
+    }
+    return window.matchMedia(QUERY).matches;
+}
+
+function unsubscribeNoop(): void {
+    return;
+}
+
+function subscribe(callback: () => void): () => void {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return unsubscribeNoop;
+    }
+
+    const mql = window.matchMedia(QUERY);
+
+    if (typeof mql.addEventListener === 'function') {
+        mql.addEventListener('change', callback);
+        return (): void => { mql.removeEventListener('change', callback) };
+    }
+
+    const legacyMql = mql as unknown as LegacyMediaQueryList;
+    legacyMql.addListener(callback);
+    return (): void => { legacyMql.removeListener(callback) };
+}
+
+export function useReducedMotion(): boolean {
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/react/hooks/useSaveData.ts
+++ b/src/react/hooks/useSaveData.ts
@@ -1,0 +1,34 @@
+import { useSyncExternalStore } from 'react';
+
+function getServerSnapshot(): boolean {
+    return false;
+}
+
+function getSnapshot(): boolean {
+    if (typeof navigator === 'undefined') {
+        return false;
+    }
+    return navigator.connection?.saveData === true;
+}
+
+function unsubscribeNoop(): void {
+    return;
+}
+
+function subscribe(callback: () => void): () => void {
+    if (typeof navigator === 'undefined') {
+        return unsubscribeNoop;
+    }
+
+    const connection = navigator.connection;
+    if (!connection || typeof connection.addEventListener !== 'function') {
+        return unsubscribeNoop;
+    }
+
+    connection.addEventListener('change', callback);
+    return (): void => { connection.removeEventListener?.('change', callback) };
+}
+
+export function useSaveData(): boolean {
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -4,5 +4,7 @@ export { PingPongShaderEngine } from './components/engine/PingPongShaderEngine';
 export { ShaderEngine } from './components/engine/ShaderEngine';
 export { useDarkMode } from './hooks/useDarkMode';
 export { usePingPongPasses } from './hooks/usePingPongPasses';
+export { useReducedMotion } from './hooks/useReducedMotion';
+export { useSaveData } from './hooks/useSaveData';
 export { useUniformUpdaters } from './hooks/useUniformUpdaters';
 export { createCommonUpdaters, createUniformUpdater, createUniformUpdaters } from './lib/createUniformUpdater';

--- a/src/react/lib/motionPolicy.test.ts
+++ b/src/react/lib/motionPolicy.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MotionGate, MotionGateInputs } from '@/react/lib/motionPolicy';
+import { resolveMotionGate } from '@/react/lib/motionPolicy';
+import type { MotionPolicy } from '@/types';
+
+const POLICIES: MotionPolicy[] = ['static-frame', 'pause', 'ignore'];
+const BOOLS = [true, false];
+
+function gateForPolicy(policy: MotionPolicy): MotionGate {
+    if (policy === 'static-frame') {
+        return 'static';
+    }
+    if (policy === 'pause') {
+        return 'pause';
+    }
+    return 'none';
+}
+
+function mostRestrictive(a: MotionGate, b: MotionGate): MotionGate {
+    if (a === 'static' || b === 'static') {
+        return 'static';
+    }
+    if (a === 'pause' || b === 'pause') {
+        return 'pause';
+    }
+    return 'none';
+}
+
+function expected(inputs: MotionGateInputs): MotionGate {
+    const reducedMotionGate = inputs.reducedMotionActive ? gateForPolicy(inputs.reducedMotion) : 'none';
+    const saveDataGate = inputs.saveDataActive ? gateForPolicy(inputs.saveData) : 'none';
+    return mostRestrictive(reducedMotionGate, saveDataGate);
+}
+
+describe('resolveMotionGate truth table', () => {
+    it('matches the reference across every policy and activation combination', () => {
+        for (const reducedMotion of POLICIES) {
+            for (const saveData of POLICIES) {
+                for (const reducedMotionActive of BOOLS) {
+                    for (const saveDataActive of BOOLS) {
+                        const inputs: MotionGateInputs = {
+                            reducedMotionActive, saveDataActive, reducedMotion, saveData
+                        };
+                        expect(resolveMotionGate(inputs)).toBe(expected(inputs));
+                    }
+                }
+            }
+        }
+    });
+});
+
+describe('resolveMotionGate precedence', () => {
+    it('is none when neither axis is active regardless of configured policy', () => {
+        expect(resolveMotionGate({
+            reducedMotionActive: false,
+            saveDataActive: false,
+            reducedMotion: 'static-frame',
+            saveData: 'static-frame'
+        })).toBe('none');
+    });
+
+    it('an inactive axis never contributes even when set to static-frame', () => {
+        expect(resolveMotionGate({
+            reducedMotionActive: false,
+            saveDataActive: true,
+            reducedMotion: 'static-frame',
+            saveData: 'ignore'
+        })).toBe('none');
+    });
+
+    it('ignore contributes nothing even when active', () => {
+        expect(resolveMotionGate({
+            reducedMotionActive: true,
+            saveDataActive: false,
+            reducedMotion: 'ignore',
+            saveData: 'static-frame'
+        })).toBe('none');
+    });
+
+    it('static beats pause when both axes are active', () => {
+        expect(resolveMotionGate({
+            reducedMotionActive: true,
+            saveDataActive: true,
+            reducedMotion: 'pause',
+            saveData: 'static-frame'
+        })).toBe('static');
+
+        expect(resolveMotionGate({
+            reducedMotionActive: true,
+            saveDataActive: true,
+            reducedMotion: 'static-frame',
+            saveData: 'pause'
+        })).toBe('static');
+    });
+
+    it('pause wins over ignore when both axes are active', () => {
+        expect(resolveMotionGate({
+            reducedMotionActive: true,
+            saveDataActive: true,
+            reducedMotion: 'pause',
+            saveData: 'ignore'
+        })).toBe('pause');
+    });
+
+    it('a single active axis drives the gate on its own', () => {
+        expect(resolveMotionGate({
+            reducedMotionActive: true,
+            saveDataActive: false,
+            reducedMotion: 'static-frame',
+            saveData: 'static-frame'
+        })).toBe('static');
+
+        expect(resolveMotionGate({
+            reducedMotionActive: false,
+            saveDataActive: true,
+            reducedMotion: 'static-frame',
+            saveData: 'pause'
+        })).toBe('pause');
+    });
+});

--- a/src/react/lib/motionPolicy.ts
+++ b/src/react/lib/motionPolicy.ts
@@ -1,0 +1,36 @@
+import type { MotionPolicy } from '@/types';
+
+export type MotionGate = 'none' | 'pause' | 'static';
+
+function gateForPolicy(policy: MotionPolicy): MotionGate {
+    if (policy === 'static-frame') {
+        return 'static';
+    }
+    if (policy === 'pause') {
+        return 'pause';
+    }
+    return 'none';
+}
+
+function mostRestrictive(a: MotionGate, b: MotionGate): MotionGate {
+    if (a === 'static' || b === 'static') {
+        return 'static';
+    }
+    if (a === 'pause' || b === 'pause') {
+        return 'pause';
+    }
+    return 'none';
+}
+
+export interface MotionGateInputs {
+    reducedMotionActive: boolean;
+    saveDataActive: boolean;
+    reducedMotion: MotionPolicy;
+    saveData: MotionPolicy;
+}
+
+export function resolveMotionGate(inputs: MotionGateInputs): MotionGate {
+    const reducedMotionGate = inputs.reducedMotionActive ? gateForPolicy(inputs.reducedMotion) : 'none';
+    const saveDataGate = inputs.saveDataActive ? gateForPolicy(inputs.saveData) : 'none';
+    return mostRestrictive(reducedMotionGate, saveDataGate);
+}

--- a/src/react/lib/renderLoop.test.ts
+++ b/src/react/lib/renderLoop.test.ts
@@ -288,6 +288,94 @@ describe('RenderLoop speed and control', () => {
     });
 });
 
+describe('RenderLoop motion gate', () => {
+    it('stops scheduling continuous rAF when gated static in always mode', () => {
+        const h = harness({ frameloop: 'always' });
+        h.loop.start();
+        h.flush(16);
+        expect(h.pending).toBe(1);
+
+        h.loop.setMotionGate('static');
+        expect(h.pending).toBe(0);
+    });
+
+    it('renders exactly one frame per invalidate while gated, and elapsed does not advance across repeated invalidates', () => {
+        const h = harness({ frameloop: 'always' });
+        h.loop.start();
+        h.flush(16);
+        expect(h.renders).toEqual([0]);
+
+        h.loop.setMotionGate('static');
+        expect(h.pending).toBe(0);
+
+        h.loop.invalidate();
+        expect(h.pending).toBe(1);
+        h.flush(500);
+        expect(h.renders).toEqual([0, 0]);
+        expect(h.pending).toBe(0);
+
+        h.loop.invalidate();
+        expect(h.pending).toBe(1);
+        h.setNow(999999);
+        h.flush(999999);
+        expect(h.renders).toEqual([0, 0, 0]);
+        expect(h.pending).toBe(0);
+    });
+
+    it('setFrame while gated static renders synchronously at frameToMs(staticFrame)', () => {
+        const h = harness({ frameloop: 'always' });
+        h.loop.start();
+        h.flush(16);
+        h.loop.setMotionGate('static');
+        expect(h.pending).toBe(0);
+
+        h.loop.setFrame(120);
+        expect(h.renders[h.renders.length - 1]).toBe(2000);
+        expect(h.loop.getFrame()).toBe(120);
+        expect(h.pending).toBe(0);
+    });
+
+    it('lifting the gate after time has passed resumes from the frozen clock without a jump', () => {
+        const h = harness({ frameloop: 'always' });
+        h.loop.start();
+        h.flush(16);
+        expect(h.renders[0]).toBe(0);
+
+        h.loop.setMotionGate('static');
+        h.setNow(100000);
+        h.loop.invalidate();
+        h.flush(100016);
+        expect(h.renders[1]).toBe(0);
+
+        h.loop.setMotionGate('none');
+        expect(h.pending).toBe(1);
+        h.flush(100032);
+        expect(h.renders[2]).toBe(0);
+
+        h.flush(100048);
+        expect(h.renders[3]).toBe(16);
+    });
+
+    it('a pause gate freezes the clock at its current value rather than resetting it', () => {
+        const h = harness({ frameloop: 'always' });
+        h.loop.start();
+        h.flush(16);
+        h.flush(32);
+        expect(h.renders[1]).toBe(16);
+
+        h.loop.setMotionGate('pause');
+        h.loop.invalidate();
+        h.setNow(500);
+        h.flush(500);
+        expect(h.renders[2]).toBe(16);
+
+        h.loop.invalidate();
+        h.setNow(999999);
+        h.flush(999999);
+        expect(h.renders[3]).toBe(16);
+    });
+});
+
 describe('RenderLoop introspection getters', () => {
     it('reports the configured frameloop mode and reacts to setFrameloop', () => {
         const h = harness({ frameloop: 'demand' });
@@ -303,6 +391,21 @@ describe('RenderLoop introspection getters', () => {
 
         h.loop.setSpeed(0.5);
         expect(h.loop.getSpeed()).toBe(0.5);
+    });
+
+    it('reports the motion gate and reacts to setMotionGate, no-op when unchanged', () => {
+        const h = harness({ frameloop: 'always' });
+        expect(h.loop.getMotionGate()).toBe('none');
+
+        h.loop.start();
+        h.flush(16);
+        h.loop.setMotionGate('static');
+        expect(h.loop.getMotionGate()).toBe('static');
+        expect(h.pending).toBe(0);
+
+        h.loop.setMotionGate('static');
+        expect(h.loop.getMotionGate()).toBe('static');
+        expect(h.pending).toBe(0);
     });
 
     it('reports paused before start and while hidden, unpaused once started and visible', () => {

--- a/src/react/lib/renderLoop.ts
+++ b/src/react/lib/renderLoop.ts
@@ -1,3 +1,4 @@
+import type { MotionGate } from '@/react/lib/motionPolicy';
 import { shouldSchedule } from '@/react/lib/shouldSchedule';
 import {
     createTimeKeeper,
@@ -32,6 +33,7 @@ export class RenderLoop {
     private running = false;
     private handle: number | null = null;
     private cold = true;
+    private motionGate: MotionGate = 'none';
 
     constructor(deps: RenderLoopDeps) {
         this.deps = deps;
@@ -67,7 +69,8 @@ export class RenderLoop {
             documentVisible: this.documentVisible,
             intersecting: this.intersecting,
             pauseWhenHidden: this.pauseWhenHidden,
-            pendingInvalidate: this.pendingInvalidate
+            pendingInvalidate: this.pendingInvalidate,
+            motionGate: this.motionGate
         });
 
         if (should && this.handle === null) {
@@ -82,7 +85,9 @@ export class RenderLoop {
         this.handle = null;
         this.pendingInvalidate = false;
 
-        if (this.cold) {
+        if (this.motionGate !== 'none') {
+            this.time = syncTime(this.time, now);
+        } else if (this.cold) {
             this.time = syncTime(this.time, now);
             this.cold = false;
         } else {
@@ -133,6 +138,19 @@ export class RenderLoop {
 
     getSpeed(): number {
         return this.time.speed;
+    }
+
+    getMotionGate(): MotionGate {
+        return this.motionGate;
+    }
+
+    setMotionGate(gate: MotionGate): void {
+        if (this.motionGate === gate) {
+            return;
+        }
+        this.motionGate = gate;
+        this.cold = true;
+        this.evaluate();
     }
 
     isPaused(): boolean {

--- a/src/react/lib/shouldSchedule.test.ts
+++ b/src/react/lib/shouldSchedule.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { MotionGate } from '@/react/lib/motionPolicy';
 import type { ScheduleInputs } from '@/react/lib/shouldSchedule';
 import { shouldSchedule } from '@/react/lib/shouldSchedule';
 import type { Frameloop } from '@/types';
@@ -7,6 +8,7 @@ import type { Frameloop } from '@/types';
 const FRAMELOOPS: Frameloop[] = ['always', 'demand', 'never'];
 const BOOLS = [true, false];
 const SPEEDS = [1, 0];
+const MOTION_GATES: MotionGate[] = ['none', 'pause', 'static'];
 
 function expected(inputs: ScheduleInputs): boolean {
     if (inputs.pauseWhenHidden && (!inputs.documentVisible || !inputs.intersecting)) {
@@ -14,6 +16,9 @@ function expected(inputs: ScheduleInputs): boolean {
     }
     if (inputs.speed === 0) {
         return false;
+    }
+    if (inputs.motionGate !== 'none') {
+        return inputs.pendingInvalidate;
     }
     if (inputs.frameloop === 'always') {
         return true;
@@ -29,11 +34,14 @@ describe('shouldSchedule truth table', () => {
                     for (const intersecting of BOOLS) {
                         for (const pauseWhenHidden of BOOLS) {
                             for (const pendingInvalidate of BOOLS) {
-                                const inputs: ScheduleInputs = {
-                                    frameloop, speed, documentVisible,
-                                    intersecting, pauseWhenHidden, pendingInvalidate
-                                };
-                                expect(shouldSchedule(inputs)).toBe(expected(inputs));
+                                for (const motionGate of MOTION_GATES) {
+                                    const inputs: ScheduleInputs = {
+                                        frameloop, speed, documentVisible,
+                                        intersecting, pauseWhenHidden, pendingInvalidate,
+                                        motionGate
+                                    };
+                                    expect(shouldSchedule(inputs)).toBe(expected(inputs));
+                                }
                             }
                         }
                     }
@@ -49,7 +57,8 @@ const base: ScheduleInputs = {
     documentVisible: true,
     intersecting: true,
     pauseWhenHidden: true,
-    pendingInvalidate: false
+    pendingInvalidate: false,
+    motionGate: 'none'
 };
 
 describe('shouldSchedule precedence', () => {
@@ -93,5 +102,33 @@ describe('shouldSchedule precedence', () => {
         expect(shouldSchedule({
             ...base, frameloop: 'demand', pendingInvalidate: true, documentVisible: false
         })).toBe(false);
+    });
+
+    it('a motion gate suppresses continuous scheduling in always mode', () => {
+        expect(shouldSchedule({ ...base, motionGate: 'static' })).toBe(false);
+        expect(shouldSchedule({ ...base, motionGate: 'pause' })).toBe(false);
+    });
+
+    it('a motion gate still allows one coalesced repaint per invalidate', () => {
+        expect(shouldSchedule({ ...base, motionGate: 'static', pendingInvalidate: true })).toBe(true);
+        expect(shouldSchedule({ ...base, motionGate: 'pause', pendingInvalidate: true })).toBe(true);
+    });
+
+    it('hidden still wins over a motion gate with a pending invalidate', () => {
+        expect(shouldSchedule({
+            ...base, motionGate: 'static', pendingInvalidate: true, documentVisible: false
+        })).toBe(false);
+    });
+
+    it('speed zero still wins over a motion gate with a pending invalidate', () => {
+        expect(shouldSchedule({
+            ...base, motionGate: 'static', pendingInvalidate: true, speed: 0
+        })).toBe(false);
+    });
+
+    it('motionGate none preserves the pre-gate always/demand/never behavior', () => {
+        expect(shouldSchedule({ ...base, motionGate: 'none' })).toBe(true);
+        expect(shouldSchedule({ ...base, frameloop: 'demand', motionGate: 'none', pendingInvalidate: false })).toBe(false);
+        expect(shouldSchedule({ ...base, frameloop: 'demand', motionGate: 'none', pendingInvalidate: true })).toBe(true);
     });
 });

--- a/src/react/lib/shouldSchedule.ts
+++ b/src/react/lib/shouldSchedule.ts
@@ -1,3 +1,4 @@
+import type { MotionGate } from '@/react/lib/motionPolicy';
 import type { Frameloop } from '@/types';
 
 export interface ScheduleInputs {
@@ -7,6 +8,7 @@ export interface ScheduleInputs {
     intersecting: boolean;
     pauseWhenHidden: boolean;
     pendingInvalidate: boolean;
+    motionGate: MotionGate;
 }
 
 export function shouldSchedule(inputs: ScheduleInputs): boolean {
@@ -16,6 +18,10 @@ export function shouldSchedule(inputs: ScheduleInputs): boolean {
 
     if (inputs.speed === 0) {
         return false;
+    }
+
+    if (inputs.motionGate !== 'none') {
+        return inputs.pendingInvalidate;
     }
 
     if (inputs.frameloop === 'always') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,8 @@ export type Fit = 'window' | 'element';
 
 export type Dpr = number | [number, number];
 
+export type MotionPolicy = 'static-frame' | 'pause' | 'ignore';
+
 export interface ShaderHandle {
   invalidate: () => void;
   setFrame: (frame: number) => void;
@@ -106,6 +108,9 @@ export interface RenderControlProps {
   height?: number;
   pixelRatio?: number;
   useDevicePixelRatio?: boolean;
+  reducedMotion?: MotionPolicy;
+  saveData?: MotionPolicy;
+  staticFrame?: number;
 }
 
 export interface WebGLExtensionTypes {


### PR DESCRIPTION
## What

Implements Feature 1 of the motion-export plan: `prefers-reduced-motion` and Save-Data handling, **on by default** (documented pre-1.0 behavior change).

- `MotionPolicy = 'static-frame' | 'pause' | 'ignore'`; new `RenderControlProps`: `reducedMotion` (default `'static-frame'`), `saveData` (default `'static-frame'`), `staticFrame` (poster frame number, 60fps timebase, default 0).
- Pure `resolveMotionGate` (most restrictive wins: static > pause > none) + `motionGate` input on `shouldSchedule`.
- `RenderLoop.setMotionGate`: gated frames always sync (never tick) — clock frozen while gated, no time jump on gate lift; poster drawn via synchronous `setFrame(staticFrame)`.
- SSR-safe `useReducedMotion` / `useSaveData` (`useSyncExternalStore`, old-Safari `addListener` fallback, `navigator.connection` ambient type).
- `reduced-motion` demo scene + bench spec (CDP `Emulation.setEmulatedMedia`): asserts drawArrays stops incrementing after the poster while `contextsCreated` stays constant (no engine teardown on OS-preference flip).

## Semantics

- `static-frame`: poster at `staticFrame`, no autonomous motion; `invalidate()` repaints at the frozen clock (coalesced) so resize/content changes never leave a black canvas.
- `pause`: clock frozen at its current value; `invalidate()` still repaints.
- `ignore`: axis has no effect.
- Precedence: hidden/offscreen > `speed=0` > motion gate > `frameloop='always'`.

## Deviations from the plan doc (as-built adaptations)

- Poster prop is `staticFrame` (frame number, 60fps timebase) rather than `staticFrameTime` seconds — matches the established `setFrame`/`getFrame` time model.
- Under `static-frame`, `invalidate()` repaints at the frozen clock instead of being ignored — resizing the drawing buffer clears it, so an ignored invalidate would strand a black canvas.
- `staticFrameWarmup` deferred: generated ping-pong chains are time-pure (re-seed per frame), so `staticFrame` covers the developed-poster use case; deterministic warm-up for custom accumulators arrives with the capture PR's seed machinery.

## Review

Opus adversarial review: zero confirmed bugs, zero edits. Conscious choice flagged: `isPaused()`/devtools `paused` do not reflect the motion gate (gated ≠ paused-by-visibility); FrameloopPanel shows a gated engine as running.

Runtime-unverified (suggested manual pass): OS-level reduced-motion toggle feel in `?scene=reduced-motion` (`?policy=`, `?staticFrame=` queries).

Gates: typecheck / lint / 315 vitest / build / `bench/motion.spec.ts` all green.