### PR TITLE
worker: W2 runtime + shipping - WorkerRuntime on OffscreenCanvas, Vite ?worker&inline blob default, ./worker escape hatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,15 +31,23 @@
       "types": "./dist/react/devtools/index.d.ts",
       "import": "./dist/devtools.mjs",
       "require": "./dist/devtools.js"
+    },
+    "./worker": {
+      "types": "./dist/worker/workerEntry.d.ts",
+      "worker": "./dist/worker.mjs",
+      "import": "./dist/worker.mjs",
+      "default": "./dist/worker.mjs"
     }
   },
   "files": [
     "dist"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/worker.mjs"
+  ],
   "scripts": {
     "dev": "vite --config demo/vite.config.ts",
-    "build": "vite build && node scripts/assertTreeshaken.mjs",
+    "build": "vite build && vite build --config vite.worker.config.ts && node scripts/assertTreeshaken.mjs",
     "prepublishOnly": "npm run build",
     "test": "vitest run",
     "lint": "eslint . --ext .ts,.tsx",

--- a/scripts/assertTreeshaken.mjs
+++ b/scripts/assertTreeshaken.mjs
@@ -1,11 +1,26 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, relative, resolve, sep } from 'node:path';
 
 const distRoot = resolve(process.cwd(), process.argv[2] ?? 'dist');
 const ENTRIES = ['index.mjs', 'core.mjs', 'react.mjs'].map(name => resolve(distRoot, name));
+const CREATE_WORKER = resolve(distRoot, 'worker', 'createWorker.mjs');
+const SUBPATH_WORKER = resolve(distRoot, 'worker.mjs');
+
+const WORKER_BODY_MARKER = 'one worker runtime drives exactly one canvas';
 
 const FROM_SPECIFIER = /\bfrom\s*['"]([^'"]+)['"]/g;
 const BARE_IMPORT = /(?:^|[;\n])\s*import\s*['"]([^'"]+)['"]/g;
+const DYNAMIC_IMPORT = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+const matchAll = (source, pattern) => {
+    const specifiers = [];
+    let match;
+    while ((match = pattern.exec(source)) !== null) {
+        specifiers.push(match[1]);
+    }
+    pattern.lastIndex = 0;
+    return specifiers;
+};
 
 const resolveModule = (fromFile, specifier) => {
     if (!specifier.startsWith('.')) {
@@ -16,16 +31,22 @@ const resolveModule = (fromFile, specifier) => {
     return candidates.find(candidate => existsSync(candidate)) ?? null;
 };
 
-const collectSpecifiers = source => {
-    const specifiers = [];
-    let match;
-    while ((match = FROM_SPECIFIER.exec(source)) !== null) {
-        specifiers.push(match[1]);
+const collectStaticSpecifiers = source => [
+    ...matchAll(source, FROM_SPECIFIER),
+    ...matchAll(source, BARE_IMPORT)
+];
+
+const listModules = directory => {
+    const files = [];
+    for (const entry of readdirSync(directory)) {
+        const full = resolve(directory, entry);
+        if (statSync(full).isDirectory()) {
+            files.push(...listModules(full));
+        } else if (entry.endsWith('.mjs')) {
+            files.push(full);
+        }
     }
-    while ((match = BARE_IMPORT.exec(source)) !== null) {
-        specifiers.push(match[1]);
-    }
-    return specifiers;
+    return files;
 };
 
 const reachable = new Set();
@@ -38,7 +59,7 @@ while (queue.length > 0) {
     }
     reachable.add(file);
     const source = readFileSync(file, 'utf8');
-    for (const specifier of collectSpecifiers(source)) {
+    for (const specifier of collectStaticSpecifiers(source)) {
         const resolved = resolveModule(file, specifier);
         if (resolved !== null && !reachable.has(resolved)) {
             queue.push(resolved);
@@ -48,25 +69,77 @@ while (queue.length > 0) {
 
 const DEVTOOLS_PREFIX = `react${sep}devtools${sep}`;
 const failures = [];
+const rel = file => relative(distRoot, file);
 
 for (const file of reachable) {
-    const rel = relative(distRoot, file);
-    if (rel.startsWith(DEVTOOLS_PREFIX) && !rel.endsWith(`${sep}beacon.mjs`)) {
-        failures.push(`devtools panel module reachable from a main bundle: ${rel}`);
+    const name = rel(file);
+    if (name.startsWith(DEVTOOLS_PREFIX) && !name.endsWith(`${sep}beacon.mjs`)) {
+        failures.push(`devtools panel module reachable from a main bundle: ${name}`);
     }
-    if (rel === 'testing.mjs' || rel.startsWith(`testing${sep}`)) {
-        failures.push(`testing module reachable from a main bundle: ${rel}`);
+    if (name === 'testing.mjs' || name.startsWith(`testing${sep}`)) {
+        failures.push(`testing module reachable from a main bundle: ${name}`);
     }
+    if (readFileSync(file, 'utf8').includes(WORKER_BODY_MARKER)) {
+        failures.push(`the inlined worker body is statically reachable from a main bundle: ${name}`);
+    }
+}
+
+const emittedWorkerChunks = existsSync(distRoot)
+    ? listModules(distRoot)
+        .filter(file => file !== SUBPATH_WORKER)
+        .filter(file => readFileSync(file, 'utf8').includes(WORKER_BODY_MARKER))
+    : [];
+
+if (emittedWorkerChunks.length === 0) {
+    failures.push(
+        'no chunk carrying the inlined worker body was emitted; the blob-worker path has no worker to '
+        + 'construct. It should be emitted as a dynamic-import chunk of worker/createWorker.mjs.'
+    );
+}
+
+const dynamicallyImported = existsSync(CREATE_WORKER)
+    ? matchAll(readFileSync(CREATE_WORKER, 'utf8'), DYNAMIC_IMPORT)
+        .map(specifier => resolveModule(CREATE_WORKER, specifier))
+        .filter(file => file !== null)
+    : [];
+
+for (const chunk of emittedWorkerChunks) {
+    if (!dynamicallyImported.includes(chunk)) {
+        failures.push(
+            `the inlined worker chunk ${rel(chunk)} is not dynamically imported by worker/createWorker.mjs; `
+            + 'it must be reached through import() so it stays out of the main entry graph.'
+        );
+    }
+
+    const source = readFileSync(chunk, 'utf8');
+    const imports = [
+        ...collectStaticSpecifiers(source),
+        ...matchAll(source, DYNAMIC_IMPORT)
+    ];
+    if (imports.length > 0 || source.includes('importScripts')) {
+        failures.push(
+            `the inlined worker chunk ${rel(chunk)} is not self-contained (it imports ${imports.join(', ')}); `
+            + 'a worker constructed from a blob URL cannot import anything.'
+        );
+    }
+}
+
+if (!existsSync(SUBPATH_WORKER)) {
+    failures.push('worker.mjs was not emitted; the micugl/worker export would 404.');
 }
 
 if (failures.length > 0) {
-    console.error('assertTreeshaken: static import graph of index/core/react leaked a dev-only module:');
+    console.error('assertTreeshaken: the dist layout of index/core/react is wrong:');
     for (const failure of failures) {
         console.error(`  - ${failure}`);
     }
-    console.error('Only react/devtools/beacon.mjs may be statically reachable; the panel and testing');
-    console.error('chunks must be reached via dynamic import() or an explicit micugl/devtools import.');
+    console.error('Only react/devtools/beacon.mjs may be statically reachable; the panel, testing and');
+    console.error('inlined-worker chunks must be reached via dynamic import() or an explicit subpath import.');
     process.exit(1);
 }
 
-console.log(`assertTreeshaken: walked ${String(reachable.size)} modules from index/core/react; no devtools panel or testing module is statically reachable.`);
+console.log(
+    `assertTreeshaken: walked ${String(reachable.size)} modules from index/core/react; no devtools panel, `
+    + `testing or inlined-worker module is statically reachable, and the worker chunk `
+    + `(${emittedWorkerChunks.map(rel).join(', ')}) is self-contained and reached only through import().`
+);

--- a/src/core/managers/WebGLManager.test.ts
+++ b/src/core/managers/WebGLManager.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { WebGLManager } from '@/core/managers/WebGLManager';
-import { createCanvasStub } from '@/testing';
+import { createCanvasStub, createGLStub } from '@/testing';
 import type { ShaderProgramConfig } from '@/types';
 
 const CONFIG: ShaderProgramConfig = {
@@ -161,5 +161,32 @@ describe('WebGLManager updateBufferSub', () => {
         manager.createProgram('a', CONFIG);
 
         expect(() => { manager.updateBufferSub('a', 'offset', new Float32Array([1])) }).toThrow(/not found/);
+    });
+});
+
+describe('WebGLManager offscreen canvas', () => {
+    it('sizes an OffscreenCanvas without touching a style object it does not have', () => {
+        const offscreen = { width: 0, height: 0 } as unknown as OffscreenCanvas;
+        const { gl, viewportCalls } = createGLStub({ overrides: { canvas: offscreen } });
+        const manager = new WebGLManager({
+            getContext: () => gl
+        } as unknown as OffscreenCanvas);
+
+        expect(() => { manager.setSize(320, 240, 160, 120) }).not.toThrow();
+
+        expect(offscreen.width).toBe(320);
+        expect(offscreen.height).toBe(240);
+        expect(viewportCalls).toContainEqual([0, 0, 320, 240]);
+        expect(Object.keys(offscreen)).toEqual(['width', 'height']);
+    });
+
+    it('still applies the css display size to an HTMLCanvasElement', () => {
+        const { canvas } = createCanvasStub();
+        const manager = new WebGLManager(canvas);
+
+        manager.setSize(320, 240, 160, 120);
+
+        expect(canvas.style.width).toBe('160px');
+        expect(canvas.style.height).toBe('120px');
     });
 });

--- a/src/core/managers/WebGLManager.ts
+++ b/src/core/managers/WebGLManager.ts
@@ -21,17 +21,19 @@ declare global {
     }
 }
 
+export type WebGLManagerCanvas = HTMLCanvasElement | OffscreenCanvas;
+
 export class WebGLManager {
     private gl: WebGLRenderingContext;
     private fboManager: FBOManager;
-  
+
     resources = new Map<string, ShaderResources>();
     private compileCache = new Map<string, WebGLShader>();
     private uniformUpdateFns = new Map<string, Map<string, UniformUpdateFn<UniformType>>>();
     private extensions = new Map<string, any>();
     private currentProgram: WebGLProgram | null = null;
 
-    constructor(canvas: HTMLCanvasElement, options?: WebGLContextAttributes) {
+    constructor(canvas: WebGLManagerCanvas, options?: WebGLContextAttributes) {
         const defaultOptions: WebGLContextAttributes = {
             alpha: false,
             depth: false,
@@ -282,7 +284,7 @@ export class WebGLManager {
             return;
         }
 
-        const canvas = this.gl.canvas as HTMLCanvasElement;
+        const canvas = this.gl.canvas;
         const resolvedWidth = width ?? canvas.width;
         const resolvedHeight = height ?? canvas.height;
 
@@ -296,7 +298,7 @@ export class WebGLManager {
         displayWidth?: number,
         displayHeight?: number
     ): void {
-        const canvas = this.gl.canvas as HTMLCanvasElement;
+        const canvas = this.gl.canvas;
 
         const actualDisplayWidth = displayWidth ?? renderWidth;
         const actualDisplayHeight = displayHeight ?? renderHeight;
@@ -307,12 +309,14 @@ export class WebGLManager {
             this.fboManager.setCanvasViewport(renderWidth, renderHeight);
         }
 
-        canvas.style.width = `${actualDisplayWidth}px`;
-        canvas.style.height = `${actualDisplayHeight}px`;
+        if ('style' in canvas) {
+            canvas.style.width = `${actualDisplayWidth}px`;
+            canvas.style.height = `${actualDisplayHeight}px`;
+        }
     }
 
     setDrawingBufferSize(renderWidth: number, renderHeight: number): void {
-        const canvas = this.gl.canvas as HTMLCanvasElement;
+        const canvas = this.gl.canvas;
 
         if (canvas.width !== renderWidth || canvas.height !== renderHeight) {
             canvas.width = renderWidth;

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,3 +88,6 @@ export type {
     WebGLExtensionName,
     WebGLExtensionTypes
 } from './types';
+export type { CreateWorkerOptions } from './worker/createWorker';
+export { createMicuglWorker } from './worker/createWorker';
+export type { WorkerCapabilities } from './worker/protocol';

--- a/src/react/lib/contentKeys.ts
+++ b/src/react/lib/contentKeys.ts
@@ -9,7 +9,7 @@ export function singleProgramEntry(
     const entries = Object.entries(programConfigs);
     if (entries.length !== 1) {
         throw new Error(
-            `ShaderEngine requires exactly one entry in programConfigs, received ${entries.length}`
+            `micugl requires exactly one entry in programConfigs, received ${entries.length}`
         );
     }
     return entries[0];

--- a/src/worker/WorkerBridge.ts
+++ b/src/worker/WorkerBridge.ts
@@ -16,6 +16,7 @@ import type {
     UniformVector,
     WorkerCapabilities,
     WorkerInitConfig,
+    WorkerRenderOptions,
     WorkerToMain
 } from '@/worker/protocol';
 import {
@@ -61,6 +62,7 @@ export interface WorkerBridgeInit {
     frameloop: Frameloop;
     speed: number;
     active?: boolean;
+    renderOptions?: WorkerRenderOptions;
     contextAttributes?: WebGLContextAttributes;
     liveUniforms?: Record<string, string[]>;
     instancing?: InstancingConfig;
@@ -213,6 +215,7 @@ export class WorkerBridge {
             frameloop: init.frameloop,
             speed: init.speed,
             active: this.lastActive,
+            renderOptions: init.renderOptions,
             contextAttributes: init.contextAttributes
         };
 

--- a/src/worker/WorkerRuntime.test.ts
+++ b/src/worker/WorkerRuntime.test.ts
@@ -1,0 +1,711 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { GLStubConfig, GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { ShaderProgramConfig } from '@/types';
+import type { MainToWorker, SerializableRenderPass, WorkerInitConfig, WorkerToMain } from '@/worker/protocol';
+import type { WorkerRuntimeHost } from '@/worker/WorkerRuntime';
+import { WorkerRuntime } from '@/worker/WorkerRuntime';
+
+const CONFIG: ShaderProgramConfig = {
+    vertexShader: '',
+    fragmentShader: '',
+    uniforms: [
+        { name: 'u_time', type: 'float' },
+        { name: 'u_resolution', type: 'vec2' },
+        { name: 'u_intensity', type: 'float' },
+        { name: 'u_color', type: 'vec3' }
+    ]
+};
+
+const DESCRIPTORS = [
+    { name: 'u_intensity', type: 'float' as const },
+    { name: 'u_color', type: 'vec3' as const }
+];
+
+interface OffscreenStub {
+    canvas: OffscreenCanvas;
+    gl: GLStubHandle;
+    lose: () => void;
+    restore: (overrides?: GLStubConfig) => void;
+    listenerCount: () => number;
+}
+
+function createOffscreenStub(config: GLStubConfig = {}): OffscreenStub {
+    const listeners = new Map<string, ((event: Event) => void)[]>();
+    let stub: GLStubHandle | null = null;
+
+    const canvas = {
+        width: 0,
+        height: 0,
+        getContext: (): WebGLRenderingContext | null => stub?.gl ?? null,
+        addEventListener: (type: string, listener: (event: Event) => void): void => {
+            const existing = listeners.get(type) ?? [];
+            existing.push(listener);
+            listeners.set(type, existing);
+        },
+        removeEventListener: (type: string, listener: (event: Event) => void): void => {
+            const existing = listeners.get(type) ?? [];
+            const index = existing.indexOf(listener);
+            if (index !== -1) {
+                existing.splice(index, 1);
+            }
+        }
+    };
+
+    const offscreen = canvas as unknown as OffscreenCanvas;
+    const glConfig: GLStubConfig = {
+        ...config,
+        overrides: { canvas: offscreen, ...config.overrides }
+    };
+
+    stub = createGLStub(glConfig);
+
+    const emit = (type: string): void => {
+        const event = { preventDefault: (): void => undefined } as unknown as Event;
+        [...(listeners.get(type) ?? [])].forEach(listener => { listener(event) });
+    };
+
+    return {
+        canvas: offscreen,
+        gl: stub,
+        lose: () => {
+            glConfig.contextLost = true;
+            emit('webglcontextlost');
+        },
+        restore: overrides => {
+            Object.assign(glConfig, overrides ?? {});
+            glConfig.contextLost = false;
+            emit('webglcontextrestored');
+        },
+        listenerCount: () =>
+            Array.from(listeners.values()).reduce((total, entries) => total + entries.length, 0)
+    };
+}
+
+interface RuntimeHarness {
+    posted: WorkerToMain[];
+    cancels: number[];
+    close: ReturnType<typeof vi.fn>;
+    pendingHandles: () => number[];
+    tick: (now: number) => void;
+    send: (message: MainToWorker) => void;
+}
+
+function createHarness(): RuntimeHarness {
+    const posted: WorkerToMain[] = [];
+    const cancels: number[] = [];
+    const scheduled = new Map<number, (now: number) => void>();
+    const close = vi.fn();
+    let nextHandle = 1;
+
+    const host: WorkerRuntimeHost = {
+        postMessage: message => { posted.push(message) },
+        requestAnimationFrame: callback => {
+            const handle = nextHandle;
+            nextHandle += 1;
+            scheduled.set(handle, callback);
+            return handle;
+        },
+        cancelAnimationFrame: handle => {
+            cancels.push(handle);
+            scheduled.delete(handle);
+        },
+        now: () => 0,
+        close: () => { close() }
+    };
+
+    const runtime = new WorkerRuntime(host);
+
+    return {
+        posted,
+        cancels,
+        close,
+        pendingHandles: () => Array.from(scheduled.keys()),
+        tick: now => {
+            const callbacks = Array.from(scheduled.values());
+            scheduled.clear();
+            callbacks.forEach(callback => { callback(now) });
+        },
+        send: message => { runtime.handleMessage(message) }
+    };
+}
+
+function initMessage(canvas: OffscreenCanvas, overrides: Partial<WorkerInitConfig> = {}): MainToWorker {
+    return {
+        type: 'init',
+        canvas,
+        config: {
+            programConfigs: { main: CONFIG },
+            kind: 'single',
+            initialValues: { main: { u_intensity: 0.25 } },
+            descriptors: { main: DESCRIPTORS },
+            frameloop: 'always',
+            speed: 1,
+            active: true,
+            ...overrides
+        }
+    };
+}
+
+function pingPongInit(canvas: OffscreenCanvas, overrides: Partial<WorkerInitConfig> = {}): MainToWorker {
+    return initMessage(canvas, {
+        kind: 'pingpong',
+        passes: pingPongPasses(),
+        initialValues: { main: {} },
+        descriptors: { main: [] },
+        ...overrides
+    });
+}
+
+function pingPongPasses(): SerializableRenderPass[] {
+    return [
+        {
+            programId: 'main',
+            inputTextures: [],
+            outputFramebuffer: null,
+            uniforms: {
+                u_time: { kind: 'builtin', type: 'float' },
+                u_intensity: { kind: 'value', type: 'float', value: 0.5 }
+            }
+        }
+    ];
+}
+
+function floatUploads(gl: GLStubHandle): unknown[] {
+    return gl.uniformCalls.filter(call => call.name === 'uniform1f').map(call => call.value);
+}
+
+function vec2Uploads(gl: GLStubHandle): number[][] {
+    return gl.uniformCalls
+        .filter(call => call.name === 'uniform2fv')
+        .map(call => Array.from(call.value as Float32Array));
+}
+
+function callCount(gl: GLStubHandle, name: string): number {
+    return gl.calls.filter(call => call.name === name).length;
+}
+
+function drawCount(gl: GLStubHandle): number {
+    return callCount(gl, 'drawArrays');
+}
+
+function linkCount(gl: GLStubHandle): number {
+    return callCount(gl, 'linkProgram');
+}
+
+function errorCount(posted: WorkerToMain[]): number {
+    return posted.filter(message => message.type === 'error').length;
+}
+
+function lastError(posted: WorkerToMain[]): string {
+    const message = [...posted].reverse().find(entry => entry.type === 'error');
+    if (message?.type !== 'error') {
+        throw new Error(`expected an "error" message, worker posted ${JSON.stringify(posted)}`);
+    }
+    return message.message;
+}
+
+describe('WorkerRuntime init', () => {
+    it('creates the program, the quad buffer and posts ready with capabilities', () => {
+        const offscreen = createOffscreenStub({
+            extensions: { ANGLE_instanced_arrays: true },
+            maxTextureSize: 8192
+        });
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+
+        expect(linkCount(offscreen.gl)).toBe(1);
+        expect(offscreen.gl.calls.filter(call => call.name === 'bufferData')).toHaveLength(1);
+        expect(harness.posted).toEqual([
+            {
+                type: 'ready',
+                capabilities: { maxTextureSize: 8192, extensions: ['ANGLE_instanced_arrays'] }
+            }
+        ]);
+    });
+
+    it('posts an error rather than rendering blank when the program fails to link', () => {
+        const offscreen = createOffscreenStub({ linkFails: true });
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+
+        expect(lastError(harness.posted)).toContain('link');
+        expect(harness.pendingHandles()).toHaveLength(0);
+        expect(drawCount(offscreen.gl)).toBe(0);
+    });
+
+    it('rejects a message that arrives before init', () => {
+        const harness = createHarness();
+
+        harness.send({ type: 'resize', renderWidth: 10, renderHeight: 10 });
+
+        expect(lastError(harness.posted)).toBe('micugl worker: received "resize" before "init"');
+    });
+
+    it('rejects a second init', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.send(initMessage(offscreen.canvas));
+
+        expect(lastError(harness.posted)).toContain('second "init"');
+    });
+
+    it('reports a failed init once and then stays quiet instead of erroring per message', () => {
+        const offscreen = createOffscreenStub({ linkFails: true });
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        expect(errorCount(harness.posted)).toBe(1);
+
+        harness.send({ type: 'resize', renderWidth: 10, renderHeight: 10 });
+        harness.send({ type: 'resize', renderWidth: 20, renderHeight: 20 });
+        harness.send({ type: 'invalidate', frames: 1 });
+
+        expect(errorCount(harness.posted)).toBe(1);
+    });
+
+    it('never rebuilds or reports a restored context for a runtime that never finished init', () => {
+        const offscreen = createOffscreenStub({ linkFails: true });
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        const linksAfterFailure = linkCount(offscreen.gl);
+
+        offscreen.lose();
+        offscreen.restore({ linkFails: false });
+
+        expect(linkCount(offscreen.gl)).toBe(linksAfterFailure);
+        expect(harness.posted.some(message => message.type === 'contextrestored')).toBe(false);
+        expect(harness.posted.some(message => message.type === 'ready')).toBe(false);
+        expect(drawCount(offscreen.gl)).toBe(0);
+    });
+});
+
+describe('WorkerRuntime uniforms', () => {
+    let offscreen: OffscreenStub;
+    let harness: RuntimeHarness;
+
+    beforeEach(() => {
+        offscreen = createOffscreenStub();
+        harness = createHarness();
+        harness.send(initMessage(offscreen.canvas));
+    });
+
+    it('uploads a posted value on the next frame', () => {
+        harness.tick(0);
+        offscreen.gl.reset();
+
+        harness.send({ type: 'setUniformValues', programId: 'main', values: { u_intensity: 0.75 } });
+        harness.tick(16);
+
+        expect(floatUploads(offscreen.gl)).toContain(0.75);
+    });
+
+    it('re-wraps a posted plain array into a pooled Float32Array', () => {
+        harness.send({ type: 'setUniformValues', programId: 'main', values: { u_color: [1, 0.5, 0] } });
+        harness.tick(16);
+
+        const vectors = offscreen.gl.uniformCalls.filter(call => call.name === 'uniform3fv');
+        expect(vectors).toHaveLength(1);
+        expect(vectors[0].value).toBeInstanceOf(Float32Array);
+        expect(Array.from(vectors[0].value as Float32Array)).toEqual([1, 0.5, 0]);
+    });
+
+    it('computes u_time itself, advancing it every frame', () => {
+        harness.tick(1000);
+        harness.tick(2000);
+        harness.tick(4000);
+
+        expect(floatUploads(offscreen.gl)).toEqual(expect.arrayContaining([0, 1, 3]));
+    });
+
+    it('computes u_resolution from the canvas size the worker was resized to', () => {
+        harness.send({ type: 'resize', renderWidth: 640, renderHeight: 480 });
+        harness.tick(16);
+
+        expect(vec2Uploads(offscreen.gl).at(-1)).toEqual([640, 480]);
+        expect(offscreen.gl.viewportCalls.at(-1)).toEqual([0, 0, 640, 480]);
+    });
+
+    it('fails loud on a value for an undeclared uniform', () => {
+        harness.send({ type: 'setUniformValues', programId: 'main', values: { u_unknown: 1 } });
+
+        expect(lastError(harness.posted)).toContain('u_unknown');
+    });
+
+    it('fails loud on a value for an unknown program', () => {
+        harness.send({ type: 'setUniformValues', programId: 'ghost', values: { u_intensity: 1 } });
+
+        expect(lastError(harness.posted)).toContain('unknown program "ghost"');
+    });
+
+    it('fails loud on a vector value whose component count is wrong', () => {
+        harness.send({ type: 'setUniformValues', programId: 'main', values: { u_color: [1, 0] } });
+
+        expect(lastError(harness.posted)).toContain('3 components');
+    });
+});
+
+describe('WorkerRuntime scheduling', () => {
+    it('cancels the scheduled frame when the main thread deactivates it, and resumes on reactivation', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        expect(harness.pendingHandles()).toHaveLength(1);
+
+        harness.send({ type: 'setActive', active: false });
+
+        expect(harness.cancels).toHaveLength(1);
+        expect(harness.pendingHandles()).toHaveLength(0);
+
+        harness.send({ type: 'setActive', active: true });
+        expect(harness.pendingHandles()).toHaveLength(1);
+    });
+
+    it('schedules nothing when speed is 0', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas, { speed: 0 }));
+
+        expect(harness.pendingHandles()).toHaveLength(0);
+    });
+
+    it('renders only on demand, honouring a multi-frame invalidate', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas, { frameloop: 'demand' }));
+        harness.tick(16);
+        offscreen.gl.reset();
+
+        harness.tick(32);
+        expect(drawCount(offscreen.gl)).toBe(0);
+
+        harness.send({ type: 'invalidate', frames: 3 });
+        harness.tick(48);
+        harness.tick(64);
+        harness.tick(80);
+        harness.tick(96);
+
+        expect(drawCount(offscreen.gl)).toBe(3);
+    });
+
+    it('rejects a non-positive invalidate frame count', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.send({ type: 'invalidate', frames: 0 });
+
+        expect(lastError(harness.posted)).toContain('positive integer');
+    });
+
+    it('draws exactly once for renderFrame, at the requested time', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas, { frameloop: 'never', active: false }));
+        offscreen.gl.reset();
+
+        harness.send({ type: 'renderFrame', time: 500 });
+
+        expect(drawCount(offscreen.gl)).toBe(1);
+        expect(harness.pendingHandles()).toHaveLength(0);
+        expect(floatUploads(offscreen.gl)).toContain(0.5);
+    });
+
+    it('sets the loop clock from renderFrame, so later frames continue from the rendered frame', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.tick(0);
+
+        harness.send({ type: 'renderFrame', time: 2000 });
+        expect(floatUploads(offscreen.gl)).toContain(2);
+
+        offscreen.gl.reset();
+        harness.tick(5000);
+        harness.tick(6000);
+
+        expect(drawCount(offscreen.gl)).toBe(2);
+        expect(floatUploads(offscreen.gl)).toEqual([3]);
+    });
+
+    it('suppresses the clear when renderOptions.clear is false', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas, { renderOptions: { clear: false } }));
+        harness.tick(16);
+
+        expect(drawCount(offscreen.gl)).toBe(1);
+        expect(callCount(offscreen.gl, 'clear')).toBe(0);
+    });
+
+    it('clears by default', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.tick(16);
+
+        expect(callCount(offscreen.gl, 'clear')).toBe(1);
+    });
+});
+
+describe('WorkerRuntime ping-pong passes', () => {
+    it('computes a built-in pass uniform every frame instead of freezing it', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(pingPongInit(offscreen.canvas));
+
+        harness.tick(1000);
+        harness.tick(2000);
+        harness.tick(4000);
+
+        const uploads = floatUploads(offscreen.gl);
+        expect(uploads).toEqual(expect.arrayContaining([0, 1, 3, 0.5]));
+    });
+
+    it('computes the built-ins its program declares even when no pass names them', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(pingPongInit(offscreen.canvas));
+        harness.send({ type: 'resize', renderWidth: 320, renderHeight: 200 });
+        harness.tick(16);
+
+        expect(vec2Uploads(offscreen.gl).at(-1)).toEqual([320, 200]);
+    });
+
+    it('creates and resizes the framebuffers it was initialized with', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(pingPongInit(offscreen.canvas, { framebuffers: { sim: { width: 0, height: 0 } } }));
+        harness.send({ type: 'resize', renderWidth: 64, renderHeight: 32 });
+
+        const allocations = offscreen.gl.texImage2DCalls.filter(call => call.width === 64 && call.height === 32);
+        expect(allocations).toHaveLength(2);
+    });
+
+    it('applies a new pass list on setPasses', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(pingPongInit(offscreen.canvas));
+        harness.tick(0);
+        offscreen.gl.reset();
+
+        harness.send({
+            type: 'setPasses',
+            passes: [
+                {
+                    ...pingPongPasses()[0],
+                    uniforms: { u_intensity: { kind: 'value', type: 'float', value: 0.9 } }
+                }
+            ]
+        });
+        harness.tick(16);
+
+        expect(floatUploads(offscreen.gl)).toContain(0.9);
+    });
+
+    it('rejects setPasses on a single-program worker', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.send({ type: 'setPasses', passes: pingPongPasses() });
+
+        expect(lastError(harness.posted)).toContain('single');
+    });
+});
+
+describe('WorkerRuntime context loss', () => {
+    it('stops the loop on loss, then rebuilds and resumes on restore', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.tick(16);
+        expect(harness.pendingHandles()).toHaveLength(1);
+
+        const linksBefore = linkCount(offscreen.gl);
+        offscreen.lose();
+
+        expect(harness.pendingHandles()).toHaveLength(0);
+        expect(harness.cancels).toHaveLength(1);
+        expect(harness.posted.at(-1)).toEqual({ type: 'contextlost' });
+
+        offscreen.restore();
+
+        expect(linkCount(offscreen.gl)).toBe(linksBefore + 1);
+        expect(harness.posted.at(-1)).toEqual({ type: 'contextrestored' });
+        expect(harness.pendingHandles()).toHaveLength(1);
+
+        offscreen.gl.reset();
+        harness.tick(32);
+        expect(drawCount(offscreen.gl)).toBe(1);
+    });
+
+    it('destroys the GL resources of the lost context before rebuilding', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        offscreen.lose();
+        offscreen.restore();
+
+        expect(callCount(offscreen.gl, 'deleteProgram')).toBe(1);
+        expect(linkCount(offscreen.gl)).toBe(2);
+    });
+
+    it('keeps the latest posted uniform values across a restore', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.send({ type: 'setUniformValues', programId: 'main', values: { u_intensity: 0.42 } });
+
+        offscreen.lose();
+        offscreen.restore();
+        offscreen.gl.reset();
+
+        harness.tick(16);
+
+        expect(floatUploads(offscreen.gl)).toContain(0.42);
+    });
+
+    it('does not resume a runtime that was inactive when the context was lost', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas, { active: false }));
+
+        offscreen.lose();
+        offscreen.restore();
+
+        expect(harness.pendingHandles()).toHaveLength(0);
+    });
+
+    it('does not start the render loop while the context is lost', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        offscreen.lose();
+        expect(harness.pendingHandles()).toHaveLength(0);
+
+        harness.send({ type: 'setActive', active: false });
+        harness.send({ type: 'setActive', active: true });
+
+        expect(harness.pendingHandles()).toHaveLength(0);
+        expect(errorCount(harness.posted)).toBe(0);
+
+        offscreen.restore();
+
+        expect(harness.pendingHandles()).toHaveLength(1);
+    });
+
+    it('does not spend demand frames on the frames it cannot draw while the context is lost', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas, { frameloop: 'demand' }));
+        harness.tick(0);
+
+        offscreen.lose();
+        harness.send({ type: 'setActive', active: true });
+        harness.send({ type: 'invalidate', frames: 3 });
+
+        harness.tick(16);
+        harness.tick(32);
+        harness.tick(48);
+
+        offscreen.restore();
+        offscreen.gl.reset();
+
+        harness.tick(64);
+        harness.tick(80);
+        harness.tick(96);
+        harness.tick(112);
+
+        expect(drawCount(offscreen.gl)).toBe(3);
+    });
+
+    it('accepts resize and uniform values during a loss and applies them on restore', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        offscreen.lose();
+
+        harness.send({ type: 'resize', renderWidth: 128, renderHeight: 64 });
+        harness.send({ type: 'setUniformValues', programId: 'main', values: { u_intensity: 0.9 } });
+        harness.send({ type: 'invalidate', frames: 1 });
+        harness.tick(16);
+
+        expect(errorCount(harness.posted)).toBe(0);
+        expect(drawCount(offscreen.gl)).toBe(0);
+
+        offscreen.restore();
+        offscreen.gl.reset();
+        harness.tick(32);
+
+        expect(drawCount(offscreen.gl)).toBe(1);
+        expect(floatUploads(offscreen.gl)).toContain(0.9);
+        expect(vec2Uploads(offscreen.gl).at(-1)).toEqual([128, 64]);
+    });
+});
+
+describe('WorkerRuntime dispose', () => {
+    it('stops the loop, drops the canvas listeners and closes the worker', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        expect(offscreen.listenerCount()).toBe(2);
+
+        harness.send({ type: 'dispose' });
+
+        expect(harness.pendingHandles()).toHaveLength(0);
+        expect(offscreen.listenerCount()).toBe(0);
+        expect(harness.close).toHaveBeenCalledTimes(1);
+        expect(callCount(offscreen.gl, 'deleteProgram')).toBe(1);
+
+        harness.send({ type: 'renderFrame', time: 0 });
+        expect(harness.posted.some(message => message.type === 'error')).toBe(false);
+    });
+
+    it('shuts the worker down when dispose arrives before init', () => {
+        const harness = createHarness();
+
+        harness.send({ type: 'dispose' });
+
+        expect(harness.close).toHaveBeenCalledTimes(1);
+        expect(harness.posted).toEqual([]);
+    });
+
+    it('shuts the worker down after a failed init, and closes exactly once', () => {
+        const offscreen = createOffscreenStub({ linkFails: true });
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.send({ type: 'dispose' });
+        harness.send({ type: 'dispose' });
+
+        expect(harness.close).toHaveBeenCalledTimes(1);
+        expect(offscreen.listenerCount()).toBe(0);
+        expect(errorCount(harness.posted)).toBe(1);
+    });
+});

--- a/src/worker/WorkerRuntime.ts
+++ b/src/worker/WorkerRuntime.ts
@@ -1,0 +1,655 @@
+import { WebGLManager } from '@/core/managers/WebGLManager';
+import { Passes } from '@/core/systems/Passes';
+import { singleProgramEntry } from '@/react/lib/contentKeys';
+import { createCommonUpdaters } from '@/react/lib/createUniformUpdater';
+import { RenderLoop } from '@/react/lib/renderLoop';
+import { msToFrame } from '@/react/lib/timeKeeper';
+import type {
+    FramebufferOptions,
+    RenderPass,
+    RenderPassUniformValue,
+    UniformType,
+    UniformUpdateFn,
+    UniformUpdaterDef,
+    WebGLExtensionName
+} from '@/types';
+import type {
+    MainToWorker,
+    SerializableRenderPass,
+    UniformScalar,
+    UniformValueMap,
+    UniformVector,
+    WorkerCapabilities,
+    WorkerInitConfig,
+    WorkerToMain
+} from '@/worker/protocol';
+import { isWorkerBuiltinUniformName } from '@/worker/protocol';
+
+export interface WorkerRuntimeHost {
+    postMessage: (message: WorkerToMain) => void;
+    requestAnimationFrame: (callback: (now: number) => void) => number;
+    cancelAnimationFrame: (handle: number) => void;
+    now: () => number;
+    close?: () => void;
+}
+
+const UNIFORM_COMPONENTS = {
+    float: 1,
+    int: 1,
+    sampler2D: 1,
+    vec2: 2,
+    vec3: 3,
+    vec4: 4,
+    mat2: 4,
+    mat3: 9,
+    mat4: 16
+} as const satisfies Record<UniformType, number>;
+
+const PROBED_EXTENSIONS: WebGLExtensionName[] = [
+    'OES_texture_float',
+    'OES_texture_float_linear',
+    'OES_texture_half_float',
+    'OES_texture_half_float_linear',
+    'OES_vertex_array_object',
+    'ANGLE_instanced_arrays'
+];
+
+const QUAD_VERTICES = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]);
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function describeValue(value: UniformScalar | UniformVector): string {
+    return typeof value === 'number' ? 'a single number' : `${String(value.length)} components`;
+}
+
+function assertUniformComponents(
+    label: string,
+    programId: string,
+    name: string,
+    type: UniformType,
+    value: UniformScalar | UniformVector
+): void {
+    const components = UNIFORM_COMPONENTS[type];
+
+    if (components === 1) {
+        if (typeof value !== 'number') {
+            throw new Error(
+                `micugl worker: ${label} "${name}" on program "${programId}" is a "${type}" and expects a `
+                + `single number, received ${describeValue(value)}`
+            );
+        }
+        return;
+    }
+
+    if (typeof value === 'number' || value.length !== components) {
+        throw new Error(
+            `micugl worker: ${label} "${name}" on program "${programId}" is a "${type}" and expects `
+            + `${String(components)} components, received ${describeValue(value)}`
+        );
+    }
+}
+
+export class WorkerRuntime {
+    private readonly host: WorkerRuntimeHost;
+
+    private canvas: OffscreenCanvas | null = null;
+    private config: WorkerInitConfig | null = null;
+    private manager: WebGLManager | null = null;
+    private passSystem: Passes | null = null;
+    private loop: RenderLoop | null = null;
+    private programId: string | null = null;
+
+    private readonly values = new Map<string, UniformValueMap>();
+    private readonly uniformTypes = new Map<string, Map<string, UniformType>>();
+    private readonly registered = new Map<string, Set<string>>();
+
+    private renderWidth = 0;
+    private renderHeight = 0;
+    private pendingFrames = 0;
+    private active = false;
+    private contextLost = false;
+    private failed = false;
+    private disposed = false;
+
+    constructor(host: WorkerRuntimeHost) {
+        this.host = host;
+    }
+
+    handleMessage(message: MainToWorker): void {
+        if (this.disposed) {
+            return;
+        }
+        if (this.failed && message.type !== 'dispose') {
+            return;
+        }
+        try {
+            this.dispatch(message);
+        } catch (error) {
+            this.fail(error);
+        }
+    }
+
+    private dispatch(message: MainToWorker): void {
+        if (message.type === 'dispose') {
+            this.dispose();
+            return;
+        }
+
+        if (message.type === 'init') {
+            this.init(message.canvas, message.config);
+            return;
+        }
+
+        const loop = this.requireLoop(message.type);
+
+        switch (message.type) {
+            case 'setUniformValues':
+                this.setUniformValues(message.programId, message.values);
+                break;
+            case 'setPasses':
+                this.setPasses(message.passes);
+                break;
+            case 'resize':
+                this.applySize(message.renderWidth, message.renderHeight);
+                break;
+            case 'setActive':
+                this.setActive(loop, message.active);
+                break;
+            case 'invalidate':
+                this.invalidate(loop, message.frames);
+                break;
+            case 'setFrameloop':
+                loop.setFrameloop(message.mode);
+                break;
+            case 'setSpeed':
+                loop.setSpeed(message.speed);
+                break;
+            case 'renderFrame':
+                loop.setFrame(msToFrame(message.time));
+                break;
+        }
+    }
+
+    private init(canvas: OffscreenCanvas, config: WorkerInitConfig): void {
+        if (this.canvas) {
+            throw new Error(
+                'micugl worker: received a second "init" message; one worker runtime drives exactly one canvas'
+            );
+        }
+
+        this.canvas = canvas;
+        this.config = config;
+        this.renderWidth = canvas.width;
+        this.renderHeight = canvas.height;
+
+        canvas.addEventListener('webglcontextlost', this.onContextLost);
+        canvas.addEventListener('webglcontextrestored', this.onContextRestored);
+
+        this.seedUniformState(config);
+        this.build();
+
+        this.loop = new RenderLoop({
+            requestAnimationFrame: callback => this.host.requestAnimationFrame(callback),
+            cancelAnimationFrame: handle => { this.host.cancelAnimationFrame(handle) },
+            now: () => this.host.now(),
+            render: this.renderTick,
+            frameloop: config.frameloop,
+            speed: config.speed,
+            pauseWhenHidden: false
+        });
+
+        this.active = config.active;
+        if (config.active) {
+            this.loop.start();
+        }
+
+        this.host.postMessage({ type: 'ready', capabilities: this.readCapabilities() });
+    }
+
+    private seedUniformState(config: WorkerInitConfig): void {
+        for (const [programId, descriptors] of Object.entries(config.descriptors)) {
+            this.uniformTypes.set(
+                programId,
+                new Map(descriptors.map(descriptor => [descriptor.name, descriptor.type]))
+            );
+        }
+
+        for (const [programId, values] of Object.entries(config.initialValues)) {
+            const store: UniformValueMap = {};
+            for (const [name, value] of Object.entries(values)) {
+                this.validateUniformValue(programId, name, value);
+                store[name] = value;
+            }
+            this.values.set(programId, store);
+        }
+    }
+
+    private build(): void {
+        const canvas = this.canvas;
+        const config = this.config;
+        if (!canvas || !config) {
+            throw new Error('micugl worker: cannot build GL resources before "init"');
+        }
+
+        this.destroyManager();
+
+        const manager = new WebGLManager(canvas, config.contextAttributes);
+        if (manager.context.isContextLost()) {
+            throw new Error('micugl worker: the WebGL context is lost; cannot create shader programs');
+        }
+
+        this.manager = manager;
+        this.passSystem = null;
+        this.programId = null;
+        this.registered.clear();
+
+        for (const [programId, programConfig] of Object.entries(config.programConfigs)) {
+            manager.createProgram(programId, programConfig);
+        }
+
+        if (config.kind === 'single') {
+            const [programId] = singleProgramEntry(config.programConfigs);
+            manager.createBuffer(programId, 'a_position', QUAD_VERTICES);
+            manager.setAttributeOnce(programId, 'a_position', {
+                name: 'a_position',
+                size: 2,
+                type: 'FLOAT',
+                normalized: false,
+                stride: 0,
+                offset: 0
+            });
+            this.programId = programId;
+        } else {
+            this.createFramebuffers(manager, config.framebuffers);
+            this.buildPasses(manager, config.passes ?? []);
+        }
+
+        this.registerUniformUpdaters(manager);
+        this.applySize(this.renderWidth, this.renderHeight);
+    }
+
+    private createFramebuffers(
+        manager: WebGLManager,
+        framebuffers: Record<string, FramebufferOptions> | undefined
+    ): void {
+        for (const [id, options] of Object.entries(framebuffers ?? {})) {
+            manager.fbo.createFramebuffer(id, {
+                ...options,
+                width: options.width || this.renderWidth,
+                height: options.height || this.renderHeight
+            });
+        }
+    }
+
+    private buildPasses(manager: WebGLManager, passes: SerializableRenderPass[]): void {
+        const passSystem = new Passes(manager);
+        for (const pass of passes) {
+            passSystem.addPass(this.toRenderPass(pass));
+        }
+        passSystem.initializeResources();
+        this.passSystem = passSystem;
+    }
+
+    private toRenderPass(pass: SerializableRenderPass): RenderPass {
+        let uniforms: RenderPass['uniforms'];
+
+        if (pass.uniforms) {
+            uniforms = {};
+            for (const [name, uniform] of Object.entries(pass.uniforms)) {
+                if (uniform.kind === 'builtin') {
+                    const builtin = this.builtinUpdater(name, pass.programId);
+                    uniforms[name] = {
+                        type: builtin.type,
+                        value: builtin.updateFn as RenderPassUniformValue
+                    };
+                    continue;
+                }
+                uniforms[name] = {
+                    type: uniform.type,
+                    value: toPassUniformValue(pass.programId, name, uniform.type, uniform.value)
+                };
+            }
+        }
+
+        return {
+            programId: pass.programId,
+            inputTextures: pass.inputTextures,
+            outputFramebuffer: pass.outputFramebuffer,
+            uniforms,
+            renderOptions: pass.renderOptions
+        };
+    }
+
+    private builtinUpdater(name: string, programId: string): UniformUpdaterDef {
+        const builtin = createCommonUpdaters().find(def => def.name === name);
+        if (!builtin) {
+            throw new Error(
+                `micugl worker: uniform "${name}" on program "${programId}" was sent as a worker built-in, `
+                + 'but the worker computes no built-in with that name'
+            );
+        }
+        return builtin;
+    }
+
+    private registerUniformUpdaters(manager: WebGLManager): void {
+        const config = this.requireConfig();
+
+        for (const [programId, programConfig] of Object.entries(config.programConfigs)) {
+            for (const uniform of programConfig.uniforms) {
+                const hasPostedValue = this.values.get(programId)?.[uniform.name] !== undefined;
+                if (isWorkerBuiltinUniformName(uniform.name) && !hasPostedValue) {
+                    this.ensureBuiltinUpdater(manager, programId, uniform.name);
+                }
+            }
+        }
+
+        for (const [programId, values] of this.values) {
+            for (const name of Object.keys(values)) {
+                this.ensureValueUpdater(manager, programId, name);
+            }
+        }
+    }
+
+    private markRegistered(programId: string, name: string): void {
+        const names = this.registered.get(programId) ?? new Set<string>();
+        names.add(name);
+        this.registered.set(programId, names);
+    }
+
+    private isRegistered(programId: string, name: string): boolean {
+        return this.registered.get(programId)?.has(name) ?? false;
+    }
+
+    private ensureBuiltinUpdater(manager: WebGLManager, programId: string, name: string): void {
+        if (this.isRegistered(programId, name)) {
+            return;
+        }
+
+        const builtin = this.builtinUpdater(name, programId);
+        manager.registerUniformUpdater(programId, name, builtin.type, builtin.updateFn);
+        this.markRegistered(programId, name);
+    }
+
+    private ensureValueUpdater(manager: WebGLManager, programId: string, name: string): void {
+        if (this.isRegistered(programId, name)) {
+            return;
+        }
+
+        const type = this.uniformType(programId, name);
+        manager.registerUniformUpdater(programId, name, type, this.createValueUpdater(programId, name));
+        this.markRegistered(programId, name);
+    }
+
+    private createValueUpdater(programId: string, name: string): UniformUpdateFn<UniformType> {
+        const read = (): UniformScalar | UniformVector | undefined => this.values.get(programId)?.[name];
+        return read as UniformUpdateFn<UniformType>;
+    }
+
+    private uniformType(programId: string, name: string): UniformType {
+        const types = this.uniformTypes.get(programId);
+        if (!types) {
+            throw new Error(
+                `micugl worker: received uniform values for unknown program "${programId}". Programs are fixed `
+                + 'at init; the main thread must not post values for a program it did not declare.'
+            );
+        }
+
+        const type = types.get(name);
+        if (!type) {
+            throw new Error(
+                `micugl worker: received a value for uniform "${name}" on program "${programId}", which was not `
+                + 'declared at init. Worker-mode uniforms must be declared up front so the worker knows their type.'
+            );
+        }
+        return type;
+    }
+
+    private validateUniformValue(
+        programId: string,
+        name: string,
+        value: UniformScalar | UniformVector
+    ): void {
+        assertUniformComponents('uniform', programId, name, this.uniformType(programId, name), value);
+    }
+
+    private setUniformValues(programId: string, values: UniformValueMap): void {
+        const manager = this.requireManager('setUniformValues');
+        const store = this.values.get(programId) ?? {};
+
+        for (const [name, value] of Object.entries(values)) {
+            this.validateUniformValue(programId, name, value);
+            store[name] = value;
+        }
+
+        this.values.set(programId, store);
+
+        for (const name of Object.keys(values)) {
+            this.ensureValueUpdater(manager, programId, name);
+        }
+    }
+
+    private setPasses(passes: SerializableRenderPass[]): void {
+        const manager = this.requireManager('setPasses');
+        const config = this.requireConfig();
+        const passSystem = this.passSystem;
+
+        if (!passSystem) {
+            throw new Error(
+                'micugl worker: received "setPasses" but this worker was initialized in "single" mode; '
+                + 'render passes require kind: "pingpong"'
+            );
+        }
+
+        config.passes = passes;
+
+        passSystem.clearPasses();
+        for (const pass of passes) {
+            passSystem.addPass(this.toRenderPass(pass));
+        }
+        passSystem.initializeResources();
+        this.registerUniformUpdaters(manager);
+        this.loop?.invalidate();
+    }
+
+    private applySize(renderWidth: number, renderHeight: number): void {
+        const manager = this.requireManager('resize');
+        const config = this.requireConfig();
+
+        this.renderWidth = renderWidth;
+        this.renderHeight = renderHeight;
+
+        manager.setDrawingBufferSize(renderWidth, renderHeight);
+        manager.fbo.setCanvasViewport(renderWidth, renderHeight);
+
+        for (const [id, options] of Object.entries(config.framebuffers ?? {})) {
+            manager.fbo.resizeFramebuffer(
+                id,
+                options.width || renderWidth,
+                options.height || renderHeight
+            );
+        }
+
+        this.loop?.invalidate();
+    }
+
+    private setActive(loop: RenderLoop, active: boolean): void {
+        this.active = active;
+
+        if (!active) {
+            loop.stop();
+            return;
+        }
+
+        if (!this.contextLost) {
+            loop.start();
+        }
+    }
+
+    private invalidate(loop: RenderLoop, frames: number | undefined): void {
+        const requested = frames ?? 1;
+        if (!Number.isInteger(requested) || requested < 1) {
+            throw new Error(
+                'micugl worker: invalidate(frames) requires a positive integer number of frames, received '
+                + String(frames)
+            );
+        }
+
+        this.pendingFrames = Math.max(this.pendingFrames, requested);
+        loop.invalidate();
+    }
+
+    private readonly renderTick = (elapsed: number): void => {
+        try {
+            if (this.draw(elapsed)) {
+                this.consumePendingFrame();
+            }
+        } catch (error) {
+            this.fail(error);
+        }
+    };
+
+    private consumePendingFrame(): void {
+        if (this.pendingFrames === 0) {
+            return;
+        }
+
+        this.pendingFrames -= 1;
+        if (this.pendingFrames > 0) {
+            this.loop?.invalidate();
+        }
+    }
+
+    private draw(timeMs: number): boolean {
+        if (this.contextLost) {
+            return false;
+        }
+
+        const manager = this.requireManager('render');
+        const config = this.requireConfig();
+
+        if (config.kind === 'pingpong') {
+            const passSystem = this.passSystem;
+            if (!passSystem) {
+                throw new Error('micugl worker: no pass system was built for this "pingpong" worker');
+            }
+            passSystem.execute(timeMs);
+            return true;
+        }
+
+        const programId = this.programId;
+        if (!programId) {
+            throw new Error('micugl worker: no program was built for this "single" worker');
+        }
+
+        manager.fastRender(programId, timeMs, config.renderOptions?.clear);
+        const gl = manager.context;
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+        return true;
+    }
+
+    private readonly onContextLost = (event: Event): void => {
+        if (this.failed) {
+            return;
+        }
+        event.preventDefault();
+        this.contextLost = true;
+        this.loop?.stop();
+        this.host.postMessage({ type: 'contextlost' });
+    };
+
+    private readonly onContextRestored = (): void => {
+        if (this.failed) {
+            return;
+        }
+        try {
+            this.contextLost = false;
+            this.build();
+            this.host.postMessage({ type: 'contextrestored' });
+            if (this.active) {
+                this.loop?.start();
+            }
+        } catch (error) {
+            this.fail(error);
+        }
+    };
+
+    private readCapabilities(): WorkerCapabilities {
+        const manager = this.requireManager('ready');
+        const gl = manager.context;
+
+        return {
+            maxTextureSize: gl.getParameter(gl.MAX_TEXTURE_SIZE) as number,
+            extensions: PROBED_EXTENSIONS.filter(name => manager.getExtension(name) !== null)
+        };
+    }
+
+    private dispose(): void {
+        this.disposed = true;
+        this.loop?.stop();
+        this.loop = null;
+
+        this.canvas?.removeEventListener('webglcontextlost', this.onContextLost);
+        this.canvas?.removeEventListener('webglcontextrestored', this.onContextRestored);
+
+        this.destroyManager();
+        this.passSystem = null;
+
+        this.host.close?.();
+    }
+
+    private destroyManager(): void {
+        const manager = this.manager;
+        this.manager = null;
+
+        if (manager && !manager.context.isContextLost()) {
+            manager.destroyAll();
+        }
+    }
+
+    private fail(error: unknown): void {
+        this.failed = true;
+        this.loop?.stop();
+        this.host.postMessage({ type: 'error', message: errorMessage(error) });
+    }
+
+    private requireLoop(messageType: string): RenderLoop {
+        const loop = this.loop;
+        if (!loop) {
+            throw new Error(`micugl worker: received "${messageType}" before "init"`);
+        }
+        return loop;
+    }
+
+    private requireManager(messageType: string): WebGLManager {
+        const manager = this.manager;
+        if (!manager) {
+            throw new Error(`micugl worker: received "${messageType}" before the GL context was created`);
+        }
+        return manager;
+    }
+
+    private requireConfig(): WorkerInitConfig {
+        const config = this.config;
+        if (!config) {
+            throw new Error('micugl worker: the init config is missing');
+        }
+        return config;
+    }
+}
+
+function toPassUniformValue(
+    programId: string,
+    name: string,
+    type: UniformType,
+    value: UniformScalar | UniformVector
+): RenderPassUniformValue {
+    assertUniformComponents('pass uniform', programId, name, type, value);
+
+    if (typeof value === 'number') {
+        return value;
+    }
+
+    return new Float32Array(value) as RenderPassUniformValue;
+}

--- a/src/worker/createWorker.test.ts
+++ b/src/worker/createWorker.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CreateWorkerOptions, WorkerFactoryDeps, WorkerSupportScope } from '@/worker/createWorker';
+import {
+    blobWorkerFailedMessage,
+    createOnceLogger,
+    createWorkerWithDeps,
+    isWorkerModeSupported,
+    overrideWorkerFailedMessage,
+    requireInlineWorkerConstructor,
+    unsupportedMessage,
+    unusableInlineWorkerMessage
+} from '@/worker/createWorker';
+
+const WORKER = { name: 'worker' } as unknown as Worker;
+
+function supportedScope(): WorkerSupportScope {
+    return {
+        OffscreenCanvas: {},
+        Worker: {},
+        HTMLCanvasElement: { prototype: { transferControlToOffscreen: () => undefined } }
+    };
+}
+
+function inlineWorkerModule(construct: () => Worker): unknown {
+    return {
+        default: function InlineWorker(): Worker {
+            return construct();
+        }
+    };
+}
+
+function createDeps(overrides: Partial<WorkerFactoryDeps> = {}): {
+    deps: WorkerFactoryDeps;
+    log: ReturnType<typeof vi.fn>;
+    construct: ReturnType<typeof vi.fn>;
+    loadInlineWorker: ReturnType<typeof vi.fn>;
+    } {
+    const log = vi.fn((_message: string) => undefined);
+    const construct = vi.fn(() => WORKER);
+    const loadInlineWorker = vi.fn(() => Promise.resolve(inlineWorkerModule(() => construct())));
+
+    const deps: WorkerFactoryDeps = {
+        loadInlineWorker: () => loadInlineWorker(),
+        log: message => { log(message) },
+        ...overrides
+    };
+
+    return { deps, log, construct, loadInlineWorker };
+}
+
+function options(overrides: Partial<CreateWorkerOptions> = {}): CreateWorkerOptions {
+    return { scope: supportedScope(), ...overrides };
+}
+
+describe('isWorkerModeSupported', () => {
+    it('accepts a browser with OffscreenCanvas, Worker and transferControlToOffscreen', () => {
+        expect(isWorkerModeSupported(supportedScope())).toBe(true);
+    });
+
+    it('rejects an environment without OffscreenCanvas', () => {
+        const scope = supportedScope();
+        scope.OffscreenCanvas = undefined;
+        expect(isWorkerModeSupported(scope)).toBe(false);
+    });
+
+    it('rejects an environment without Worker', () => {
+        const scope = supportedScope();
+        scope.Worker = undefined;
+        expect(isWorkerModeSupported(scope)).toBe(false);
+    });
+
+    it('rejects a browser whose canvas cannot transfer control offscreen', () => {
+        const scope = supportedScope();
+        scope.HTMLCanvasElement = { prototype: {} };
+        expect(isWorkerModeSupported(scope)).toBe(false);
+    });
+
+    it('rejects a server-side scope with no canvas class at all', () => {
+        expect(isWorkerModeSupported({})).toBe(false);
+    });
+});
+
+describe('requireInlineWorkerConstructor', () => {
+    it('returns the default export of the inlined worker module', () => {
+        const construct = (): Worker => WORKER;
+        const InlineWorker = requireInlineWorkerConstructor(inlineWorkerModule(construct));
+
+        expect(new InlineWorker()).toBe(WORKER);
+    });
+
+    it.each([
+        ['a module with no default export', {}],
+        ['a default export that is not constructible', { default: 'not a worker' }],
+        ['nothing at all', null],
+        ['an undefined module', undefined]
+    ])('fails loud rather than paint nothing for %s', (_label, module) => {
+        expect(() => requireInlineWorkerConstructor(module)).toThrow(/no default export to construct/);
+    });
+});
+
+describe('createWorkerWithDeps inline worker', () => {
+    it('constructs the worker the ?worker&inline import resolved to', async () => {
+        const { deps, construct, loadInlineWorker, log } = createDeps();
+
+        const worker = await createWorkerWithDeps(options(), deps);
+
+        expect(worker).toBe(WORKER);
+        expect(loadInlineWorker).toHaveBeenCalledTimes(1);
+        expect(construct).toHaveBeenCalledTimes(1);
+        expect(log).not.toHaveBeenCalled();
+    });
+
+    it('throws instead of constructing a worker that would run no code', async () => {
+        const { deps, construct } = createDeps({ loadInlineWorker: () => Promise.resolve({}) });
+
+        await expect(createWorkerWithDeps(options(), deps))
+            .rejects.toThrow(/no default export to construct/);
+        expect(construct).not.toHaveBeenCalled();
+    });
+});
+
+describe('createWorkerWithDeps fallback', () => {
+    it('falls back to the main thread, logging why, when the browser cannot do worker mode', async () => {
+        const { deps, log, loadInlineWorker } = createDeps();
+
+        const worker = await createWorkerWithDeps(options({ scope: {} }), deps);
+
+        expect(worker).toBeNull();
+        expect(loadInlineWorker).not.toHaveBeenCalled();
+        expect(log).toHaveBeenCalledWith(unsupportedMessage());
+    });
+
+    it('falls back to the main thread when a CSP blocks the blob worker, naming both remedies', async () => {
+        const cspError = new Error('Refused to create a worker from blob: because it violates the CSP');
+        const { deps, log } = createDeps({
+            loadInlineWorker: () => Promise.resolve(inlineWorkerModule(() => { throw cspError }))
+        });
+
+        const worker = await createWorkerWithDeps(options(), deps);
+
+        expect(worker).toBeNull();
+        expect(log).toHaveBeenCalledWith(blobWorkerFailedMessage(cspError));
+
+        const message = log.mock.calls[0][0] as string;
+        expect(message).toContain('worker-src \'self\' blob:');
+        expect(message).toContain('createWorker=');
+        expect(message).toContain('micugl/worker');
+        expect(message).toContain('violates the CSP');
+    });
+});
+
+describe('createWorkerWithDeps createWorker override', () => {
+    it('uses the caller-supplied worker and never touches the inlined worker', async () => {
+        const custom = { name: 'custom' } as unknown as Worker;
+        const { deps, loadInlineWorker, construct } = createDeps();
+
+        const worker = await createWorkerWithDeps(options({ createWorker: () => custom }), deps);
+
+        expect(worker).toBe(custom);
+        expect(loadInlineWorker).not.toHaveBeenCalled();
+        expect(construct).not.toHaveBeenCalled();
+    });
+
+    it('blames the caller factory, not a blob CSP, when the caller-supplied factory throws', async () => {
+        const { deps, log } = createDeps();
+
+        const worker = await createWorkerWithDeps(
+            options({
+                createWorker: () => {
+                    throw new Error('module worker blocked');
+                }
+            }),
+            deps
+        );
+
+        expect(worker).toBeNull();
+        expect(log).toHaveBeenCalledWith(overrideWorkerFailedMessage(new Error('module worker blocked')));
+
+        const message = log.mock.calls[0][0] as string;
+        expect(message).toContain('createWorker() factory you passed threw (module worker blocked)');
+        expect(message).toContain('worker-src \'self\'');
+        expect(message).not.toContain('blob:');
+    });
+
+    it('still refuses to run when the browser cannot transfer a canvas offscreen', async () => {
+        const custom = vi.fn(() => WORKER);
+        const { deps, log } = createDeps();
+
+        const worker = await createWorkerWithDeps(
+            options({ scope: { ...supportedScope(), OffscreenCanvas: undefined }, createWorker: custom }),
+            deps
+        );
+
+        expect(worker).toBeNull();
+        expect(custom).not.toHaveBeenCalled();
+        expect(log).toHaveBeenCalledWith(unsupportedMessage());
+    });
+});
+
+describe('createOnceLogger', () => {
+    it('logs each distinct message exactly once', () => {
+        const sink = vi.fn();
+        const log = createOnceLogger(sink);
+
+        log(unsupportedMessage());
+        log(unsupportedMessage());
+        log(unusableInlineWorkerMessage());
+
+        expect(sink).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/worker/createWorker.ts
+++ b/src/worker/createWorker.ts
@@ -1,0 +1,134 @@
+export interface WorkerSupportScope {
+    OffscreenCanvas?: unknown;
+    Worker?: unknown;
+    HTMLCanvasElement?: { prototype: object };
+}
+
+export interface CreateWorkerOptions {
+    createWorker?: () => Worker;
+    scope?: WorkerSupportScope;
+    log?: (message: string) => void;
+}
+
+export type InlineWorkerConstructor = new () => Worker;
+
+export interface WorkerFactoryDeps {
+    loadInlineWorker: () => Promise<unknown>;
+    log: (message: string) => void;
+}
+
+const ESCAPE_HATCHES =
+    'Either pass createWorker={() => new Worker(new URL(\'micugl/worker\', import.meta.url), '
+    + '{ type: \'module\' })} to build the worker yourself, or turn worker mode off.';
+
+const MAIN_THREAD_FALLBACK =
+    'Rendering on the main thread instead: the picture is identical, only the threading benefit is lost.';
+
+function errorDetail(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+export function createOnceLogger(sink: (message: string) => void): (message: string) => void {
+    const seen = new Set<string>();
+    return message => {
+        if (seen.has(message)) {
+            return;
+        }
+        seen.add(message);
+        sink(message);
+    };
+}
+
+export function isWorkerModeSupported(scope: WorkerSupportScope): boolean {
+    if (scope.OffscreenCanvas === undefined || scope.Worker === undefined) {
+        return false;
+    }
+
+    const canvasClass = scope.HTMLCanvasElement;
+    if (!canvasClass) {
+        return false;
+    }
+
+    return 'transferControlToOffscreen' in canvasClass.prototype;
+}
+
+export function unsupportedMessage(): string {
+    return 'micugl worker: this environment has no OffscreenCanvas / '
+        + 'HTMLCanvasElement.transferControlToOffscreen / Worker, so the render loop cannot move off the main '
+        + `thread. ${MAIN_THREAD_FALLBACK}`;
+}
+
+export function blobWorkerFailedMessage(error: unknown): string {
+    return `micugl worker: constructing the render worker failed (${errorDetail(error)}). The usual cause is a `
+        + 'Content-Security-Policy that forbids blob: workers. Remedy: add "worker-src \'self\' blob:" to your '
+        + `CSP. ${ESCAPE_HATCHES} ${MAIN_THREAD_FALLBACK}`;
+}
+
+export function overrideWorkerFailedMessage(error: unknown): string {
+    return `micugl worker: the createWorker() factory you passed threw (${errorDetail(error)}), so there is no `
+        + 'render worker to drive the canvas. micugl did not build this worker and cannot fix it: make the '
+        + 'factory return a worker your page is allowed to load, for example a same-origin worker URL such as '
+        + 'new Worker(new URL(\'micugl/worker\', import.meta.url), { type: \'module\' }) served from your own '
+        + `origin, with "worker-src 'self'" in your CSP. ${MAIN_THREAD_FALLBACK}`;
+}
+
+export function unusableInlineWorkerMessage(): string {
+    return 'micugl worker: the inlined worker module has no default export to construct, so a worker built '
+        + 'from it would run no code and paint nothing. This build of micugl is broken: its '
+        + `"?worker&inline" import did not resolve to a worker. ${ESCAPE_HATCHES}`;
+}
+
+export function requireInlineWorkerConstructor(module: unknown): InlineWorkerConstructor {
+    const candidate = typeof module === 'object' && module !== null
+        ? (module as { default?: unknown }).default
+        : undefined;
+
+    if (typeof candidate !== 'function') {
+        throw new Error(unusableInlineWorkerMessage());
+    }
+
+    return candidate as InlineWorkerConstructor;
+}
+
+export async function createWorkerWithDeps(
+    options: CreateWorkerOptions,
+    deps: WorkerFactoryDeps
+): Promise<Worker | null> {
+    const scope = options.scope ?? (globalThis as WorkerSupportScope);
+    const log = options.log ?? deps.log;
+
+    if (!isWorkerModeSupported(scope)) {
+        log(unsupportedMessage());
+        return null;
+    }
+
+    const override = options.createWorker;
+    if (override) {
+        try {
+            return override();
+        } catch (error) {
+            log(overrideWorkerFailedMessage(error));
+            return null;
+        }
+    }
+
+    const InlineWorker = requireInlineWorkerConstructor(await deps.loadInlineWorker());
+
+    try {
+        return new InlineWorker();
+    } catch (error) {
+        log(blobWorkerFailedMessage(error));
+        return null;
+    }
+}
+
+const defaultLog = createOnceLogger(message => { console.error(message) });
+
+const defaultDeps: WorkerFactoryDeps = {
+    loadInlineWorker: () => import('@/worker/workerEntry?worker&inline'),
+    log: defaultLog
+};
+
+export function createMicuglWorker(options: CreateWorkerOptions = {}): Promise<Worker | null> {
+    return createWorkerWithDeps(options, defaultDeps);
+}

--- a/src/worker/inlineWorker.d.ts
+++ b/src/worker/inlineWorker.d.ts
@@ -1,0 +1,4 @@
+declare module '*?worker&inline' {
+    const workerConstructor: new () => Worker;
+    export default workerConstructor;
+}

--- a/src/worker/protocol.ts
+++ b/src/worker/protocol.ts
@@ -39,6 +39,8 @@ export type UniformScalar = number;
 export type UniformVector = number[];
 export type UniformValueMap = Record<string, UniformScalar | UniformVector>;
 
+export type WorkerRenderOptions = Pick<RenderOptions, 'clear'>;
+
 export interface UniformDescriptor {
     name: string;
     type: UniformType;
@@ -77,6 +79,7 @@ export interface WorkerInitConfig {
     frameloop: Frameloop;
     speed: number;
     active: boolean;
+    renderOptions?: WorkerRenderOptions;
     contextAttributes?: WebGLContextAttributes;
 }
 

--- a/src/worker/workerEntry.ts
+++ b/src/worker/workerEntry.ts
@@ -1,0 +1,29 @@
+import type { MainToWorker, WorkerToMain } from '@/worker/protocol';
+import { WorkerRuntime } from '@/worker/WorkerRuntime';
+
+export interface WorkerGlobalScopeLike {
+    postMessage: (message: WorkerToMain) => void;
+    addEventListener: (
+        type: 'message',
+        listener: (event: { data: MainToWorker }) => void
+    ) => void;
+    requestAnimationFrame: (callback: (now: number) => void) => number;
+    cancelAnimationFrame: (handle: number) => void;
+    close: () => void;
+}
+
+export function startWorkerRuntime(scope: WorkerGlobalScopeLike): WorkerRuntime {
+    const runtime = new WorkerRuntime({
+        postMessage: message => { scope.postMessage(message) },
+        requestAnimationFrame: callback => scope.requestAnimationFrame(callback),
+        cancelAnimationFrame: handle => { scope.cancelAnimationFrame(handle) },
+        now: () => performance.now(),
+        close: () => { scope.close() }
+    });
+
+    scope.addEventListener('message', event => { runtime.handleMessage(event.data) });
+
+    return runtime;
+}
+
+startWorkerRuntime(globalThis as unknown as WorkerGlobalScopeLike);

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,5 +7,12 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts", "src/micugl.d.ts"],
+  "include": [
+    "vite.config.ts",
+    "vite.worker.config.ts",
+    "vite.workerPlugins.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "src/micugl.d.ts"
+  ],
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,13 @@ import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
+import { assertWorkerIsReactFree } from './vite.workerPlugins';
+
 export default defineConfig({
+    worker: {
+        format: 'iife',
+        plugins: () => [assertWorkerIsReactFree()]
+    },
     build: {
         lib: {
             entry: {

--- a/vite.worker.config.ts
+++ b/vite.worker.config.ts
@@ -1,0 +1,30 @@
+import { resolve } from 'node:path';
+
+import { defineConfig } from 'vite';
+
+import { assertWorkerIsReactFree } from './vite.workerPlugins';
+
+export default defineConfig({
+    build: {
+        outDir: 'dist',
+        emptyOutDir: false,
+        target: 'es2020',
+        minify: 'esbuild',
+        lib: {
+            entry: resolve(__dirname, 'src/worker/workerEntry.ts'),
+            formats: ['es'],
+            fileName: () => 'worker.mjs'
+        },
+        rollupOptions: {
+            external: [],
+            output: {
+                preserveModules: false,
+                inlineDynamicImports: true
+            }
+        }
+    },
+    resolve: {
+        alias: { '@': resolve(__dirname, 'src') }
+    },
+    plugins: [assertWorkerIsReactFree()]
+});

--- a/vite.workerPlugins.ts
+++ b/vite.workerPlugins.ts
@@ -1,0 +1,20 @@
+import type { Plugin } from 'vite';
+
+const REACT_SPECIFIER = /^react(?:$|[/-])/;
+
+export function assertWorkerIsReactFree(): Plugin {
+    return {
+        name: 'micugl-worker-no-react',
+        enforce: 'pre',
+        resolveId(source, importer) {
+            if (REACT_SPECIFIER.test(source)) {
+                throw new Error(
+                    `micugl worker build: the worker bundle must not depend on React, but "${source}" was `
+                    + `imported by ${importer ?? 'the worker entry'}. Keep worker-side code in React-free `
+                    + 'modules.'
+                );
+            }
+            return null;
+        }
+    };
+}


### PR DESCRIPTION
Second slice of worker rendering (plan Feature 1). W1 gave us the message protocol and the main-side controller; this is the half that actually renders, plus the mechanism that ships the worker to consumers. No React wiring yet - that is W3.

## What runs in the worker

`WorkerRuntime` is built from an `init` message: it constructs a `WebGLManager` on the transferred `OffscreenCanvas`, then either the single-program fullscreen path or the ping-pong path (`Passes` + `FBOManager`), and owns the rAF loop. It reuses `RenderLoop`, `createCommonUpdaters` and the dirty-check machinery verbatim rather than reimplementing frameloop/demand/speed semantics, so worker mode and main-thread mode cannot drift. `WebGLManager` is now offscreen-safe (the `.style` writes in `setSize` are guarded; the `gl.canvas` casts accept either canvas type), with no behavior change on the main thread.

`workerEntry.ts` is the thin global-scope entry the build bundles self-contained.

## How the worker gets to consumers

Vite's own `?worker&inline`, loaded through a dynamic import so it stays a lazily-fetched chunk. At our build time this produces a fully self-contained classic worker embedded as a plain string (Vite 6 stopped using base64), wrapped in a Blob and an object URL at runtime. Consumers need no bundler configuration and no extra file to host.

The first draft of this hand-rolled the same thing: a placeholder source module whose body a custom Vite `transform` plugin rewrote into the bundled worker IIFE, plus a staging directory and assertions that the artifact was import-free. That is a real pattern - Sentry's replay worker and zip.js both do it - but they are on raw rollup, where there is no built-in. In Vite lib mode it reimplements a first-class feature, so it is gone: the placeholder file, the transform plugin, the classic-worker assertions and the whole `.worker-build` pass are deleted.

The second build config survives for the one thing the inline path does not give us: `dist/worker.mjs`, a standalone ES module worker behind the `./worker` export. That is the escape hatch, and it is a documented, tested path rather than an afterthought - under a strict CSP it is the only path that works, because there is no nonce or hash mechanism for workers.

A blocked blob worker (CSP) is caught before anything is transferred, logged once with the actual remedy (`worker-src 'self' blob:`, or pass `createWorker`), and falls back to main-thread rendering. That is the one justified fail-open: worker-mode uniform rules are a strict subset of main-thread rules, so the picture is still correct and only the threading benefit is lost. An unusable inline module, by contrast, is a packaging bug and throws.

The treeshake guard now asserts the property rather than a filename: nothing statically reachable from the public entries may contain the worker body, some emitted chunk must contain it, that chunk must be reached only by dynamic import, and it must be self-contained. Verified non-vacuous against a copied `dist` - injecting a static import, deleting the chunk, adding an import to it, and deleting `dist/worker.mjs` each fail the build.

## Bugs caught in review

Two reviewers ran over this, one for correctness and one for style and simplification. The correctness pass found that **`u_time` was frozen at zero in worker mode**, which is the feature's headline promise. The runtime registered built-in updaters from the `descriptors` the bridge sends, but the bridge builds those from the `uniforms` prop, while main-thread mode *unconditionally injects* `u_time`/`u_resolution` whether you declare them or not. So the plan's own example registered no built-in updater at all, and the existing test only passed because its fixture hand-listed `u_time` - a shape the real wiring never produces. Built-ins are now driven off the shader program's own uniform list.

Also fixed: `renderFrame` drew out of band without setting the loop clock, so any resize discarded the deterministic frame; `setActive(true)` during a lost context started a loop that drew nothing forever and silently consumed queued demand frames; a failed `init` left an undead runtime that posted one error per subsequent message and could later report a restored context without ever reporting ready; `dispose` before `init` errored instead of shutting down and never called `close()`; rebuilding after context loss leaked the previous `WebGLManager`; and the `createWorker` override's failure message blamed blob CSP for a path that never touches blob while telling you to pass the prop you had just passed.

The style pass removed a `WebGLContextFactory` that existed for nothing (the union `getContext` call typechecks on its own), two `as unknown as` casts, a duplicated uniform validation, an eslint config change that `tsconfig.node.json` had already made unnecessary, and a `draw()` that returned early on a state the code claimed was impossible. The wire protocol is no longer exported from the package root, so an internal message format is not frozen as public API.

Context loss is now genuinely simulated in the tests (previously they fired the event while the stub still reported a live context, so the guard was dead code in the suite), including `resize`/`invalidate`/`setActive` arriving mid-loss, which is where two of the bugs above lived.

## Verification

555 tests. Full gate green from a clean tree: typecheck with no prior build, lint, test, build including the treeshake guard. Both paths were driven in a real headless browser: `bun run dev` boots a live module worker with no build artifact, and the built `dist/` boots the classic blob worker, each replying with our own runtime's fail-loud message.

Known and deliberate: in dev the inline import resolves to a module worker pointing at the source, while a build produces a classic blob worker. The worker source graph has no `importScripts`, no `import.meta`, no top-level await and no dynamic import, so both scopes behave identically - that is a constraint worker-side code has to keep.

Cosmetic, not fixed: the inline chunk lands at `dist/worker/workerEntry.mjs`, next to `workerEntry.d.ts`, which declares the source module rather than the wrapper. Nothing resolves the two together and the exports map blocks deep imports.
