### PR TITLE
instancing: core GL plumbing (I1) — drawArraysInstanced, buffer usage + bufferSubData, InstanceUploader

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,6 +18,8 @@ export type {
     BufferData,
     FramebufferOptions,
     FramebufferResources,
+    InstanceAttribute,
+    InstancingConfig,
     PingPongState,
     RenderOptions,
     RenderPass,

--- a/src/core/lib/instanceBuffers.test.ts
+++ b/src/core/lib/instanceBuffers.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from 'vitest';
+
+import type { InstanceBufferManager } from '@/core/lib/instanceBuffers';
+import {
+    deriveAttributeCapacity,
+    InstanceUploader,
+    resolveAttributeData,
+    resolveInstanceCount,
+    validateAttributeLength,
+    validateCountWithinCapacity,
+    validateInstanceCount,
+    validateUploadLength
+} from '@/core/lib/instanceBuffers';
+import type { InstancingConfig } from '@/types';
+
+interface RecordedCreateBuffer {
+    programId: string;
+    attributeName: string;
+    data: Float32Array | Uint8Array | Uint16Array;
+    usage: 'static' | 'dynamic' | undefined;
+}
+
+interface RecordedUpdateBuffer {
+    programId: string;
+    attributeName: string;
+    data: Float32Array | Uint8Array | Uint16Array;
+}
+
+interface RecordedUpdateBufferSub {
+    programId: string;
+    attributeName: string;
+    data: Float32Array | Uint8Array | Uint16Array;
+    offset: number | undefined;
+}
+
+function createRecordingManager(): InstanceBufferManager & {
+    createBufferCalls: RecordedCreateBuffer[];
+    updateBufferCalls: RecordedUpdateBuffer[];
+    updateBufferSubCalls: RecordedUpdateBufferSub[];
+    } {
+    const createBufferCalls: RecordedCreateBuffer[] = [];
+    const updateBufferCalls: RecordedUpdateBuffer[] = [];
+    const updateBufferSubCalls: RecordedUpdateBufferSub[] = [];
+
+    return {
+        createBufferCalls,
+        updateBufferCalls,
+        updateBufferSubCalls,
+        createBuffer(programId, attributeName, data, usage): WebGLBuffer {
+            createBufferCalls.push({ programId, attributeName, data, usage });
+            return {};
+        },
+        updateBuffer(programId, attributeName, data): void {
+            updateBufferCalls.push({ programId, attributeName, data });
+        },
+        updateBufferSub(programId, attributeName, data, offset): void {
+            updateBufferSubCalls.push({ programId, attributeName, data, offset });
+        }
+    };
+}
+
+describe('resolveInstanceCount', () => {
+    it('returns a plain number as-is', () => {
+        expect(resolveInstanceCount(5)).toBe(5);
+    });
+
+    it('calls a function to resolve the count', () => {
+        expect(resolveInstanceCount(() => 7)).toBe(7);
+    });
+});
+
+describe('resolveAttributeData', () => {
+    it('returns a plain array as-is', () => {
+        const data = new Float32Array([1, 2]);
+        expect(resolveAttributeData(data)).toBe(data);
+    });
+
+    it('calls a function to resolve the array', () => {
+        const data = new Float32Array([3, 4]);
+        expect(resolveAttributeData(() => data)).toBe(data);
+    });
+});
+
+describe('validateAttributeLength', () => {
+    it('passes when length is a multiple of size', () => {
+        expect(() => { validateAttributeLength('foo', 9, 3) }).not.toThrow();
+    });
+
+    it('throws naming the attribute when length is not a multiple of size', () => {
+        expect(() => { validateAttributeLength('foo', 10, 3) }).toThrow(/foo/);
+    });
+});
+
+describe('deriveAttributeCapacity', () => {
+    it('defaults capacity to the initial instance count', () => {
+        expect(deriveAttributeCapacity('foo', 12, 3, undefined)).toBe(4);
+    });
+
+    it('accepts an explicit capacity at or above the initial instance count', () => {
+        expect(deriveAttributeCapacity('foo', 12, 3, 10)).toBe(10);
+    });
+
+    it('throws when explicit capacity is smaller than the initial data', () => {
+        expect(() => deriveAttributeCapacity('foo', 12, 3, 2)).toThrow(/foo/);
+    });
+
+    it('throws when the initial length is not a multiple of size', () => {
+        expect(() => deriveAttributeCapacity('foo', 10, 3, undefined)).toThrow(/foo/);
+    });
+});
+
+describe('validateUploadLength', () => {
+    it('passes when the data covers the requested count', () => {
+        expect(() => { validateUploadLength('foo', 12, 3, 4) }).not.toThrow();
+    });
+
+    it('throws when length is not a multiple of size', () => {
+        expect(() => { validateUploadLength('foo', 10, 3, 2) }).toThrow(/foo/);
+    });
+
+    it('throws when the data is shorter than count * size', () => {
+        expect(() => { validateUploadLength('foo', 6, 3, 4) }).toThrow(/foo/);
+    });
+});
+
+describe('validateInstanceCount', () => {
+    it('passes for zero and positive integers', () => {
+        expect(() => { validateInstanceCount(0) }).not.toThrow();
+        expect(() => { validateInstanceCount(5) }).not.toThrow();
+    });
+
+    it('throws for a negative count', () => {
+        expect(() => { validateInstanceCount(-1) }).toThrow(/non-negative integer/);
+    });
+
+    it('throws for a fractional count', () => {
+        expect(() => { validateInstanceCount(2.5) }).toThrow(/non-negative integer/);
+    });
+
+    it('throws for NaN and Infinity', () => {
+        expect(() => { validateInstanceCount(NaN) }).toThrow(/non-negative integer/);
+        expect(() => { validateInstanceCount(Infinity) }).toThrow(/non-negative integer/);
+    });
+});
+
+describe('validateCountWithinCapacity', () => {
+    it('passes when count is at or below capacity', () => {
+        expect(() => { validateCountWithinCapacity('foo', 10, 10) }).not.toThrow();
+    });
+
+    it('throws naming the attribute, count, and capacity on overflow', () => {
+        expect(() => { validateCountWithinCapacity('foo', 11, 10) }).toThrow(/foo/);
+    });
+});
+
+describe('InstanceUploader', () => {
+    const staticData = new Float32Array([0, 0, 1, 1, 2, 2]);
+
+    function makeConfig(overrides: Partial<InstancingConfig> = {}): InstancingConfig {
+        return {
+            instanceCount: 3,
+            attributes: {
+                offset: { data: staticData, size: 2 }
+            },
+            ...overrides
+        };
+    }
+
+    it('creates a buffer per attribute on initialize', () => {
+        const manager = createRecordingManager();
+        const uploader = new InstanceUploader(manager, 'prog', makeConfig());
+
+        uploader.initialize();
+
+        expect(manager.createBufferCalls).toHaveLength(1);
+        expect(manager.createBufferCalls[0]).toMatchObject({
+            programId: 'prog',
+            attributeName: 'offset',
+            usage: 'static'
+        });
+    });
+
+    it('derives default capacity from the initial data when none is given', () => {
+        const manager = createRecordingManager();
+        const uploader = new InstanceUploader(manager, 'prog', makeConfig());
+        uploader.initialize();
+
+        expect(() => uploader.upload()).not.toThrow();
+
+        const config = makeConfig({ instanceCount: 4 });
+        const overflowUploader = new InstanceUploader(manager, 'prog', config);
+        overflowUploader.initialize();
+        expect(() => overflowUploader.upload()).toThrow(/capacity/);
+    });
+
+    it('throws on capacity overflow naming the attribute, count, and capacity', () => {
+        const manager = createRecordingManager();
+        const config: InstancingConfig = {
+            instanceCount: 5,
+            attributes: {
+                offset: { data: staticData, size: 2, capacity: 3 }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        expect(() => uploader.upload()).toThrow(/offset/);
+    });
+
+    it('throws when a resolved attribute array length is not a multiple of size', () => {
+        const manager = createRecordingManager();
+        let current = new Float32Array([1, 2, 3, 4]);
+        const config: InstancingConfig = {
+            instanceCount: 2,
+            attributes: {
+                offset: { data: () => current, size: 2, capacity: 10 }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        current = new Float32Array([1, 2, 3]);
+        expect(() => uploader.upload()).toThrow(/offset/);
+    });
+
+    it('throws when a resolved attribute array is shorter than count * size', () => {
+        const manager = createRecordingManager();
+        const config: InstancingConfig = {
+            instanceCount: 5,
+            attributes: {
+                offset: { data: staticData, size: 2, capacity: 10 }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        expect(() => uploader.upload()).toThrow(/offset/);
+    });
+
+    it('uploads a static attribute once then skips when the array identity is unchanged', () => {
+        const manager = createRecordingManager();
+        const uploader = new InstanceUploader(manager, 'prog', makeConfig());
+        uploader.initialize();
+
+        uploader.upload();
+        uploader.upload();
+        uploader.upload();
+
+        expect(manager.updateBufferCalls).toHaveLength(0);
+    });
+
+    it('re-uploads a static attribute when the array identity changes', () => {
+        const manager = createRecordingManager();
+        let current = staticData;
+        const config: InstancingConfig = {
+            instanceCount: 3,
+            attributes: {
+                offset: { data: () => current, size: 2 }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        uploader.upload();
+        expect(manager.updateBufferCalls).toHaveLength(0);
+
+        current = new Float32Array([9, 9, 8, 8, 7, 7]);
+        uploader.upload();
+        expect(manager.updateBufferCalls).toHaveLength(1);
+
+        uploader.upload();
+        expect(manager.updateBufferCalls).toHaveLength(1);
+    });
+
+    it('uploads a dynamic attribute on every call regardless of identity', () => {
+        const manager = createRecordingManager();
+        const data = new Float32Array([1, 1, 2, 2, 3, 3]);
+        const config: InstancingConfig = {
+            instanceCount: 3,
+            attributes: {
+                offset: { data, size: 2, usage: 'dynamic' }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        uploader.upload();
+        uploader.upload();
+
+        expect(manager.updateBufferSubCalls).toHaveLength(2);
+        expect(manager.updateBufferCalls).toHaveLength(0);
+    });
+
+    it('allocates a dynamic buffer sized to capacity, not the initial data', () => {
+        const manager = createRecordingManager();
+        const config: InstancingConfig = {
+            instanceCount: 2,
+            attributes: {
+                offset: { data: new Float32Array([1, 1]), size: 2, usage: 'dynamic', capacity: 10 }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        const created = manager.createBufferCalls[0]?.data ?? new Float32Array(0);
+        expect(created.length).toBe(20);
+    });
+
+    it('returns the resolved instance count', () => {
+        const manager = createRecordingManager();
+        const uploader = new InstanceUploader(manager, 'prog', makeConfig());
+        uploader.initialize();
+
+        expect(uploader.upload()).toBe(3);
+    });
+
+    it('returns 0 and uploads nothing when the resolved count is 0', () => {
+        const manager = createRecordingManager();
+        const config: InstancingConfig = {
+            instanceCount: 0,
+            attributes: {
+                offset: { data: staticData, size: 2 },
+                velocity: { data: new Float32Array([1, 1, 2, 2, 3, 3]), size: 2, usage: 'dynamic' }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        expect(uploader.upload()).toBe(0);
+        expect(manager.updateBufferCalls).toHaveLength(0);
+        expect(manager.updateBufferSubCalls).toHaveLength(0);
+    });
+
+    it('resolves instanceCount via a function', () => {
+        const manager = createRecordingManager();
+        let count = 2;
+        const config: InstancingConfig = {
+            instanceCount: () => count,
+            attributes: {
+                offset: { data: staticData, size: 2 }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        expect(uploader.upload()).toBe(2);
+        count = 3;
+        expect(uploader.upload()).toBe(3);
+    });
+
+    it('throws and uploads nothing when the resolved count is not a non-negative integer', () => {
+        const manager = createRecordingManager();
+        let count = 2;
+        const config: InstancingConfig = {
+            instanceCount: () => count,
+            attributes: {
+                offset: { data: staticData, size: 2, usage: 'dynamic', capacity: 10 }
+            }
+        };
+        const uploader = new InstanceUploader(manager, 'prog', config);
+        uploader.initialize();
+
+        for (const bad of [NaN, -1, 2.5]) {
+            count = bad;
+            expect(() => uploader.upload()).toThrow(/non-negative integer/);
+        }
+
+        expect(manager.updateBufferSubCalls).toHaveLength(0);
+    });
+
+    it('throws if upload is called before initialize', () => {
+        const manager = createRecordingManager();
+        const uploader = new InstanceUploader(manager, 'prog', makeConfig());
+
+        expect(() => uploader.upload()).toThrow(/initialize/);
+    });
+});

--- a/src/core/lib/instanceBuffers.ts
+++ b/src/core/lib/instanceBuffers.ts
@@ -1,0 +1,177 @@
+import type { InstanceAttribute, InstancingConfig } from '@/types';
+
+export interface InstanceBufferManager {
+    createBuffer(
+        programId: string,
+        attributeName: string,
+        data: Float32Array | Uint8Array | Uint16Array,
+        usage?: 'static' | 'dynamic'
+    ): WebGLBuffer;
+    updateBuffer(
+        programId: string,
+        attributeName: string,
+        data: Float32Array | Uint8Array | Uint16Array
+    ): void;
+    updateBufferSub(
+        programId: string,
+        attributeName: string,
+        data: Float32Array | Uint8Array | Uint16Array,
+        offset?: number
+    ): void;
+}
+
+export function resolveInstanceCount(instanceCount: number | (() => number)): number {
+    return typeof instanceCount === 'function' ? instanceCount() : instanceCount;
+}
+
+export function validateInstanceCount(count: number): void {
+    if (!Number.isInteger(count) || count < 0) {
+        throw new Error(`Instance count must be a non-negative integer, got ${count}`);
+    }
+}
+
+export function resolveAttributeData(data: Float32Array | (() => Float32Array)): Float32Array {
+    return typeof data === 'function' ? data() : data;
+}
+
+export function validateAttributeLength(attributeName: string, length: number, size: number): void {
+    if (length % size !== 0) {
+        throw new Error(
+            `Instance attribute "${attributeName}" data length ${length} is not a multiple of size ${size}`
+        );
+    }
+}
+
+export function deriveAttributeCapacity(
+    attributeName: string,
+    initialLength: number,
+    size: number,
+    explicitCapacity: number | undefined
+): number {
+    validateAttributeLength(attributeName, initialLength, size);
+    const initialInstanceCount = initialLength / size;
+
+    if (explicitCapacity === undefined) {
+        return initialInstanceCount;
+    }
+
+    if (explicitCapacity < initialInstanceCount) {
+        throw new Error(
+            `Instance attribute "${attributeName}" capacity ${explicitCapacity} is smaller than its initial ` +
+            `data (${initialInstanceCount} instances)`
+        );
+    }
+
+    return explicitCapacity;
+}
+
+export function validateUploadLength(
+    attributeName: string,
+    length: number,
+    size: number,
+    count: number
+): void {
+    validateAttributeLength(attributeName, length, size);
+    const availableInstances = length / size;
+
+    if (availableInstances < count) {
+        throw new Error(
+            `Instance attribute "${attributeName}" provides ${availableInstances} instances but ${count} were requested`
+        );
+    }
+}
+
+export function validateCountWithinCapacity(
+    attributeName: string,
+    count: number,
+    capacity: number
+): void {
+    if (count > capacity) {
+        throw new Error(
+            `Instance count ${count} exceeds capacity ${capacity} for attribute "${attributeName}"`
+        );
+    }
+}
+
+interface AttributeState {
+    name: string;
+    attribute: InstanceAttribute;
+    usage: 'static' | 'dynamic';
+    capacity: number;
+    lastUploadedData: Float32Array | null;
+}
+
+export class InstanceUploader {
+    private readonly manager: InstanceBufferManager;
+    private readonly programId: string;
+    private readonly config: InstancingConfig;
+    private readonly states: AttributeState[] = [];
+    private initialized = false;
+
+    constructor(manager: InstanceBufferManager, programId: string, config: InstancingConfig) {
+        this.manager = manager;
+        this.programId = programId;
+        this.config = config;
+    }
+
+    initialize(): void {
+        for (const [name, attribute] of Object.entries(this.config.attributes)) {
+            const usage = attribute.usage ?? 'static';
+            const initialData = resolveAttributeData(attribute.data);
+            const capacity = deriveAttributeCapacity(name, initialData.length, attribute.size, attribute.capacity);
+
+            const allocation = usage === 'dynamic'
+                ? allocateDynamicBuffer(initialData, capacity * attribute.size)
+                : initialData;
+
+            this.manager.createBuffer(this.programId, name, allocation, usage);
+
+            this.states.push({
+                name,
+                attribute,
+                usage,
+                capacity,
+                lastUploadedData: usage === 'static' ? initialData : null
+            });
+        }
+
+        this.initialized = true;
+    }
+
+    upload(): number {
+        if (!this.initialized) {
+            throw new Error('InstanceUploader.upload called before initialize()');
+        }
+
+        const count = resolveInstanceCount(this.config.instanceCount);
+        validateInstanceCount(count);
+
+        for (const state of this.states) {
+            validateCountWithinCapacity(state.name, count, state.capacity);
+        }
+
+        if (count === 0) {
+            return 0;
+        }
+
+        for (const state of this.states) {
+            const data = resolveAttributeData(state.attribute.data);
+            validateUploadLength(state.name, data.length, state.attribute.size, count);
+
+            if (state.usage === 'dynamic') {
+                this.manager.updateBufferSub(this.programId, state.name, data, 0);
+            } else if (data !== state.lastUploadedData) {
+                this.manager.updateBuffer(this.programId, state.name, data);
+                state.lastUploadedData = data;
+            }
+        }
+
+        return count;
+    }
+}
+
+function allocateDynamicBuffer(initialData: Float32Array, allocatedLength: number): Float32Array {
+    const allocation = new Float32Array(allocatedLength);
+    allocation.set(initialData);
+    return allocation;
+}

--- a/src/core/managers/WebGLManager.test.ts
+++ b/src/core/managers/WebGLManager.test.ts
@@ -63,3 +63,103 @@ describe('WebGLManager readPixels', () => {
         expect(() => manager.readPixels(4, 4)).toThrow(/context is lost/);
     });
 });
+
+describe('WebGLManager drawArraysInstanced', () => {
+    it('uses drawArraysInstancedANGLE when ANGLE_instanced_arrays is present', () => {
+        const { canvas, calls } = createCanvasStub({ extensions: { ANGLE_instanced_arrays: true } });
+        const manager = new WebGLManager(canvas);
+
+        manager.drawArraysInstanced(1, 0, 4, 10);
+
+        const drawCalls = calls.filter(c => c.name === 'drawArraysInstancedANGLE');
+        expect(drawCalls).toHaveLength(1);
+        expect(drawCalls[0]?.args).toEqual([1, 0, 4, 10]);
+    });
+
+    it('falls back to gl.drawArraysInstanced when the extension lacks the function', () => {
+        const drawArraysInstancedCalls: [number, number, number, number][] = [];
+        const { canvas } = createCanvasStub({
+            extensions: { ANGLE_instanced_arrays: false },
+            overrides: {
+                drawArraysInstanced: (mode: number, first: number, count: number, instanceCount: number): void => {
+                    drawArraysInstancedCalls.push([mode, first, count, instanceCount]);
+                }
+            }
+        });
+        const manager = new WebGLManager(canvas);
+
+        manager.drawArraysInstanced(1, 0, 4, 10);
+
+        expect(drawArraysInstancedCalls).toHaveLength(1);
+        expect(drawArraysInstancedCalls[0]).toEqual([1, 0, 4, 10]);
+    });
+
+    it('throws when neither ANGLE_instanced_arrays nor gl.drawArraysInstanced is available', () => {
+        const { canvas } = createCanvasStub({
+            extensions: { ANGLE_instanced_arrays: false },
+            overrides: { drawArraysInstanced: undefined }
+        });
+        const manager = new WebGLManager(canvas);
+
+        expect(() => { manager.drawArraysInstanced(1, 0, 4, 10) }).toThrow(/ANGLE_instanced_arrays/);
+    });
+});
+
+describe('WebGLManager instanced buffer usage', () => {
+    it('passes DYNAMIC_DRAW to bufferData when usage is dynamic', () => {
+        const { canvas, calls } = createCanvasStub();
+        const manager = new WebGLManager(canvas);
+        manager.createProgram('a', CONFIG);
+
+        manager.createBuffer('a', 'offset', new Float32Array([1, 2, 3, 4]), 'dynamic');
+
+        const bufferDataCall = calls.find(c => c.name === 'bufferData');
+        expect(bufferDataCall?.args[2]).toBe(manager.context.DYNAMIC_DRAW);
+    });
+
+    it('passes STATIC_DRAW to bufferData by default', () => {
+        const { canvas, calls } = createCanvasStub();
+        const manager = new WebGLManager(canvas);
+        manager.createProgram('a', CONFIG);
+
+        manager.createBuffer('a', 'offset', new Float32Array([1, 2, 3, 4]));
+
+        const bufferDataCall = calls.find(c => c.name === 'bufferData');
+        expect(bufferDataCall?.args[2]).toBe(manager.context.STATIC_DRAW);
+    });
+});
+
+describe('WebGLManager updateBufferSub', () => {
+    it('calls bufferSubData (not bufferData) with the given offset', () => {
+        const { canvas, calls, reset } = createCanvasStub();
+        const manager = new WebGLManager(canvas);
+        manager.createProgram('a', CONFIG);
+        manager.createBuffer('a', 'offset', new Float32Array([0, 0, 0, 0]));
+        reset();
+
+        const update = new Float32Array([1, 2]);
+        manager.updateBufferSub('a', 'offset', update, 4);
+
+        expect(calls.some(c => c.name === 'bufferData')).toBe(false);
+        const subCall = calls.find(c => c.name === 'bufferSubData');
+        expect(subCall?.args).toEqual([manager.context.ARRAY_BUFFER, 4, update]);
+    });
+
+    it('throws when the write would exceed the allocated buffer', () => {
+        const { canvas } = createCanvasStub();
+        const manager = new WebGLManager(canvas);
+        manager.createProgram('a', CONFIG);
+        manager.createBuffer('a', 'offset', new Float32Array([0, 0, 0, 0]));
+
+        const update = new Float32Array([1, 2, 3, 4, 5]);
+        expect(() => { manager.updateBufferSub('a', 'offset', update, 4) }).toThrow(/allocated/);
+    });
+
+    it('throws when the buffer does not exist', () => {
+        const { canvas } = createCanvasStub();
+        const manager = new WebGLManager(canvas);
+        manager.createProgram('a', CONFIG);
+
+        expect(() => { manager.updateBufferSub('a', 'offset', new Float32Array([1])) }).toThrow(/not found/);
+    });
+});

--- a/src/core/managers/WebGLManager.ts
+++ b/src/core/managers/WebGLManager.ts
@@ -17,6 +17,7 @@ import type { BufferData, UniformTypeMap } from '@/types';
 declare global {
     interface WebGLRenderingContext {
         vertexAttribDivisor: ((index: number, divisor: number) => void) | undefined;
+        drawArraysInstanced: ((mode: number, first: number, count: number, instanceCount: number) => void) | undefined;
     }
 }
 
@@ -144,7 +145,12 @@ export class WebGLManager {
         return shader;
     }
 
-    createBuffer(programId: string, attributeName: string, data: Float32Array | Uint8Array | Uint16Array): WebGLBuffer {
+    createBuffer(
+        programId: string,
+        attributeName: string,
+        data: Float32Array | Uint8Array | Uint16Array,
+        usage: 'static' | 'dynamic' = 'static'
+    ): WebGLBuffer {
         const gl = this.gl;
         const resources = this.resources.get(programId);
 
@@ -152,15 +158,15 @@ export class WebGLManager {
             throw new Error(`Program with id ${programId} not found`);
         }
 
-         
+
         const buffer = gl.createBuffer() as WebGLBuffer | null;
         if (!buffer) {
             throw new Error('Failed to create buffer');
         }
         gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-        gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, data, usage === 'dynamic' ? gl.DYNAMIC_DRAW : gl.STATIC_DRAW);
 
-        resources.buffers[attributeName] = { buffer, data };
+        resources.buffers[attributeName] = { buffer, data, allocatedByteLength: data.byteLength };
         return buffer;
     }
 
@@ -180,6 +186,36 @@ export class WebGLManager {
         gl.bindBuffer(gl.ARRAY_BUFFER, bufferData.buffer);
         gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
         bufferData.data = data;
+        bufferData.allocatedByteLength = data.byteLength;
+    }
+
+    updateBufferSub(
+        programId: string,
+        attributeName: string,
+        data: Float32Array | Uint8Array | Uint16Array,
+        offset = 0
+    ): void {
+        const gl = this.gl;
+        const resources = this.resources.get(programId);
+
+        if (!resources) {
+            throw new Error(`Program with id ${programId} not found`);
+        }
+
+        const bufferData = resources.buffers[attributeName] as BufferData | undefined;
+        if (!bufferData) {
+            throw new Error(`Buffer for attribute ${attributeName} not found`);
+        }
+
+        if (offset + data.byteLength > bufferData.allocatedByteLength) {
+            throw new Error(
+                `updateBufferSub for attribute ${attributeName} would write past the allocated buffer: ` +
+                `offset ${offset} + ${data.byteLength} bytes exceeds ${bufferData.allocatedByteLength} allocated bytes`
+            );
+        }
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, bufferData.buffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, offset, data);
     }
 
    
@@ -434,6 +470,19 @@ export class WebGLManager {
 
     drawArrays(mode: number, first: number, count: number): void {
         this.gl.drawArrays(mode, first, count);
+    }
+
+    drawArraysInstanced(mode: number, first: number, count: number, instanceCount: number): void {
+        const gl = this.gl;
+        const instancedExt = this.getExtension('ANGLE_instanced_arrays');
+
+        if (instancedExt?.drawArraysInstancedANGLE) {
+            instancedExt.drawArraysInstancedANGLE(mode, first, count, instanceCount);
+        } else if (gl.drawArraysInstanced) {
+            gl.drawArraysInstanced(mode, first, count, instanceCount);
+        } else {
+            throw new Error('Instanced rendering requires ANGLE_instanced_arrays');
+        }
     }
 
     drawElements(mode: number, count: number, type: number, offset: number): void {

--- a/src/testing/glStub.ts
+++ b/src/testing/glStub.ts
@@ -189,6 +189,9 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
         ANGLE_instanced_arrays: {
             vertexAttribDivisorANGLE: (index: number, divisor: number): void => {
                 record('vertexAttribDivisorANGLE', [index, divisor]);
+            },
+            drawArraysInstancedANGLE: (mode: number, first: number, count: number, primcount: number): void => {
+                record('drawArraysInstancedANGLE', [mode, first, count, primcount]);
             }
         },
         WEBGL_lose_context: {
@@ -397,6 +400,9 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
         },
         bufferData: (target: number, data: ArrayBufferView, usage: number): void => {
             record('bufferData', [target, data, usage]);
+        },
+        bufferSubData: (target: number, offset: number, data: ArrayBufferView): void => {
+            record('bufferSubData', [target, offset, data]);
         },
         drawArrays: (mode: number, first: number, count: number): void => {
             record('drawArrays', [mode, first, count]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,13 @@
 
 export interface BufferData {
   buffer: WebGLBuffer;
-  data: 
-    Float32Array 
-    | Uint8Array 
-    | Uint16Array 
-    | Int8Array 
+  data:
+    Float32Array
+    | Uint8Array
+    | Uint16Array
+    | Int8Array
     | Int16Array;
+  allocatedByteLength: number;
 }
 
 export type UniformType = 
@@ -55,6 +56,19 @@ export interface AttributeConfig {
   stride: number;
   offset: number;
   instanced?: boolean;
+}
+
+export interface InstanceAttribute {
+  data: Float32Array | (() => Float32Array);
+  size: number;
+  usage?: 'static' | 'dynamic';
+  normalized?: boolean;
+  capacity?: number;
+}
+
+export interface InstancingConfig {
+  instanceCount: number | (() => number);
+  attributes: Record<string, InstanceAttribute>;
 }
 
 export interface ShaderResources {


### PR DESCRIPTION
First slice of the instancing track (plan: worker-instancing, PR I1 of I1→I2→I3).

## What

- **`WebGLManager.drawArraysInstanced(mode, first, count, instanceCount)`** — dispatches to `ANGLE_instanced_arrays.drawArraysInstancedANGLE` (cached ext), falls back to a native `gl.drawArraysInstanced` when present, throws `'Instanced rendering requires ANGLE_instanced_arrays'` otherwise. No silent N-draw fallback: emulating instancing with N draws is a 10–100x perf cliff masquerading as success.
- **Buffer usage hints** — `createBuffer` gains optional `usage: 'static' | 'dynamic'` (default `'static'`, backward compatible) mapping to `STATIC_DRAW`/`DYNAMIC_DRAW`.
- **`updateBufferSub`** — `bufferSubData` path for per-frame dynamic instance data (no realloc). `BufferData` now tracks `allocatedByteLength`; a sub-write past the allocation throws instead of leaving a silent GL `INVALID_VALUE`.
- **`InstanceUploader`** (`src/core/lib/instanceBuffers.ts`) — `initialize()` creates per-attribute buffers sized to capacity; `upload()` resolves live `instanceCount`/data (number or function), validates fail-loud (non-integer/negative/NaN count, count > capacity, `length % size !== 0`, `length < count*size` all throw), uploads `dynamic` attributes every call via `bufferSubData`, re-uploads `static` ones only on array identity change, returns the resolved count (0 = caller skips the draw).
- **New public types** `InstanceAttribute` / `InstancingConfig` in `src/types.ts`, re-exported from `micugl/core`.

React component (`BaseInstancedShaderComponent` + `ShaderEngine.instancing`) lands in I2; demo + bench comparison in I3.

## Review

Adversarial review confirmed and fixed one bug pre-PR: `upload()` didn't validate the resolved live count, so a callback returning `NaN`/`-1`/`2.5` silently corrupted the draw call — now throws before any upload.

## Tests

430 vitest (+45): 12 new `WebGLManager` tests (ext dispatch/fallback/throw, usage mapping, `bufferSubData` semantics + overflow/missing-buffer throws), 33 `instanceBuffers` tests (validators in isolation + uploader behavior incl. static identity dirty-check, dynamic every-call, count-0 short-circuit, capacity derivation). Full gate suite green (typecheck, lint, test, build incl. treeshake guard).