### PR TITLE
worker: W1 protocol + main-side WorkerBridge - typed messages, value-diff posting, fail-loud uniform boundary

### DIFF
--- a/src/worker/WorkerBridge.test.ts
+++ b/src/worker/WorkerBridge.test.ts
@@ -1,0 +1,603 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { vec2, vec3 } from '@/core';
+import type { InstancingConfig, RenderPass, ShaderProgramConfig } from '@/types';
+import type { MainToWorker, WorkerToMain } from '@/worker/protocol';
+import type {
+    WorkerBridgeCallbacks,
+    WorkerBridgeInit,
+    WorkerBridgeMessageEvent,
+    WorkerTransport
+} from '@/worker/WorkerBridge';
+import { WorkerBridge } from '@/worker/WorkerBridge';
+
+const FAKE_CANVAS = {} as unknown as OffscreenCanvas;
+
+const CONFIG: ShaderProgramConfig = {
+    vertexShader: '',
+    fragmentShader: '',
+    uniforms: []
+};
+
+function createFakeTransport(): {
+    transport: WorkerTransport;
+    postMessage: ReturnType<typeof vi.fn>;
+    terminate: ReturnType<typeof vi.fn>;
+    emit: (message: WorkerToMain) => void;
+    listenerCount: () => number;
+    } {
+    const postMessage = vi.fn();
+    const terminate = vi.fn();
+    const listeners: ((event: WorkerBridgeMessageEvent<WorkerToMain>) => void)[] = [];
+
+    const transport: WorkerTransport = {
+        postMessage: (message: MainToWorker, transfer?: Transferable[]) => {
+            postMessage(message, transfer);
+        },
+        addEventListener: (_type, listener) => {
+            listeners.push(listener);
+        },
+        removeEventListener: (_type, listener) => {
+            const index = listeners.indexOf(listener);
+            if (index !== -1) {
+                listeners.splice(index, 1);
+            }
+        },
+        terminate
+    };
+
+    return {
+        transport,
+        postMessage,
+        terminate,
+        emit: message => {
+            listeners.forEach(listener => { listener({ data: message }) });
+        },
+        listenerCount: () => listeners.length
+    };
+}
+
+function baseInit(overrides: Partial<WorkerBridgeInit> = {}): WorkerBridgeInit {
+    return {
+        canvas: FAKE_CANVAS,
+        kind: 'single',
+        programConfigs: { main: CONFIG },
+        uniforms: { main: {} },
+        frameloop: 'always',
+        speed: 1,
+        ...overrides
+    };
+}
+
+function pingPongInit(passes: RenderPass[], overrides: Partial<WorkerBridgeInit> = {}): WorkerBridgeInit {
+    return baseInit({
+        kind: 'pingpong',
+        programConfigs: { main: CONFIG, blur: CONFIG },
+        uniforms: { main: {}, blur: {} },
+        passes,
+        ...overrides
+    });
+}
+
+function emitReady(fake: ReturnType<typeof createFakeTransport>): void {
+    fake.emit({ type: 'ready', capabilities: { maxTextureSize: 4096, extensions: [] } });
+}
+
+function initMessage(fake: ReturnType<typeof createFakeTransport>): Extract<MainToWorker, { type: 'init' }> {
+    const [message] = fake.postMessage.mock.calls[0] as [MainToWorker];
+    if (message.type !== 'init') {
+        throw new Error('expected init message');
+    }
+    return message;
+}
+
+describe('WorkerBridge init assembly', () => {
+    it('posts an init message transferring the canvas', () => {
+        const fake = createFakeTransport();
+        new WorkerBridge(fake.transport, baseInit());
+
+        expect(fake.postMessage).toHaveBeenCalledTimes(1);
+        const [message, transfer] = fake.postMessage.mock.calls[0] as [MainToWorker, Transferable[]];
+        expect(message.type).toBe('init');
+        expect(transfer).toEqual([FAKE_CANVAS]);
+    });
+
+    it('builds descriptors and initial values from value uniforms', () => {
+        const fake = createFakeTransport();
+        new WorkerBridge(fake.transport, baseInit({
+            uniforms: {
+                main: {
+                    u_intensity: { type: 'float', value: 0.5 },
+                    u_palette: { type: 'vec3', value: vec3([1, 0, 0]) }
+                }
+            }
+        }));
+
+        const [message] = fake.postMessage.mock.calls[0] as [MainToWorker];
+        if (message.type !== 'init') {
+            throw new Error('expected init message');
+        }
+        expect(message.config.descriptors.main).toEqual([
+            { name: 'u_intensity', type: 'float' },
+            { name: 'u_palette', type: 'vec3' }
+        ]);
+        expect(message.config.initialValues.main).toEqual({
+            u_intensity: 0.5,
+            u_palette: [1, 0, 0]
+        });
+    });
+});
+
+describe('WorkerBridge fail-loud boundary', () => {
+    it('throws naming the uniform and program for a non-built-in function uniform', () => {
+        const fake = createFakeTransport();
+        expect(() => new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_mouse: { type: 'vec2', value: () => vec2([0, 0]) } } }
+        }))).toThrow(/u_mouse/);
+        expect(() => new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_mouse: { type: 'vec2', value: () => vec2([0, 0]) } } }
+        }))).toThrow(/main/);
+        expect(() => new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_mouse: { type: 'vec2', value: () => vec2([0, 0]) } } }
+        }))).toThrow(/liveUniforms/);
+    });
+
+    it('does not throw for a function uniform listed in liveUniforms', () => {
+        const fake = createFakeTransport();
+        expect(() => new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_mouse: { type: 'vec2', value: () => vec2([0, 0]) } } },
+            liveUniforms: { main: ['u_mouse'] }
+        }))).not.toThrow();
+    });
+
+    it('does not throw for a function-valued built-in uniform (u_time / u_resolution)', () => {
+        const fake = createFakeTransport();
+        expect(() => new WorkerBridge(fake.transport, baseInit({
+            uniforms: {
+                main: {
+                    u_time: { type: 'float', value: (time?: number) => (time ?? 0) * 0.001 },
+                    u_resolution: { type: 'vec2', value: () => vec2([1, 1]) }
+                }
+            }
+        }))).not.toThrow();
+    });
+
+    it('throws for a non-clone-safe non-function uniform value', () => {
+        const fake = createFakeTransport();
+        expect(() => new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_bad: { type: 'float', value: { nope: true } as unknown as number } } }
+        }))).toThrow(/u_bad/);
+    });
+
+    it('throws naming the uniform, the pass, and the program for a non-built-in function pass uniform', () => {
+        const passes: RenderPass[] = [
+            { programId: 'main', inputTextures: [] },
+            {
+                programId: 'blur',
+                inputTextures: [],
+                uniforms: { u_amount: { type: 'float', value: () => 1 } }
+            }
+        ];
+        const build = (): WorkerBridge => new WorkerBridge(createFakeTransport().transport, pingPongInit(passes));
+
+        expect(build).toThrow(/u_amount/);
+        expect(build).toThrow(/pass 1/);
+        expect(build).toThrow(/blur/);
+    });
+
+    it('still throws for a function pass uniform listed in liveUniforms, explaining why', () => {
+        const passes: RenderPass[] = [{
+            programId: 'blur',
+            inputTextures: [],
+            uniforms: { u_mouse: { type: 'vec2', value: () => vec2([0, 0]) } }
+        }];
+        const build = (): WorkerBridge => new WorkerBridge(
+            createFakeTransport().transport,
+            pingPongInit(passes, { liveUniforms: { blur: ['u_mouse'] } })
+        );
+
+        expect(build).toThrow(/u_mouse/);
+        expect(build).toThrow(/liveUniforms/);
+        expect(build).toThrow(/does not cover pass uniforms/);
+    });
+
+    it('does not throw for a function-valued built-in pass uniform, marking it worker-computed', () => {
+        const fake = createFakeTransport();
+        const passes: RenderPass[] = [{
+            programId: 'blur',
+            inputTextures: [],
+            uniforms: {
+                u_time: { type: 'float', value: (time: number) => time * 0.001 },
+                u_resolution: {
+                    type: 'vec2',
+                    value: (_time: number, width: number, height: number) => vec2([width, height])
+                },
+                u_color: { type: 'vec3', value: vec3([1, 0, 0]) }
+            }
+        }];
+
+        expect(() => new WorkerBridge(fake.transport, pingPongInit(passes))).not.toThrow();
+
+        expect(initMessage(fake).config.passes?.[0].uniforms).toEqual({
+            u_time: { kind: 'builtin', type: 'float' },
+            u_resolution: { kind: 'builtin', type: 'vec2' },
+            u_color: { kind: 'value', type: 'vec3', value: [1, 0, 0] }
+        });
+    });
+
+    it('throws for a non-clone-safe non-function pass uniform value', () => {
+        const passes: RenderPass[] = [{
+            programId: 'blur',
+            inputTextures: [],
+            uniforms: { u_bad: { type: 'float', value: { nope: true } as unknown as number } }
+        }];
+
+        expect(() => new WorkerBridge(createFakeTransport().transport, pingPongInit(passes)))
+            .toThrow(/u_bad/);
+    });
+
+    it('throws naming instancing when an instancing config is present in worker mode', () => {
+        const fake = createFakeTransport();
+        const instancing: InstancingConfig = {
+            instanceCount: 10,
+            attributes: {}
+        };
+        expect(() => new WorkerBridge(fake.transport, baseInit({ instancing })))
+            .toThrow(/instancing/);
+    });
+});
+
+describe('WorkerBridge value-diff posting', () => {
+    it('posts setUniformValues only for uniforms that actually changed', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit({
+            uniforms: {
+                main: {
+                    u_a: { type: 'float', value: 1 },
+                    u_b: { type: 'vec3', value: vec3([0, 0, 0]) }
+                }
+            }
+        }));
+        fake.postMessage.mockClear();
+
+        bridge.setUniformValues('main', { u_a: 1, u_b: [0, 0, 0] });
+        expect(fake.postMessage).not.toHaveBeenCalled();
+
+        bridge.setUniformValues('main', { u_a: 2, u_b: [0, 0, 0] });
+        expect(fake.postMessage).toHaveBeenCalledTimes(1);
+        expect(fake.postMessage).toHaveBeenCalledWith(
+            { type: 'setUniformValues', programId: 'main', values: { u_a: 2 } },
+            undefined
+        );
+
+        fake.postMessage.mockClear();
+        bridge.setUniformValues('main', { u_a: 2 });
+        expect(fake.postMessage).not.toHaveBeenCalled();
+
+        bridge.setUniformValues('main', { u_b: [1, 0, 0] });
+        expect(fake.postMessage).toHaveBeenCalledWith(
+            { type: 'setUniformValues', programId: 'main', values: { u_b: [1, 0, 0] } },
+            undefined
+        );
+    });
+
+    it('posts a change made by mutating the caller array in place', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_b: { type: 'vec3', value: vec3([0, 0, 0]) } } }
+        }));
+        fake.postMessage.mockClear();
+
+        const live = [0, 0, 0];
+        bridge.setUniformValues('main', { u_b: live });
+        expect(fake.postMessage).not.toHaveBeenCalled();
+
+        live[0] = 1;
+        bridge.setUniformValues('main', { u_b: live });
+
+        expect(fake.postMessage).toHaveBeenCalledTimes(1);
+        expect(fake.postMessage).toHaveBeenCalledWith(
+            { type: 'setUniformValues', programId: 'main', values: { u_b: [1, 0, 0] } },
+            undefined
+        );
+    });
+
+    it('does not re-post an unchanged NaN value', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_a: { type: 'float', value: 0 } } }
+        }));
+        fake.postMessage.mockClear();
+
+        bridge.setUniformValues('main', { u_a: Number.NaN });
+        expect(fake.postMessage).toHaveBeenCalledTimes(1);
+
+        bridge.setUniformValues('main', { u_a: Number.NaN });
+        expect(fake.postMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('normalizes typed array values and throws on non-clone-safe values', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_b: { type: 'vec3', value: vec3([0, 0, 0]) } } }
+        }));
+        fake.postMessage.mockClear();
+
+        bridge.setUniformValues('main', { u_b: new Float32Array([1, 2, 3]) });
+        expect(fake.postMessage).toHaveBeenCalledWith(
+            { type: 'setUniformValues', programId: 'main', values: { u_b: [1, 2, 3] } },
+            undefined
+        );
+
+        expect(() => { bridge.setUniformValues('main', { u_b: (() => 1) as unknown as number }) })
+            .toThrow(/u_b/);
+    });
+});
+
+describe('WorkerBridge setPasses', () => {
+    it('posts serialized passes, applying the same built-in exemption and fail-loud rules', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, pingPongInit([{ programId: 'main', inputTextures: [] }]));
+        fake.postMessage.mockClear();
+
+        bridge.setPasses([{
+            programId: 'blur',
+            inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+            outputFramebuffer: null,
+            uniforms: {
+                u_time: { type: 'float', value: (time: number) => time },
+                u_amount: { type: 'float', value: 0.25 }
+            }
+        }]);
+
+        expect(fake.postMessage).toHaveBeenCalledWith({
+            type: 'setPasses',
+            passes: [{
+                programId: 'blur',
+                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+                outputFramebuffer: null,
+                uniforms: {
+                    u_time: { kind: 'builtin', type: 'float' },
+                    u_amount: { kind: 'value', type: 'float', value: 0.25 }
+                },
+                renderOptions: undefined
+            }]
+        }, undefined);
+
+        expect(() => {
+            bridge.setPasses([{
+                programId: 'blur',
+                inputTextures: [],
+                uniforms: { u_amount: { type: 'float', value: () => 1 } }
+            }]);
+        }).toThrow(/u_amount/);
+    });
+});
+
+describe('WorkerBridge invalidate coalescing', () => {
+    it('collapses synchronous invalidate calls into one message using the max frames', async () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.invalidate();
+        bridge.invalidate(3);
+        bridge.invalidate(2);
+
+        expect(fake.postMessage).not.toHaveBeenCalled();
+        await Promise.resolve();
+
+        expect(fake.postMessage).toHaveBeenCalledTimes(1);
+        expect(fake.postMessage).toHaveBeenCalledWith({ type: 'invalidate', frames: 3 }, undefined);
+    });
+
+    it('throws instead of posting a garbage frame count across the boundary', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        expect(() => { bridge.invalidate(0) }).toThrow(/positive integer/);
+        expect(() => { bridge.invalidate(-1) }).toThrow(/positive integer/);
+        expect(() => { bridge.invalidate(1.5) }).toThrow(/positive integer/);
+        expect(() => { bridge.invalidate(Number.NaN) }).toThrow(/positive integer/);
+        expect(fake.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('starts a fresh coalescing window after a flush', async () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.invalidate(1);
+        await Promise.resolve();
+        expect(fake.postMessage).toHaveBeenCalledTimes(1);
+
+        bridge.invalidate(5);
+        await Promise.resolve();
+        expect(fake.postMessage).toHaveBeenCalledTimes(2);
+        expect(fake.postMessage).toHaveBeenLastCalledWith({ type: 'invalidate', frames: 5 }, undefined);
+    });
+});
+
+describe('WorkerBridge resize queueing', () => {
+    it('queues resizes last-wins before ready and flushes exactly one on ready', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.resize(100, 200);
+        bridge.resize(50, 60);
+        expect(fake.postMessage).not.toHaveBeenCalled();
+
+        emitReady(fake);
+
+        const resizeCalls = fake.postMessage.mock.calls.filter(
+            call => (call[0] as MainToWorker).type === 'resize'
+        );
+        expect(resizeCalls).toHaveLength(1);
+        expect(resizeCalls[0][0]).toEqual({ type: 'resize', renderWidth: 50, renderHeight: 60 });
+    });
+
+    it('does not post a resize on ready when none was queued', () => {
+        const fake = createFakeTransport();
+        new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        emitReady(fake);
+
+        expect(fake.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('posts resizes immediately after ready', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        emitReady(fake);
+        fake.postMessage.mockClear();
+
+        bridge.resize(10, 20);
+
+        expect(fake.postMessage).toHaveBeenCalledWith({ type: 'resize', renderWidth: 10, renderHeight: 20 }, undefined);
+    });
+});
+
+describe('WorkerBridge active gating', () => {
+    it('sends the initial active state in the init config so the dedupe is not an assumption', () => {
+        const activeFake = createFakeTransport();
+        new WorkerBridge(activeFake.transport, baseInit());
+        expect(initMessage(activeFake).config.active).toBe(true);
+
+        const hiddenFake = createFakeTransport();
+        const hidden = new WorkerBridge(hiddenFake.transport, baseInit({ active: false }));
+        expect(initMessage(hiddenFake).config.active).toBe(false);
+
+        hiddenFake.postMessage.mockClear();
+        hidden.setActive(false);
+        expect(hiddenFake.postMessage).not.toHaveBeenCalled();
+
+        hidden.setActive(true);
+        expect(hiddenFake.postMessage).toHaveBeenCalledWith({ type: 'setActive', active: true }, undefined);
+    });
+
+    it('only posts setActive when the value actually changes from the default (active)', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.setActive(true);
+        expect(fake.postMessage).not.toHaveBeenCalled();
+
+        bridge.setActive(false);
+        expect(fake.postMessage).toHaveBeenCalledWith({ type: 'setActive', active: false }, undefined);
+
+        fake.postMessage.mockClear();
+        bridge.setActive(false);
+        expect(fake.postMessage).not.toHaveBeenCalled();
+
+        bridge.setActive(true);
+        expect(fake.postMessage).toHaveBeenCalledWith({ type: 'setActive', active: true }, undefined);
+    });
+});
+
+describe('WorkerBridge lifecycle passthroughs', () => {
+    it('forwards setFrameloop, setSpeed, and renderFrame immediately', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.setFrameloop('demand');
+        bridge.setSpeed(2);
+        bridge.renderFrame(123);
+
+        expect(fake.postMessage).toHaveBeenNthCalledWith(1, { type: 'setFrameloop', mode: 'demand' }, undefined);
+        expect(fake.postMessage).toHaveBeenNthCalledWith(2, { type: 'setSpeed', speed: 2 }, undefined);
+        expect(fake.postMessage).toHaveBeenNthCalledWith(3, { type: 'renderFrame', time: 123 }, undefined);
+    });
+});
+
+describe('WorkerBridge dispose', () => {
+    it('posts dispose, detaches the listener, terminates the transport, and becomes inert', async () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        expect(fake.listenerCount()).toBe(1);
+        fake.postMessage.mockClear();
+
+        bridge.dispose();
+
+        expect(fake.postMessage).toHaveBeenCalledWith({ type: 'dispose' }, undefined);
+        expect(fake.terminate).toHaveBeenCalledTimes(1);
+        expect(fake.listenerCount()).toBe(0);
+
+        fake.postMessage.mockClear();
+        bridge.setActive(false);
+        bridge.setFrameloop('never');
+        bridge.setSpeed(0);
+        bridge.renderFrame(1);
+        bridge.resize(1, 1);
+        bridge.invalidate();
+        await Promise.resolve();
+        bridge.setUniformValues('main', { u_a: 1 });
+        bridge.dispose();
+
+        expect(fake.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not flush an invalidate microtask scheduled before dispose', async () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.invalidate(2);
+        bridge.dispose();
+        fake.postMessage.mockClear();
+        await Promise.resolve();
+
+        expect(fake.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('drops a resize queued before ready when disposed first', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+
+        bridge.resize(10, 20);
+        bridge.dispose();
+        fake.postMessage.mockClear();
+        emitReady(fake);
+
+        expect(fake.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores inbound messages received after dispose', () => {
+        const fake = createFakeTransport();
+        const onReady = vi.fn();
+        const callbacks: WorkerBridgeCallbacks = { onReady };
+        const bridge = new WorkerBridge(fake.transport, baseInit(), callbacks);
+
+        bridge.dispose();
+        emitReady(fake);
+
+        expect(onReady).not.toHaveBeenCalled();
+    });
+});
+
+describe('WorkerBridge inbound message callbacks', () => {
+    it('surfaces ready, contextlost, contextrestored, and error to injected callbacks', () => {
+        const fake = createFakeTransport();
+        const onReady = vi.fn();
+        const onContextLost = vi.fn();
+        const onContextRestored = vi.fn();
+        const onError = vi.fn();
+        new WorkerBridge(fake.transport, baseInit(), { onReady, onContextLost, onContextRestored, onError });
+
+        emitReady(fake);
+        expect(onReady).toHaveBeenCalledWith({ maxTextureSize: 4096, extensions: [] });
+
+        fake.emit({ type: 'contextlost' });
+        expect(onContextLost).toHaveBeenCalledTimes(1);
+
+        fake.emit({ type: 'contextrestored' });
+        expect(onContextRestored).toHaveBeenCalledTimes(1);
+
+        fake.emit({ type: 'error', message: 'program link failed' });
+        expect(onError).toHaveBeenCalledWith('program link failed');
+    });
+});

--- a/src/worker/WorkerBridge.ts
+++ b/src/worker/WorkerBridge.ts
@@ -1,0 +1,371 @@
+import type {
+    FramebufferOptions,
+    Frameloop,
+    InstancingConfig,
+    RenderPass,
+    ShaderProgramConfig,
+    UniformParam
+} from '@/types';
+import type {
+    MainToWorker,
+    SerializableRenderPass,
+    SerializableRenderPassUniform,
+    UniformDescriptor,
+    UniformScalar,
+    UniformValueMap,
+    UniformVector,
+    WorkerCapabilities,
+    WorkerInitConfig,
+    WorkerToMain
+} from '@/worker/protocol';
+import {
+    isWorkerBuiltinUniformName,
+    normalizeCloneSafeUniformValue,
+    uniformValuesEqual,
+    WORKER_BUILTIN_UNIFORM_NAMES
+} from '@/worker/protocol';
+
+export interface WorkerBridgeMessageEvent<T> {
+    data: T;
+}
+
+export interface WorkerTransport {
+    postMessage: (message: MainToWorker, transfer?: Transferable[]) => void;
+    addEventListener: (
+        type: 'message',
+        listener: (event: WorkerBridgeMessageEvent<WorkerToMain>) => void
+    ) => void;
+    removeEventListener?: (
+        type: 'message',
+        listener: (event: WorkerBridgeMessageEvent<WorkerToMain>) => void
+    ) => void;
+    terminate?: () => void;
+}
+
+export interface WorkerBridgeCallbacks {
+    onReady?: (capabilities: WorkerCapabilities) => void;
+    onContextLost?: () => void;
+    onContextRestored?: () => void;
+    onError?: (message: string) => void;
+}
+
+export type WorkerBridgeProgramUniforms = Record<string, UniformParam>;
+
+export interface WorkerBridgeInit {
+    canvas: OffscreenCanvas;
+    kind: 'single' | 'pingpong';
+    programConfigs: Record<string, ShaderProgramConfig>;
+    uniforms: Record<string, WorkerBridgeProgramUniforms>;
+    passes?: RenderPass[];
+    framebuffers?: Record<string, FramebufferOptions>;
+    frameloop: Frameloop;
+    speed: number;
+    active?: boolean;
+    contextAttributes?: WebGLContextAttributes;
+    liveUniforms?: Record<string, string[]>;
+    instancing?: InstancingConfig;
+}
+
+function isLiveUniformName(
+    liveUniforms: Record<string, string[]> | undefined,
+    programId: string,
+    name: string
+): boolean {
+    return liveUniforms?.[programId]?.includes(name) ?? false;
+}
+
+function functionUniformErrorMessage(programId: string, name: string): string {
+    return `micugl worker: uniform "${name}" on program "${programId}" is a function and cannot be `
+        + 'sent to a worker. Either give it a plain value (number, number[], or typed array) so it is '
+        + `posted on change, or list "${name}" in the "liveUniforms" prop for program "${programId}" `
+        + 'to have it evaluated on the main thread each frame.';
+}
+
+function notCloneSafeErrorMessage(programId: string, name: string): string {
+    return `micugl worker: uniform "${name}" on program "${programId}" is not structured-clone-safe. `
+        + 'Worker-mode uniform values must be a number, a number[], or a typed array.';
+}
+
+function passLabel(programId: string, passIndex: number): string {
+    return `pass ${String(passIndex)} (program "${programId}")`;
+}
+
+function passUniformFunctionErrorMessage(programId: string, passIndex: number, name: string): string {
+    const builtins = WORKER_BUILTIN_UNIFORM_NAMES.join(', ');
+    return `micugl worker: pass uniform "${name}" on ${passLabel(programId, passIndex)} is a function and `
+        + `cannot be sent to a worker. Only the worker-side built-ins (${builtins}) may be functions in a `
+        + 'render pass, because the worker computes them itself from the frame time and canvas size. The '
+        + `"liveUniforms" escape hatch does not cover pass uniforms in v1: per-frame overriding of pass `
+        + `uniform values is not plumbed through the worker, so listing "${name}" there would silently do `
+        + `nothing. Give "${name}" a plain value (number, number[], or typed array) instead, or turn off `
+        + 'worker mode for this component.';
+}
+
+function passUniformNotCloneSafeErrorMessage(programId: string, passIndex: number, name: string): string {
+    return `micugl worker: pass uniform "${name}" on ${passLabel(programId, passIndex)} is not `
+        + 'structured-clone-safe. Render-pass uniform values must be a number, a number[], or a typed array.';
+}
+
+function buildProgramDescriptorsAndInitialValues(
+    programId: string,
+    uniforms: WorkerBridgeProgramUniforms,
+    liveUniforms: Record<string, string[]> | undefined
+): { descriptors: UniformDescriptor[]; initialValues: UniformValueMap } {
+    const descriptors: UniformDescriptor[] = [];
+    const initialValues: UniformValueMap = {};
+
+    for (const [name, param] of Object.entries(uniforms)) {
+        descriptors.push({ name, type: param.type });
+
+        if (typeof param.value === 'function') {
+            if (isWorkerBuiltinUniformName(name) || isLiveUniformName(liveUniforms, programId, name)) {
+                continue;
+            }
+            throw new Error(functionUniformErrorMessage(programId, name));
+        }
+
+        const normalized = normalizeCloneSafeUniformValue(param.value);
+        if (normalized === null) {
+            throw new Error(notCloneSafeErrorMessage(programId, name));
+        }
+        initialValues[name] = normalized;
+    }
+
+    return { descriptors, initialValues };
+}
+
+function buildSerializablePass(pass: RenderPass, passIndex: number): SerializableRenderPass {
+    let uniforms: Record<string, SerializableRenderPassUniform> | undefined;
+
+    if (pass.uniforms) {
+        uniforms = {};
+        for (const [name, param] of Object.entries(pass.uniforms)) {
+            if (typeof param.value === 'function') {
+                if (!isWorkerBuiltinUniformName(name)) {
+                    throw new Error(passUniformFunctionErrorMessage(pass.programId, passIndex, name));
+                }
+                uniforms[name] = { kind: 'builtin', type: param.type };
+                continue;
+            }
+            const normalized = normalizeCloneSafeUniformValue(param.value);
+            if (normalized === null) {
+                throw new Error(passUniformNotCloneSafeErrorMessage(pass.programId, passIndex, name));
+            }
+            uniforms[name] = { kind: 'value', type: param.type, value: normalized };
+        }
+    }
+
+    return {
+        programId: pass.programId,
+        inputTextures: pass.inputTextures,
+        outputFramebuffer: pass.outputFramebuffer,
+        uniforms,
+        renderOptions: pass.renderOptions
+    };
+}
+
+export class WorkerBridge {
+    private readonly transport: WorkerTransport;
+    private readonly callbacks: WorkerBridgeCallbacks;
+    private readonly handleMessage = (event: WorkerBridgeMessageEvent<WorkerToMain>): void => {
+        this.onMessage(event.data);
+    };
+
+    private disposed = false;
+    private ready = false;
+    private lastActive: boolean;
+    private pendingResize: { renderWidth: number; renderHeight: number } | null = null;
+    private pendingInvalidateFrames: number | null = null;
+    private invalidateScheduled = false;
+    private readonly lastPostedValues = new Map<string, UniformValueMap>();
+
+    constructor(transport: WorkerTransport, init: WorkerBridgeInit, callbacks: WorkerBridgeCallbacks = {}) {
+        this.transport = transport;
+        this.callbacks = callbacks;
+        this.lastActive = init.active ?? true;
+
+        if (init.instancing !== undefined) {
+            throw new Error(
+                'micugl worker: "instancing" is not supported in worker mode (v1). '
+                + 'Remove the "instancing" prop or disable "worker" mode on this component.'
+            );
+        }
+
+        const descriptors: Record<string, UniformDescriptor[]> = {};
+        const initialValues: Record<string, UniformValueMap> = {};
+
+        for (const [programId, uniforms] of Object.entries(init.uniforms)) {
+            const built = buildProgramDescriptorsAndInitialValues(programId, uniforms, init.liveUniforms);
+            descriptors[programId] = built.descriptors;
+            initialValues[programId] = built.initialValues;
+            this.lastPostedValues.set(programId, { ...built.initialValues });
+        }
+
+        const passes = init.passes?.map(buildSerializablePass);
+
+        const config: WorkerInitConfig = {
+            programConfigs: init.programConfigs,
+            kind: init.kind,
+            passes,
+            framebuffers: init.framebuffers,
+            initialValues,
+            descriptors,
+            frameloop: init.frameloop,
+            speed: init.speed,
+            active: this.lastActive,
+            contextAttributes: init.contextAttributes
+        };
+
+        this.transport.addEventListener('message', this.handleMessage);
+        this.transport.postMessage({ type: 'init', canvas: init.canvas, config }, [init.canvas]);
+    }
+
+    private post(message: MainToWorker): void {
+        this.transport.postMessage(message);
+    }
+
+    private onMessage(message: WorkerToMain): void {
+        if (this.disposed) {
+            return;
+        }
+        switch (message.type) {
+            case 'ready':
+                this.ready = true;
+                if (this.pendingResize) {
+                    this.post({ type: 'resize', ...this.pendingResize });
+                    this.pendingResize = null;
+                }
+                this.callbacks.onReady?.(message.capabilities);
+                break;
+            case 'contextlost':
+                this.callbacks.onContextLost?.();
+                break;
+            case 'contextrestored':
+                this.callbacks.onContextRestored?.();
+                break;
+            case 'error':
+                this.callbacks.onError?.(message.message);
+                break;
+        }
+    }
+
+    setUniformValues(programId: string, values: Record<string, UniformScalar | UniformVector | ArrayBufferView>): void {
+        if (this.disposed) {
+            return;
+        }
+
+        const last = this.lastPostedValues.get(programId) ?? {};
+        const diff: UniformValueMap = {};
+
+        for (const [name, rawValue] of Object.entries(values)) {
+            const normalized = normalizeCloneSafeUniformValue(rawValue);
+            if (normalized === null) {
+                throw new Error(notCloneSafeErrorMessage(programId, name));
+            }
+            if (!uniformValuesEqual(last[name], normalized)) {
+                diff[name] = normalized;
+            }
+        }
+
+        if (Object.keys(diff).length === 0) {
+            return;
+        }
+
+        this.lastPostedValues.set(programId, { ...last, ...diff });
+        this.post({ type: 'setUniformValues', programId, values: diff });
+    }
+
+    setPasses(passes: RenderPass[]): void {
+        if (this.disposed) {
+            return;
+        }
+        this.post({ type: 'setPasses', passes: passes.map(buildSerializablePass) });
+    }
+
+    resize(renderWidth: number, renderHeight: number): void {
+        if (this.disposed) {
+            return;
+        }
+        if (!this.ready) {
+            this.pendingResize = { renderWidth, renderHeight };
+            return;
+        }
+        this.post({ type: 'resize', renderWidth, renderHeight });
+    }
+
+    setActive(active: boolean): void {
+        if (this.disposed) {
+            return;
+        }
+        if (active === this.lastActive) {
+            return;
+        }
+        this.lastActive = active;
+        this.post({ type: 'setActive', active });
+    }
+
+    invalidate(frames?: number): void {
+        if (this.disposed) {
+            return;
+        }
+
+        const requested = frames ?? 1;
+        if (!Number.isInteger(requested) || requested < 1) {
+            throw new Error(
+                'micugl worker: invalidate(frames) requires a positive integer number of frames, received '
+                + String(frames)
+            );
+        }
+        this.pendingInvalidateFrames = Math.max(this.pendingInvalidateFrames ?? 0, requested);
+
+        if (this.invalidateScheduled) {
+            return;
+        }
+        this.invalidateScheduled = true;
+
+        queueMicrotask(() => {
+            this.invalidateScheduled = false;
+            const framesToSend = this.pendingInvalidateFrames;
+            this.pendingInvalidateFrames = null;
+            if (framesToSend === null || this.disposed) {
+                return;
+            }
+            this.post({ type: 'invalidate', frames: framesToSend });
+        });
+    }
+
+    setFrameloop(mode: Frameloop): void {
+        if (this.disposed) {
+            return;
+        }
+        this.post({ type: 'setFrameloop', mode });
+    }
+
+    setSpeed(speed: number): void {
+        if (this.disposed) {
+            return;
+        }
+        this.post({ type: 'setSpeed', speed });
+    }
+
+    renderFrame(time: number): void {
+        if (this.disposed) {
+            return;
+        }
+        this.post({ type: 'renderFrame', time });
+    }
+
+    dispose(): void {
+        if (this.disposed) {
+            return;
+        }
+        this.disposed = true;
+        this.post({ type: 'dispose' });
+        if (this.transport.removeEventListener) {
+            this.transport.removeEventListener('message', this.handleMessage);
+        }
+        if (this.transport.terminate) {
+            this.transport.terminate();
+        }
+    }
+}

--- a/src/worker/protocol.test.ts
+++ b/src/worker/protocol.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    isWorkerBuiltinUniformName,
+    MAIN_TO_WORKER_MESSAGE_TYPES,
+    normalizeCloneSafeUniformValue,
+    uniformValuesEqual,
+    WORKER_BUILTIN_UNIFORM_NAMES,
+    WORKER_TO_MAIN_MESSAGE_TYPES
+} from '@/worker/protocol';
+
+describe('WORKER_BUILTIN_UNIFORM_NAMES / isWorkerBuiltinUniformName', () => {
+    it('recognizes u_time and u_resolution and nothing else', () => {
+        expect(WORKER_BUILTIN_UNIFORM_NAMES).toEqual(['u_time', 'u_resolution']);
+        expect(isWorkerBuiltinUniformName('u_time')).toBe(true);
+        expect(isWorkerBuiltinUniformName('u_resolution')).toBe(true);
+        expect(isWorkerBuiltinUniformName('u_intensity')).toBe(false);
+        expect(isWorkerBuiltinUniformName('u_mouse')).toBe(false);
+    });
+});
+
+describe('message type tag constants', () => {
+    it('lists every MainToWorker discriminant exactly once', () => {
+        expect(MAIN_TO_WORKER_MESSAGE_TYPES).toEqual([
+            'init',
+            'setUniformValues',
+            'setPasses',
+            'resize',
+            'setActive',
+            'invalidate',
+            'setFrameloop',
+            'setSpeed',
+            'renderFrame',
+            'dispose'
+        ]);
+        expect(new Set(MAIN_TO_WORKER_MESSAGE_TYPES).size).toBe(MAIN_TO_WORKER_MESSAGE_TYPES.length);
+    });
+
+    it('lists every WorkerToMain discriminant exactly once', () => {
+        expect(WORKER_TO_MAIN_MESSAGE_TYPES).toEqual(['ready', 'contextlost', 'contextrestored', 'error']);
+        expect(new Set(WORKER_TO_MAIN_MESSAGE_TYPES).size).toBe(WORKER_TO_MAIN_MESSAGE_TYPES.length);
+    });
+});
+
+describe('normalizeCloneSafeUniformValue', () => {
+    it('passes plain numbers through unchanged', () => {
+        expect(normalizeCloneSafeUniformValue(1.5)).toBe(1.5);
+        expect(normalizeCloneSafeUniformValue(0)).toBe(0);
+    });
+
+    it('copies plain number arrays instead of aliasing the caller array', () => {
+        const source = [1, 2, 3];
+        const normalized = normalizeCloneSafeUniformValue(source);
+
+        expect(normalized).toEqual([1, 2, 3]);
+        expect(normalized).not.toBe(source);
+
+        source[0] = 99;
+        expect(normalized).toEqual([1, 2, 3]);
+        expect(normalizeCloneSafeUniformValue([])).toEqual([]);
+    });
+
+    it('rejects arrays containing non-number entries', () => {
+        expect(normalizeCloneSafeUniformValue([1, '2', 3])).toBeNull();
+        expect(normalizeCloneSafeUniformValue([1, null, 3])).toBeNull();
+        expect(normalizeCloneSafeUniformValue([[1, 2], [3, 4]])).toBeNull();
+        expect(normalizeCloneSafeUniformValue([true, false])).toBeNull();
+    });
+
+    it('rejects sparse arrays whose holes would clone as undefined', () => {
+        const sparse: number[] = [1, 2, 3];
+        Reflect.deleteProperty(sparse, 1);
+
+        expect(normalizeCloneSafeUniformValue(sparse)).toBeNull();
+    });
+
+    it('rejects bigint typed arrays that cannot become uniform numbers', () => {
+        expect(normalizeCloneSafeUniformValue(new BigInt64Array([1n, 2n]))).toBeNull();
+    });
+
+    it('accepts non-finite numbers, which are clone-safe', () => {
+        expect(normalizeCloneSafeUniformValue(Number.NaN)).toBeNaN();
+        expect(normalizeCloneSafeUniformValue([Number.POSITIVE_INFINITY])).toEqual([Number.POSITIVE_INFINITY]);
+    });
+
+    it('normalizes typed arrays into plain arrays', () => {
+        expect(normalizeCloneSafeUniformValue(new Float32Array([1, 2, 3]))).toEqual([1, 2, 3]);
+        expect(normalizeCloneSafeUniformValue(new Uint8Array([9, 8]))).toEqual([9, 8]);
+    });
+
+    it('rejects array-like objects that are not arrays or typed arrays', () => {
+        expect(normalizeCloneSafeUniformValue({ length: 2, 0: 1, 1: 2 })).toBeNull();
+        expect(normalizeCloneSafeUniformValue(new Proxy({ x: 1 }, {}))).toBeNull();
+    });
+
+    it('rejects DataView (not a numeric typed array)', () => {
+        expect(normalizeCloneSafeUniformValue(new DataView(new ArrayBuffer(4)))).toBeNull();
+    });
+
+    it('rejects functions', () => {
+        expect(normalizeCloneSafeUniformValue(() => 1)).toBeNull();
+    });
+
+    it('rejects other non-clone-safe values', () => {
+        expect(normalizeCloneSafeUniformValue(undefined)).toBeNull();
+        expect(normalizeCloneSafeUniformValue({ x: 1 })).toBeNull();
+        expect(normalizeCloneSafeUniformValue('nope')).toBeNull();
+        expect(normalizeCloneSafeUniformValue(Symbol('s'))).toBeNull();
+    });
+});
+
+describe('uniformValuesEqual', () => {
+    it('treats an absent previous value as always different', () => {
+        expect(uniformValuesEqual(undefined, 1)).toBe(false);
+        expect(uniformValuesEqual(undefined, [1, 2])).toBe(false);
+    });
+
+    it('compares scalars by value', () => {
+        expect(uniformValuesEqual(1, 1)).toBe(true);
+        expect(uniformValuesEqual(1, 2)).toBe(false);
+    });
+
+    it('treats a scalar/vector type mismatch as different', () => {
+        expect(uniformValuesEqual([1], 1)).toBe(false);
+        expect(uniformValuesEqual(1, [1])).toBe(false);
+    });
+
+    it('compares vectors element-wise', () => {
+        expect(uniformValuesEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+        expect(uniformValuesEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+    });
+
+    it('treats different-length vectors as different', () => {
+        expect(uniformValuesEqual([1, 2], [1, 2, 3])).toBe(false);
+    });
+
+    it('treats an unchanged NaN as equal so it is not re-posted forever', () => {
+        expect(uniformValuesEqual(Number.NaN, Number.NaN)).toBe(true);
+        expect(uniformValuesEqual([1, Number.NaN], [1, Number.NaN])).toBe(true);
+        expect(uniformValuesEqual([1, Number.NaN], [1, 2])).toBe(false);
+        expect(uniformValuesEqual([1, 2], [1, Number.NaN])).toBe(false);
+    });
+});

--- a/src/worker/protocol.ts
+++ b/src/worker/protocol.ts
@@ -1,0 +1,144 @@
+import type {
+    FramebufferOptions,
+    Frameloop,
+    RenderOptions,
+    ShaderProgramConfig,
+    TextureBinding,
+    UniformType
+} from '@/types';
+
+export const WORKER_BUILTIN_UNIFORM_NAMES = ['u_time', 'u_resolution'] as const;
+
+export type WorkerBuiltinUniformName = typeof WORKER_BUILTIN_UNIFORM_NAMES[number];
+
+export function isWorkerBuiltinUniformName(name: string): name is WorkerBuiltinUniformName {
+    return (WORKER_BUILTIN_UNIFORM_NAMES as readonly string[]).includes(name);
+}
+
+export const MAIN_TO_WORKER_MESSAGE_TYPES = [
+    'init',
+    'setUniformValues',
+    'setPasses',
+    'resize',
+    'setActive',
+    'invalidate',
+    'setFrameloop',
+    'setSpeed',
+    'renderFrame',
+    'dispose'
+] as const;
+
+export const WORKER_TO_MAIN_MESSAGE_TYPES = [
+    'ready',
+    'contextlost',
+    'contextrestored',
+    'error'
+] as const;
+
+export type UniformScalar = number;
+export type UniformVector = number[];
+export type UniformValueMap = Record<string, UniformScalar | UniformVector>;
+
+export interface UniformDescriptor {
+    name: string;
+    type: UniformType;
+}
+
+export interface SerializableRenderPassValueUniform {
+    kind: 'value';
+    type: UniformType;
+    value: UniformScalar | UniformVector;
+}
+
+export interface SerializableRenderPassBuiltinUniform {
+    kind: 'builtin';
+    type: UniformType;
+}
+
+export type SerializableRenderPassUniform =
+    | SerializableRenderPassValueUniform
+    | SerializableRenderPassBuiltinUniform;
+
+export interface SerializableRenderPass {
+    programId: string;
+    inputTextures: TextureBinding[];
+    outputFramebuffer?: string | null;
+    uniforms?: Record<string, SerializableRenderPassUniform>;
+    renderOptions?: RenderOptions;
+}
+
+export interface WorkerInitConfig {
+    programConfigs: Record<string, ShaderProgramConfig>;
+    kind: 'single' | 'pingpong';
+    passes?: SerializableRenderPass[];
+    framebuffers?: Record<string, FramebufferOptions>;
+    initialValues: Record<string, UniformValueMap>;
+    descriptors: Record<string, UniformDescriptor[]>;
+    frameloop: Frameloop;
+    speed: number;
+    active: boolean;
+    contextAttributes?: WebGLContextAttributes;
+}
+
+export interface WorkerCapabilities {
+    maxTextureSize: number;
+    extensions: string[];
+}
+
+export type MainToWorker =
+    | { type: 'init'; canvas: OffscreenCanvas; config: WorkerInitConfig }
+    | { type: 'setUniformValues'; programId: string; values: UniformValueMap }
+    | { type: 'setPasses'; passes: SerializableRenderPass[] }
+    | { type: 'resize'; renderWidth: number; renderHeight: number }
+    | { type: 'setActive'; active: boolean }
+    | { type: 'invalidate'; frames?: number }
+    | { type: 'setFrameloop'; mode: Frameloop }
+    | { type: 'setSpeed'; speed: number }
+    | { type: 'renderFrame'; time: number }
+    | { type: 'dispose' };
+
+export type WorkerToMain =
+    | { type: 'ready'; capabilities: WorkerCapabilities }
+    | { type: 'contextlost' }
+    | { type: 'contextrestored' }
+    | { type: 'error'; message: string };
+
+function isNumberArray(entries: unknown[]): entries is number[] {
+    return entries.every(entry => typeof entry === 'number');
+}
+
+export function normalizeCloneSafeUniformValue(value: unknown): UniformScalar | UniformVector | null {
+    if (typeof value === 'number') {
+        return value;
+    }
+    const isNumericTypedArray = ArrayBuffer.isView(value) && !(value instanceof DataView);
+    if (Array.isArray(value) || isNumericTypedArray) {
+        const entries: unknown[] = Array.from(value as unknown as ArrayLike<unknown>);
+        return isNumberArray(entries) ? entries : null;
+    }
+    return null;
+}
+
+export function uniformValuesEqual(
+    a: UniformScalar | UniformVector | undefined,
+    b: UniformScalar | UniformVector
+): boolean {
+    if (a === undefined) {
+        return false;
+    }
+    if (typeof b === 'number') {
+        return Object.is(a, b);
+    }
+    if (typeof a === 'number') {
+        return false;
+    }
+    if (a.length !== b.length) {
+        return false;
+    }
+    for (let i = 0; i < b.length; i++) {
+        if (!Object.is(a[i], b[i])) {
+            return false;
+        }
+    }
+    return true;
+}


### PR DESCRIPTION
First slice of worker rendering (plan Feature 1, sections 1.1-1.6). Pure logic only: the message protocol and the main-side controller, fully unit-tested against a fake worker. No React wiring, no worker runtime, nothing exported from the public entrypoints yet - those are W2 (`WorkerRuntime` + worker build) and W3 (component wiring).

## `src/worker/protocol.ts`

Types, message tags and clone-safety helpers, with no DOM/GL/React dependency so both threads can share it and vitest can exercise it directly: the `MainToWorker`/`WorkerToMain` unions, `WorkerInitConfig`, the worker-side built-in uniform names (`u_time`, `u_resolution`), `normalizeCloneSafeUniformValue`, and `uniformValuesEqual`.

`SerializableRenderPassUniform` is a discriminated union - `{ kind: 'value', type, value }` or `{ kind: 'builtin', type }`. A built-in in a pass can't just be dropped on the way across: the worker has to know the pass declared `u_time` in order to compute it, and dropping it would hand the shader a frozen uniform, which is the silent failure the plan exists to prevent.

## `src/worker/WorkerBridge.ts`

A pure controller over an injected transport (`{ postMessage, addEventListener, removeEventListener?, terminate? }`) - satisfied by a real `Worker` and by a test fake. It assembles `init` and transfers the canvas, dirty-checks uniform values and posts only what actually changed, coalesces `invalidate` through a microtask (max of the batch), queues `resize` last-wins until `ready` then posts immediately after, dedupes `setActive`, forwards frameloop/speed/renderFrame, and goes inert on `dispose`.

## The uniform boundary fails loud

A function-valued uniform cannot be structured-cloned, so it throws unless it is a worker-side built-in (the worker computes `u_time`/`u_resolution` itself) or is listed in the `liveUniforms` escape hatch. The error names the uniform, its program, and both remedies. Function uniforms inside passes throw unless they are built-ins - `liveUniforms` deliberately does not cover pass uniforms in v1, and the message says so rather than accepting the name and doing nothing. Instancing in worker mode throws; it remains a v1 non-goal.

## Bugs caught in review, before they reached W3

- **Built-ins in passes were throwing unconditionally.** Every ping-pong pass uniform is function-valued today (`buildPasses` routes everything through `buildLiveUpdaters`), and `PingPongShaderEngine` registers no program-level updaters, so `u_time` exists *only* as a function-valued pass uniform. An unconditional throw would have made worker ping-pong impossible.
- **In-place array mutation was never posted.** The normalizer returned the caller's array by identity and the bridge stored that same reference, so a mutated-in-place vector was dirty-checked against itself. Values are copied now.
- **NaN re-posted forever** (`!==` is always true for NaN); comparison uses `Object.is`.
- **Sparse arrays and BigInt typed arrays passed clone-safety validation** and would have exploded worker-side. Both are rejected now.
- **`setPasses` was declared in the protocol but unreachable** from the bridge, so W3 would have had to post raw messages and bypass pass validation.
- **`invalidate(0)` / `invalidate(-1)` / `invalidate(NaN)`** posted meaningless frame counts; they throw now, matching the `validateInstanceCount` precedent.
- Worker initial active state is explicit in `WorkerInitConfig` rather than assumed.

## Verification

499 tests (36 new for this slice, plus the review's regression cases - each fails against the pre-review code). Full gate green: typecheck, lint, test, build.
