### PR TITLE
worker: W3 react wiring — worker/createWorker/liveUniforms props, transfer ordering, fail-loud uniform boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,103 @@ deterministic frame instead of animating continuously.
   `setFrame`/`ShaderHandle`. Pick a frame that looks good as a static image for shaders
   that are dull at frame 0.
 
+## Worker rendering (OffscreenCanvas)
+
+`worker` moves the GL context and the render loop off the main thread, onto an
+`OffscreenCanvas` inside a Web Worker. The picture is identical; the difference is that
+main-thread jank (React renders, layout, long tasks) no longer stalls the animation.
+
+```tsx
+<BaseShaderComponent worker programId='blob' shaderConfig={config} uniforms={uniforms} />
+```
+
+- `worker={true}` — always use a worker. If a uniform or a prop cannot cross the worker
+  boundary, micugl **throws** and names the uniform and the remedy.
+- `worker="auto"` — use a worker when this browser and this component's props allow it, and
+  fall back to main-thread rendering otherwise. `"auto"` never throws.
+- `worker={false}` (default) — main-thread rendering, unchanged.
+
+### Shipping the worker: CSP
+
+By default micugl builds the worker from an **inlined blob**, so there is no worker file to
+copy, host, or version, and nothing to configure. A strict Content-Security-Policy will block
+that. Two supported fixes, both first-class:
+
+1. Allow blob workers in your CSP:
+
+   ```
+   worker-src 'self' blob:;
+   ```
+
+2. Or build the worker yourself from the `micugl/worker` export and keep `worker-src 'self'`:
+
+   ```tsx
+   <BaseShaderComponent
+       worker
+       createWorker={() => new Worker(new URL('micugl/worker', import.meta.url), { type: 'module' })}
+       ...
+   />
+   ```
+
+If the worker cannot be constructed (no `OffscreenCanvas` support, or a CSP that forbids it),
+micugl logs once, explains the remedy, and renders on the main thread instead. The canvas is
+never transferred in that case, so the fallback is complete: same picture, no worker.
+
+### Uniforms in worker mode
+
+A worker cannot call your functions, so a function-valued uniform cannot simply be sent across.
+
+- **Plain values** (`number`, `number[]`, typed array) are posted when they change, and are
+  dirty-checked on both sides. This is the normal path; use it for anything you drive from
+  React state.
+- **`u_time` and `u_resolution`** are computed inside the worker, from its own frame clock and
+  the canvas size. Do not pass them as functions: micugl throws rather than let the worker
+  quietly compute a different value than the one you wrote.
+- **`liveUniforms`** (`BaseShaderComponent` / `ShaderEngine` only) names function-valued
+  uniforms that micugl evaluates on a main-thread `requestAnimationFrame` and posts every
+  frame:
+
+  ```tsx
+  <BaseShaderComponent
+      worker
+      uniforms={{ mouse: { type: 'vec2', value: () => pointerRef.current } }}
+      liveUniforms={['mouse']}
+      ...
+  />
+  ```
+
+  This costs you a main-thread rAF (the thing worker mode exists to avoid), so keep the list
+  short, or empty. The `time` argument these functions receive comes from the **main thread's**
+  clock and can drift slightly from the worker's, so `liveUniforms` is for inputs that do not
+  depend on time (pointer, scroll, sensors). Time-driven uniforms belong in the shader, where
+  `u_time` is exact.
+- Any other function-valued uniform throws under `worker={true}` and downgrades to the main
+  thread under `worker="auto"`.
+- `liveUniforms` does not cover ping-pong pass uniforms in v1, which is why the ping-pong
+  components do not accept the prop. A `customPasses` entry may not carry a function-valued
+  pass uniform in worker mode, not even `u_time`: the worker cannot call your function, and
+  computing its own built-in instead would draw a different picture. Give the pass uniform a
+  plain value, let micugl build the ping-pong passes for you (their uniforms are posted to the
+  worker), or turn worker mode off on that component.
+
+### v1 non-goals
+
+Worker mode leaves no WebGL context on the main thread, and the following features need one.
+In worker mode they throw, naming the remedy (turn worker mode off on that component):
+
+- `renderToBlob()`, `renderToDataURL()`, `captureStream()`, `record()`, `renderSequence()`,
+  and `resetSimulation()`.
+- `getFrame()`: the render clock lives in the worker and cannot be read synchronously from the
+  main thread. Drive the clock instead with `setFrame(frame)`.
+- Devtools (`debug`): there is no main-thread context to inspect. `debug` + `worker` logs once
+  and inspects nothing.
+- Instancing, and a custom `renderCallback` on `ShaderEngine` (worker mode requires the fast
+  path). Both throw under `worker={true}`.
+
+`invalidate()`, `setFrame()`, `start()`, `stop()`, `frameloop`, `speed`, `pauseWhenHidden`,
+`dpr`, `fit`, `reducedMotion` / `saveData` and the IntersectionObserver / visibility pausing all
+work exactly as they do on the main thread.
+
 ## Deterministic capture
 
 Both `ShaderEngine` and `PingPongShaderEngine` expose `renderToBlob(options?)` and

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "eslint-plugin-react-x": "^1.48.4",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "globals": "^16.0.0",
+        "jsdom": "^29.1.1",
         "mp4-muxer": "^5.2.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -30,12 +31,26 @@
         "webm-muxer": "^5.1.4",
       },
       "peerDependencies": {
+        "mp4-muxer": "^5.2.2",
         "react": "^18.0.0 || ^19.0.0 || ^19.1.0",
         "react-dom": "^18.0.0 || ^19.0.0",
+        "webm-muxer": "^5.1.4",
       },
+      "optionalPeers": [
+        "mp4-muxer",
+        "webm-muxer",
+      ],
     },
   },
   "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.28.6", "", {}, "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg=="],
@@ -73,6 +88,20 @@
     "@babel/traverse": ["@babel/traverse@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/generator": "^7.28.6", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.6", "@babel/template": "^7.28.6", "@babel/types": "^7.28.6", "debug": "^4.3.1" } }, "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg=="],
 
     "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.1.0", "", {}, "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.9", "", { "dependencies": { "@csstools/color-helpers": "^6.1.0", "@csstools/css-calc": "^3.2.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.6", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.6", "", { "os": "aix", "cpu": "ppc64" }, "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw=="],
 
@@ -155,6 +184,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.3", "", { "dependencies": { "@eslint/core": "^0.15.1", "levn": "^0.4.1" } }, "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -346,6 +377,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.17", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ=="],
 
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
     "birecord": ["birecord@0.1.1", "", {}, "sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -376,17 +409,23 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
     "de-indent": ["de-indent@1.0.2", "", {}, "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="],
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.277", "", {}, "sha512-wKXFZw4erWmmOz5N/grBoJ2XrNJGDFMu2+W5ACHza5rHtvsqrK4gb6rnLC7XxKB9WlJ+RmyQatuEXmtm86xbnw=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "es-module-lexer": ["es-module-lexer@2.3.0", "", {}, "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw=="],
 
@@ -472,6 +511,8 @@
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -490,6 +531,8 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jju": ["jju@1.4.0", "", {}, "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="],
@@ -497,6 +540,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -524,9 +569,11 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -557,6 +604,8 @@
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
@@ -606,6 +655,8 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -636,6 +687,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
@@ -644,7 +697,15 @@
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
+    "tldts": ["tldts@7.4.8", "", { "dependencies": { "tldts-core": "^7.4.8" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A=="],
+
+    "tldts-core": ["tldts-core@7.4.8", "", {}, "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
@@ -659,6 +720,8 @@
     "typescript-eslint": ["typescript-eslint@8.37.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.37.0", "@typescript-eslint/parser": "8.37.0", "@typescript-eslint/typescript-estree": "8.37.0", "@typescript-eslint/utils": "8.37.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA=="],
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -676,7 +739,15 @@
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
     "webm-muxer": ["webm-muxer@5.1.4", "", { "dependencies": { "@types/dom-webcodecs": "^0.1.4", "@types/wicg-file-system-access": "^2020.9.5" } }, "sha512-ditzgFVFbfqPaugkIr4mGhAdob5K9HY6Rzlh7TRsA368yA1sp/m5O7nQCcMLdgFDeNGtFPg8B+MeXLtpzKWX6Q=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -684,11 +755,17 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@4.0.5", "", {}, "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -725,6 +802,8 @@
     "@vitest/snapshot/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "@vue/compiler-core/@babel/parser": ["@babel/parser@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.0" }, "bin": "./bin/babel-parser.js" }, "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g=="],
+
+    "@vue/compiler-core/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "@vue/language-core/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-plugin-react-x": "^1.48.4",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^16.0.0",
+    "jsdom": "^29.1.1",
     "mp4-muxer": "^5.2.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,8 @@ export type {
     Vec3,
     Vec4,
     WebGLExtensionName,
-    WebGLExtensionTypes
+    WebGLExtensionTypes,
+    WorkerMode
 } from './types';
 export type { CreateWorkerOptions } from './worker/createWorker';
 export { createMicuglWorker } from './worker/createWorker';

--- a/src/react/components/base/BaseInstancedShaderComponent.tsx
+++ b/src/react/components/base/BaseInstancedShaderComponent.tsx
@@ -13,7 +13,7 @@ import type {
     UniformParam
 } from '@/types';
 
-export interface BaseInstancedShaderProps extends RenderControlProps {
+export interface BaseInstancedShaderProps extends Omit<RenderControlProps, 'worker' | 'createWorker'> {
     programId: string;
     shaderConfig: ShaderProgramConfig;
     uniforms: Record<string, UniformParam>;

--- a/src/react/components/base/BasePingPongShaderComponent.tsx
+++ b/src/react/components/base/BasePingPongShaderComponent.tsx
@@ -2,9 +2,11 @@ import type { CSSProperties } from 'react';
 import { forwardRef, memo, useRef } from 'react';
 
 import type { FramebufferOptions, RenderOptions, RenderPass, ShaderProgramConfig } from '@/core';
+import type { PingPongShaderEngineWorkerProps } from '@/react/components/engine/PingPongShaderEngine';
 import { PingPongShaderEngine } from '@/react/components/engine/PingPongShaderEngine';
 import { usePingPongPasses } from '@/react/hooks/usePingPongPasses';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
+import { workerPingPongUniforms } from '@/react/lib/workerMode';
 import type { PingPongShaderHandle, RenderControlProps, UniformParam } from '@/types';
 
 export interface BasePingPongShaderProps extends RenderControlProps {
@@ -62,6 +64,8 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
     reducedMotion,
     saveData,
     staticFrame,
+    worker,
+    createWorker,
     customPasses,
     renderOptions = RENDER_OPTIONS
 }, ref) => {
@@ -89,6 +93,21 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
     const debugPortRef = useRef<UniformDebugPort | null>(null);
     debugPortRef.current = port;
 
+    const workerProps: PingPongShaderEngineWorkerProps = worker === undefined || worker === false
+        ? {}
+        : {
+            worker,
+            createWorker,
+            workerCustomPasses: customPasses !== undefined,
+            workerUniforms: workerPingPongUniforms({
+                programId,
+                uniforms,
+                secondaryProgramId: secondaryShaderConfig ? actualSecondaryProgramId : undefined,
+                secondaryUniforms,
+                customPasses: customPasses !== undefined
+            })
+        };
+
     return (
         <PingPongShaderEngine
             ref={ref}
@@ -96,6 +115,7 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
             passes={passes}
             framebuffers={framebuffers}
             debugPortRef={debugPortRef}
+            {...workerProps}
             className={className}
             style={style}
             width={width}

--- a/src/react/components/base/BaseShaderComponent.tsx
+++ b/src/react/components/base/BaseShaderComponent.tsx
@@ -3,6 +3,7 @@ import { forwardRef, memo, useRef } from 'react';
 
 import type { RenderOptions, ShaderProgramConfig, ShaderRenderCallback } from '@/core';
 import { ShaderEngine } from '@/react';
+import type { ShaderEngineWorkerProps } from '@/react/components/engine/ShaderEngine';
 import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import type { RenderControlProps, ShaderHandle, UniformParam } from '@/types';
@@ -12,6 +13,7 @@ export interface BaseShaderProps extends RenderControlProps {
     shaderConfig: ShaderProgramConfig;
     uniforms: Record<string, UniformParam>;
     skipDefaultUniforms?: boolean;
+    liveUniforms?: string[];
     debug?: boolean;
     className?: string;
     style?: CSSProperties;
@@ -35,6 +37,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     shaderConfig,
     uniforms,
     skipDefaultUniforms = false,
+    liveUniforms,
     debug = false,
     width,
     height,
@@ -49,6 +52,8 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     reducedMotion,
     saveData,
     staticFrame,
+    worker,
+    createWorker,
     className = '',
     style,
     renderOptions = RENDER_OPTIONS
@@ -58,6 +63,10 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     const debugPortRef = useRef<UniformDebugPort | null>(null);
     debugPortRef.current = port;
 
+    const workerProps: ShaderEngineWorkerProps = worker === undefined || worker === false
+        ? {}
+        : { worker, createWorker, workerUniforms: { [programId]: uniforms }, liveUniforms };
+
     return (
         <ShaderEngine
             ref={ref}
@@ -65,6 +74,8 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
             renderCallback={renderFullscreenQuad}
             uniformUpdaters={updaters}
             debugPortRef={debugPortRef}
+            {...workerProps}
+            workerSkipDefaultUniforms={skipDefaultUniforms}
             width={width}
             height={height}
             pixelRatio={pixelRatio}

--- a/src/react/components/base/BaseShaderComponent.worker.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.worker.test.tsx
@@ -1,0 +1,264 @@
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { Frameloop, ShaderHandle, UniformParam } from '@/types';
+import type { MainToWorker, WorkerToMain } from '@/worker/protocol';
+import type { WorkerRuntimeHost } from '@/worker/WorkerRuntime';
+import { WorkerRuntime } from '@/worker/WorkerRuntime';
+
+const PROGRAM_ID = 'blob';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_level: 'float' }
+});
+
+interface FrameQueue {
+    schedule: (callback: (now: number) => void) => number;
+    cancel: (handle: number) => void;
+    pending: () => number;
+    tick: (now: number) => void;
+}
+
+function createFrameQueue(): FrameQueue {
+    const scheduled = new Map<number, (now: number) => void>();
+    let nextHandle = 1;
+
+    return {
+        schedule: callback => {
+            const handle = nextHandle;
+            nextHandle += 1;
+            scheduled.set(handle, callback);
+            return handle;
+        },
+        cancel: handle => { scheduled.delete(handle) },
+        pending: () => scheduled.size,
+        tick: now => {
+            const callbacks = Array.from(scheduled.values());
+            scheduled.clear();
+            callbacks.forEach(callback => { callback(now) });
+        }
+    };
+}
+
+interface WorkerHarness {
+    createWorker: () => Worker;
+    gl: GLStubHandle;
+    frames: FrameQueue;
+    errors: string[];
+    uploads: (name: string) => unknown[];
+}
+
+function createWorkerHarness(): WorkerHarness {
+    const offscreenCanvas = {
+        width: 0,
+        height: 0,
+        getContext: (): WebGLRenderingContext => stub.gl,
+        addEventListener: (): void => undefined,
+        removeEventListener: (): void => undefined
+    };
+    const offscreen = offscreenCanvas as unknown as OffscreenCanvas;
+    const stub = createGLStub({ overrides: { canvas: offscreen } });
+
+    const frames = createFrameQueue();
+    const errors: string[] = [];
+    const listeners: ((event: MessageEvent<WorkerToMain>) => void)[] = [];
+
+    const host: WorkerRuntimeHost = {
+        postMessage: message => {
+            if (message.type === 'error') {
+                errors.push(message.message);
+            }
+            listeners.forEach(listener => { listener({ data: message } as MessageEvent<WorkerToMain>) });
+        },
+        requestAnimationFrame: frames.schedule,
+        cancelAnimationFrame: frames.cancel,
+        now: () => 0
+    };
+
+    const runtime = new WorkerRuntime(host);
+
+    const worker = {
+        postMessage: (message: MainToWorker) => { runtime.handleMessage(message) },
+        addEventListener: (_type: string, listener: (event: MessageEvent<WorkerToMain>) => void) => {
+            listeners.push(listener);
+        },
+        removeEventListener: () => undefined,
+        terminate: () => undefined
+    };
+
+    (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas = {};
+    (globalThis as { Worker?: unknown }).Worker = {};
+    (HTMLCanvasElement.prototype as unknown as {
+        transferControlToOffscreen: () => OffscreenCanvas;
+    }).transferControlToOffscreen = function transferControlToOffscreen(this: HTMLCanvasElement) {
+        offscreenCanvas.width = this.width;
+        offscreenCanvas.height = this.height;
+        return offscreen;
+    };
+
+    return {
+        createWorker: () => worker as unknown as Worker,
+        gl: stub,
+        frames,
+        errors,
+        uploads: name => {
+            const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+            return stub.uniformCalls
+                .filter(call => call.location === location)
+                .map(call => call.value);
+        }
+    };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let mainFrames: FrameQueue;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mainFrames = createFrameQueue();
+    globalThis.requestAnimationFrame = mainFrames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = mainFrames.cancel;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+});
+
+interface SceneProps {
+    worker: WorkerHarness;
+    handleRef: { current: ShaderHandle | null };
+    uniforms: Record<string, UniformParam>;
+    liveUniforms?: string[];
+    frameloop: Frameloop;
+}
+
+const Scene = ({ worker, handleRef, uniforms, liveUniforms, frameloop }: SceneProps) => (
+    <BaseShaderComponent
+        ref={handleRef}
+        worker={true}
+        createWorker={worker.createWorker}
+        programId={PROGRAM_ID}
+        shaderConfig={CONFIG}
+        uniforms={uniforms}
+        liveUniforms={liveUniforms}
+        width={WIDTH}
+        height={HEIGHT}
+        useDevicePixelRatio={false}
+        frameloop={frameloop}
+        reducedMotion='ignore'
+        saveData='ignore'
+    />
+);
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+describe('BaseShaderComponent in worker mode', () => {
+    it('throws once, in render, for a liveUniforms name that is not a uniform', async () => {
+        const worker = createWorkerHarness();
+        const handleRef = { current: null as ShaderHandle | null };
+
+        await expect(mount(
+            <Scene
+                worker={worker}
+                handleRef={handleRef}
+                uniforms={{ level: { type: 'float', value: 0.5 } }}
+                liveUniforms={['ghost']}
+                frameloop='always'
+            />
+        )).rejects.toThrow(/u_ghost/);
+
+        expect(worker.frames.pending()).toBe(0);
+        expect(mainFrames.pending()).toBe(0);
+    });
+
+    it('samples and posts the live uniform on invalidate(), so a demand frame is not drawn with a stale value',
+        async () => {
+            const worker = createWorkerHarness();
+            const handleRef = { current: null as ShaderHandle | null };
+            const level = { current: 0 };
+
+            await mount(
+                <Scene
+                    worker={worker}
+                    handleRef={handleRef}
+                    uniforms={{ level: { type: 'float', value: () => level.current } }}
+                    liveUniforms={['level']}
+                    frameloop='demand'
+                />
+            );
+
+            worker.frames.tick(0);
+            expect(worker.errors).toEqual([]);
+            expect(worker.uploads('u_level')).toEqual([0]);
+
+            level.current = 0.75;
+            await act(async () => {
+                handleRef.current?.invalidate();
+                await Promise.resolve();
+            });
+
+            expect(mainFrames.pending()).toBe(1);
+
+            worker.frames.tick(16);
+
+            expect(worker.errors).toEqual([]);
+            expect(worker.uploads('u_level')).toEqual([0, 0.75]);
+        });
+
+    it('starts the sampler loop when liveUniforms is switched on after the worker connected', async () => {
+        const worker = createWorkerHarness();
+        const handleRef = { current: null as ShaderHandle | null };
+        const level = { current: 0.75 };
+
+        await mount(
+            <Scene
+                worker={worker}
+                handleRef={handleRef}
+                uniforms={{ level: { type: 'float', value: 0 } }}
+                frameloop='always'
+            />
+        );
+
+        worker.frames.tick(0);
+        expect(worker.uploads('u_level')).toEqual([0]);
+        expect(mainFrames.pending()).toBe(0);
+
+        await mount(
+            <Scene
+                worker={worker}
+                handleRef={handleRef}
+                uniforms={{ level: { type: 'float', value: () => level.current } }}
+                liveUniforms={['level']}
+                frameloop='always'
+            />
+        );
+
+        expect(mainFrames.pending()).toBe(1);
+        act(() => { mainFrames.tick(16) });
+        worker.frames.tick(16);
+
+        expect(worker.errors).toEqual([]);
+        expect(worker.uploads('u_level')).toEqual([0, 0.75]);
+    });
+});

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -6,6 +6,7 @@ import {
     useCallback,
     useEffect,
     useImperativeHandle,
+    useMemo,
     useRef,
     useState
 } from 'react';
@@ -23,6 +24,8 @@ import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
 import { useReducedMotion } from '@/react/hooks/useReducedMotion';
 import { useSaveData } from '@/react/hooks/useSaveData';
+import type { WorkerBridgeInitPayload } from '@/react/hooks/useWorkerBridge';
+import { useWorkerBridge } from '@/react/hooks/useWorkerBridge';
 import { pixelsToBlob, pixelsToDataURL } from '@/react/lib/captureBlob';
 import { framebuffersContentKey, programConfigsContentKey } from '@/react/lib/contentKeys';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
@@ -37,6 +40,16 @@ import {
     resolveResolution
 } from '@/react/lib/resolution';
 import { frameToMs } from '@/react/lib/timeKeeper';
+import type { WorkerBlock, WorkerProgramUniforms } from '@/react/lib/workerMode';
+import {
+    findWorkerBlock,
+    isWorkerRequested,
+    normalizeWorkerPrograms,
+    stripPassUniforms,
+    workerBlockMessage,
+    workerGetFrameMessage,
+    workerHandleUnsupportedMessage
+} from '@/react/lib/workerMode';
 import type {
     Dpr,
     PingPongShaderHandle,
@@ -44,10 +57,12 @@ import type {
     RenderControlProps,
     RenderToBlobOptions,
     SeedOptions,
-    SequenceOptions
+    SequenceOptions,
+    WorkerMode
 } from '@/types';
+import type { WorkerBridge } from '@/worker/WorkerBridge';
 
-interface PingPongShaderEngineProps extends RenderControlProps {
+interface PingPongShaderEngineBaseProps extends Omit<RenderControlProps, 'worker' | 'createWorker'> {
     programConfigs: Record<string, ShaderProgramConfig>;
     passes: RenderPass[];
     framebuffers?: Record<string, FramebufferOptions>;
@@ -58,6 +73,17 @@ interface PingPongShaderEngineProps extends RenderControlProps {
     debug?: boolean;
     debugPortRef?: RefObject<UniformDebugPort | null>;
 }
+
+export type PingPongShaderEngineWorkerProps =
+    | { worker?: false; createWorker?: never; workerUniforms?: never; workerCustomPasses?: never }
+    | {
+        worker: WorkerMode;
+        createWorker?: () => Worker;
+        workerUniforms: WorkerProgramUniforms;
+        workerCustomPasses: boolean;
+    };
+
+type PingPongShaderEngineProps = PingPongShaderEngineBaseProps & PingPongShaderEngineWorkerProps;
 
 interface ObservedSize {
     cssWidth: number;
@@ -82,6 +108,10 @@ const readNow = (): number => (typeof performance === 'object' ? performance.now
 
 const readDevicePixelRatio = (): number =>
     typeof window === 'object' ? window.devicePixelRatio : 1;
+
+const deny = (method: string) => (): never => {
+    throw new Error(workerHandleUnsupportedMessage('PingPongShaderEngine', method));
+};
 
 let engineIdCounter = 0;
 
@@ -121,6 +151,10 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     renderHeight,
     debug = false,
     debugPortRef,
+    workerUniforms,
+    workerCustomPasses = false,
+    worker,
+    createWorker,
     useDevicePixelRatio,
     pixelRatio,
     frameloop = 'always',
@@ -152,10 +186,30 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     const observedSizeRef = useRef<ObservedSize | null>(null);
     const appliedPassesRef = useRef<RenderPass[] | null>(null);
     const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    const initPropsRef = useRef({ programConfigs, framebuffers, passes });
+    const bridgeRef = useRef<WorkerBridge | null>(null);
+    const renderSizeRef = useRef({ renderWidth: 0, renderHeight: 0 });
+    const workerActiveRef = useRef(false);
 
     const [epoch, setEpoch] = useState(0);
+
+    const workerRequested = isWorkerRequested(worker);
+    const workerPasses = useMemo(
+        () => workerRequested && !workerCustomPasses ? stripPassUniforms(passes) : passes,
+        [workerRequested, workerCustomPasses, passes]
+    );
+    const workerPrograms = workerRequested && workerUniforms
+        ? normalizeWorkerPrograms(workerUniforms)
+        : undefined;
+    const block: WorkerBlock | null = workerRequested
+        ? findWorkerBlock({
+            uniforms: workerPrograms,
+            fastPath: true,
+            instancing: false,
+            passes: workerPasses
+        })
+        : null;
+
+    const initPropsRef = useRef({ programConfigs, framebuffers, passes });
 
     const dprMin = Array.isArray(dpr) ? dpr[0] : dpr;
     const dprMax = Array.isArray(dpr) ? dpr[1] : dpr;
@@ -257,9 +311,12 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     }, []);
 
     const applySize = useCallback(() => {
-        const manager = managerRef.current;
         const canvas = canvasRef.current;
-        if (!readyRef.current || !manager || !canvas) return;
+        if (!canvas) return;
+
+        const workerMode = workerActiveRef.current;
+        const manager = managerRef.current;
+        if (!workerMode && (!readyRef.current || !manager)) return;
 
         const devicePixelRatio = readDevicePixelRatio();
         const disableDevicePixelRatio = useDevicePixelRatio === false;
@@ -308,6 +365,18 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         const bufferWidth = renderWidth ?? computedWidth;
         const bufferHeight = renderHeight ?? computedHeight;
 
+        if (workerMode) {
+            if (fit !== 'element') {
+                canvas.style.width = `${displayWidth}px`;
+                canvas.style.height = `${displayHeight}px`;
+            }
+            renderSizeRef.current = { renderWidth: bufferWidth, renderHeight: bufferHeight };
+            bridgeRef.current?.resize(bufferWidth, bufferHeight);
+            return;
+        }
+
+        if (!manager) return;
+
         if (fit === 'element') {
             manager.setDrawingBufferSize(bufferWidth, bufferHeight);
         } else {
@@ -325,6 +394,48 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     }, [width, height, renderWidth, renderHeight, dprMin, dprMax, maxPixelCount, pixelRatio, useDevicePixelRatio, fit]);
 
     const applySizeRef = useRef(applySize);
+
+    const session = useWorkerBridge({
+        worker,
+        blocked: block !== null,
+        contentKey,
+        canvasRef,
+        controllerRef,
+        bridgeRef,
+        createWorker,
+        programs: workerPrograms,
+        debug,
+        frameloop,
+        speed,
+        motionGate,
+        staticFrame,
+        measure: () => {
+            applySizeRef.current();
+            return renderSizeRef.current;
+        },
+        buildInit: (active): WorkerBridgeInitPayload => {
+            if (!workerPrograms) {
+                throw new Error(workerBlockMessage('PingPongShaderEngine', { kind: 'uniforms-missing' }));
+            }
+            return {
+                kind: 'pingpong',
+                programConfigs,
+                uniforms: workerPrograms,
+                passes: workerPasses,
+                framebuffers,
+                skipDefaultUniforms: workerCustomPasses,
+                frameloop,
+                speed,
+                active
+            };
+        },
+        onConnected: () => {
+            appliedPassesRef.current = workerPasses;
+        }
+    });
+
+    const { active: workerActive, canvasKey, syncActive, setStopped } = session;
+    workerActiveRef.current = workerActive;
 
     useEffect(() => {
         initPropsRef.current = { programConfigs, framebuffers, passes };
@@ -346,6 +457,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     }, [renderFrame]);
 
     useEffect(() => {
+        if (workerActive) return;
         if (!canvasRef.current) return;
 
         const manager = new WebGLManager(canvasRef.current);
@@ -430,7 +542,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             passSystemRef.current = null;
             emitEngineUnmount(engineIdRef.current);
         };
-    }, [contentKey, epoch, debugPortRef]);
+    }, [workerActive, contentKey, epoch, debugPortRef]);
 
     useEffect(() => {
         applySize();
@@ -469,9 +581,18 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         const onResize = () => { applySize() };
         window.addEventListener('resize', onResize);
         return () => { window.removeEventListener('resize', onResize) };
-    }, [fit, width, height, applySize]);
+    }, [fit, width, height, canvasKey, applySize]);
 
     useEffect(() => {
+        if (workerActive) {
+            const bridge = bridgeRef.current;
+            if (!bridge || workerPasses === appliedPassesRef.current) return;
+
+            appliedPassesRef.current = workerPasses;
+            bridge.setPasses(workerPasses);
+            return;
+        }
+
         const passSystem = passSystemRef.current;
         if (!passSystem || !readyRef.current) return;
 
@@ -486,18 +607,27 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         });
         passSystem.initializeResources();
         controllerRef.current?.invalidate();
-    }, [passes]);
+    }, [workerActive, passes, workerPasses]);
 
     useEffect(() => {
         const controller = controllerRef.current;
         if (!controller) return;
 
+        const setVisible = (documentVisible: boolean) => {
+            controller.setVisible(documentVisible);
+            syncActive();
+        };
+        const setIntersecting = (intersecting: boolean) => {
+            controller.setIntersecting(intersecting);
+            syncActive();
+        };
+
         const onVisibility = () => {
-            controller.setVisible(typeof document === 'object' ? !document.hidden : true);
+            setVisible(typeof document === 'object' ? !document.hidden : true);
         };
 
         if (typeof document === 'object') {
-            controller.setVisible(!document.hidden);
+            setVisible(!document.hidden);
             document.addEventListener('visibilitychange', onVisibility);
         }
 
@@ -507,12 +637,12 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             observer = new IntersectionObserver(entries => {
                 const entry = entries[entries.length - 1] as IntersectionObserverEntry | undefined;
                 if (entry) {
-                    controller.setIntersecting(entry.isIntersecting);
+                    setIntersecting(entry.isIntersecting);
                 }
             }, { threshold: 0 });
             observer.observe(canvas);
         } else {
-            controller.setIntersecting(true);
+            setIntersecting(true);
         }
 
         return () => {
@@ -521,7 +651,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             }
             observer?.disconnect();
         };
-    }, []);
+    }, [canvasKey, syncActive]);
 
     useEffect(() => {
         const controller = controllerRef.current;
@@ -530,7 +660,8 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         controller.setFrameloop(frameloop);
         controller.setSpeed(speed);
         controller.setPauseWhenHidden(pauseWhenHidden);
-    }, [frameloop, speed, pauseWhenHidden]);
+        syncActive();
+    }, [frameloop, speed, pauseWhenHidden, syncActive]);
 
     useEffect(() => {
         const controller = controllerRef.current;
@@ -543,17 +674,8 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     }, [motionGate, staticFrame]);
 
     useEffect(() => {
-        if (!debug) return;
-        let cancelled = false;
-        void import('@/react/devtools/attach').then(module => {
-            if (!cancelled) {
-                module.ensureDevtoolsMounted();
-            }
-        });
-        return () => { cancelled = true };
-    }, [debug]);
+        if (workerActive) return;
 
-    useEffect(() => {
         const canvas = canvasRef.current;
         if (!canvas) return;
 
@@ -572,7 +694,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             canvas.removeEventListener('webglcontextlost', onLost);
             canvas.removeEventListener('webglcontextrestored', onRestored);
         };
-    }, []);
+    }, [workerActive, canvasKey]);
 
     useEffect(() => {
         if (releaseTimerRef.current !== null) {
@@ -589,7 +711,19 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         };
     }, []);
 
-    useImperativeHandle(ref, () => ({
+    useImperativeHandle(ref, (): PingPongShaderHandle => workerActive ? {
+        invalidate: () => { bridgeRef.current?.invalidate() },
+        setFrame: (frame: number) => { bridgeRef.current?.renderFrame(frameToMs(frame)) },
+        getFrame: () => { throw new Error(workerGetFrameMessage('PingPongShaderEngine')) },
+        start: () => { setStopped(false) },
+        stop: () => { setStopped(true) },
+        resetSimulation: deny('resetSimulation'),
+        renderToBlob: deny('renderToBlob'),
+        renderToDataURL: deny('renderToDataURL'),
+        captureStream: deny('captureStream'),
+        record: deny('record'),
+        renderSequence: deny('renderSequence')
+    } : {
         invalidate: () => { controllerRef.current?.invalidate() },
         setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
         getFrame: () => controllerRef.current?.getFrame() ?? 0,
@@ -667,10 +801,19 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
                 }
             });
         }
-    }), [resetSimulation, captureStill]);
+    }, [workerActive, resetSimulation, captureStill, setStopped]);
+
+    if (workerActive && block) {
+        throw new Error(workerBlockMessage('PingPongShaderEngine', block));
+    }
+
+    if (session.error) {
+        throw session.error;
+    }
 
     return (
         <canvas
+            key={canvasKey}
             ref={canvasRef}
             className={className}
             style={{

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -25,6 +25,8 @@ import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
 import { useReducedMotion } from '@/react/hooks/useReducedMotion';
 import { useSaveData } from '@/react/hooks/useSaveData';
+import type { WorkerBridgeInitPayload } from '@/react/hooks/useWorkerBridge';
+import { useWorkerBridge } from '@/react/hooks/useWorkerBridge';
 import { pixelsToBlob, pixelsToDataURL } from '@/react/lib/captureBlob';
 import { instancingContentKey, programConfigContentKey, singleProgramEntry } from '@/react/lib/contentKeys';
 import { createDelegatingInstancingConfig } from '@/react/lib/instancingConfig';
@@ -40,6 +42,17 @@ import {
     resolveResolution
 } from '@/react/lib/resolution';
 import { frameToMs } from '@/react/lib/timeKeeper';
+import type { WorkerBlock, WorkerProgramUniforms } from '@/react/lib/workerMode';
+import {
+    findWorkerBlock,
+    isWorkerRequested,
+    normalizeLiveUniformNames,
+    normalizeWorkerPrograms,
+    sampleLiveUniforms,
+    workerBlockMessage,
+    workerGetFrameMessage,
+    workerHandleUnsupportedMessage
+} from '@/react/lib/workerMode';
 import type {
     Dpr,
     InstancingConfig,
@@ -47,8 +60,10 @@ import type {
     RenderControlProps,
     RenderToBlobOptions,
     SequenceOptions,
-    ShaderHandle
+    ShaderHandle,
+    WorkerMode
 } from '@/types';
+import type { WorkerBridge } from '@/worker/WorkerBridge';
 
 interface UniformUpdaterEntry {
     name: string;
@@ -56,7 +71,7 @@ interface UniformUpdaterEntry {
     updateFn: UniformUpdateFn<UniformType>;
 }
 
-interface ShaderEngineProps extends RenderControlProps {
+interface ShaderEngineBaseProps extends Omit<RenderControlProps, 'worker' | 'createWorker'> {
     programConfigs: Record<string, ShaderProgramConfig>;
     renderCallback: ShaderRenderCallback;
     renderOptions?: RenderOptions;
@@ -67,7 +82,20 @@ interface ShaderEngineProps extends RenderControlProps {
     instancing?: InstancingConfig;
     debug?: boolean;
     debugPortRef?: RefObject<UniformDebugPort | null>;
+    workerSkipDefaultUniforms?: boolean;
 }
+
+export type ShaderEngineWorkerProps =
+    | { worker?: false; createWorker?: never; workerUniforms?: never; liveUniforms?: never }
+    | {
+        worker: WorkerMode;
+        createWorker?: () => Worker;
+        workerUniforms: WorkerProgramUniforms;
+        liveUniforms?: string[];
+        instancing?: never;
+    };
+
+type ShaderEngineProps = ShaderEngineBaseProps & ShaderEngineWorkerProps;
 
 interface ObservedSize {
     cssWidth: number;
@@ -80,6 +108,8 @@ const DEFAULT_RENDER_OPTIONS: RenderOptions = {};
 const DEFAULT_CLASS_NAME = '';
 const DEFAULT_STYLE: CSSProperties = {};
 const DEFAULT_UNIFORM_UPDATERS: Record<string, UniformUpdaterEntry[]> = {};
+
+const LIVE_NAME_SEPARATOR = '\u0001';
 
 const scheduleFrame = (callback: (now: number) => void): number =>
     typeof requestAnimationFrame === 'function' ? requestAnimationFrame(callback) : 0;
@@ -94,6 +124,10 @@ const readNow = (): number => (typeof performance === 'object' ? performance.now
 
 const readDevicePixelRatio = (): number =>
     typeof window === 'object' ? window.devicePixelRatio : 1;
+
+const deny = (method: string) => (): never => {
+    throw new Error(workerHandleUnsupportedMessage('ShaderEngine', method));
+};
 
 let engineIdCounter = 0;
 
@@ -134,6 +168,11 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     instancing,
     debug = false,
     debugPortRef,
+    workerUniforms,
+    workerSkipDefaultUniforms = false,
+    liveUniforms,
+    worker,
+    createWorker,
     useDevicePixelRatio,
     pixelRatio,
     frameloop = 'always',
@@ -167,11 +206,32 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const instanceUploaderRef = useRef<InstanceUploader | null>(null);
     const instancingRef = useRef(instancing);
+    const bridgeRef = useRef<WorkerBridge | null>(null);
+    const renderSizeRef = useRef({ renderWidth: 0, renderHeight: 0 });
+    const workerActiveRef = useRef(false);
+
+    const [epoch, setEpoch] = useState(0);
+
+    const workerRequested = isWorkerRequested(worker);
+    const liveNames = workerRequested ? normalizeLiveUniformNames(liveUniforms) : [];
+    const liveKey = liveNames.join(LIVE_NAME_SEPARATOR);
+    const workerPrograms = workerRequested && workerUniforms
+        ? normalizeWorkerPrograms(workerUniforms)
+        : undefined;
+    const block: WorkerBlock | null = workerRequested
+        ? findWorkerBlock({
+            uniforms: workerPrograms,
+            fastPath: useFastPath,
+            instancing: instancing !== undefined,
+            liveUniforms: { programId: keyProgramId, names: liveNames }
+        })
+        : null;
+
+    const liveRef = useRef({ programId: keyProgramId, programs: workerPrograms, names: liveNames });
+    liveRef.current = { programId: keyProgramId, programs: workerPrograms, names: liveNames };
 
     const initPropsRef = useRef({ programConfigs, uniformUpdaters, instancing });
     const renderConfigRef = useRef({ useFastPath, renderOptions, renderCallback });
-
-    const [epoch, setEpoch] = useState(0);
 
     const dprMin = Array.isArray(dpr) ? dpr[0] : dpr;
     const dprMax = Array.isArray(dpr) ? dpr[1] : dpr;
@@ -264,10 +324,45 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         return { ...result, type: opts.type, quality: opts.quality };
     }, [renderFrame, drawFastPathGeometry]);
 
+    const commitSize = useCallback((
+        resolution: { renderWidth: number; renderHeight: number },
+        display?: { displayWidth: number; displayHeight: number }
+    ) => {
+        renderSizeRef.current = {
+            renderWidth: resolution.renderWidth,
+            renderHeight: resolution.renderHeight
+        };
+
+        if (workerActiveRef.current) {
+            const canvas = canvasRef.current;
+            if (canvas && display) {
+                canvas.style.width = `${display.displayWidth}px`;
+                canvas.style.height = `${display.displayHeight}px`;
+            }
+            bridgeRef.current?.resize(resolution.renderWidth, resolution.renderHeight);
+        } else {
+            const manager = managerRef.current;
+            if (!manager) return;
+
+            if (display) {
+                manager.setSize(
+                    resolution.renderWidth,
+                    resolution.renderHeight,
+                    display.displayWidth,
+                    display.displayHeight
+                );
+            } else {
+                manager.setDrawingBufferSize(resolution.renderWidth, resolution.renderHeight);
+            }
+        }
+
+        controllerRef.current?.invalidate();
+    }, []);
+
     const applySize = useCallback(() => {
-        const manager = managerRef.current;
         const canvas = canvasRef.current;
-        if (!readyRef.current || !manager || !canvas) return;
+        if (!canvas) return;
+        if (!workerActiveRef.current && (!readyRef.current || !managerRef.current)) return;
 
         const devicePixelRatio = readDevicePixelRatio();
         const disableDevicePixelRatio = useDevicePixelRatio === false;
@@ -278,7 +373,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             const hasFixed = width !== undefined || height !== undefined;
 
             if (!hasFixed && observed?.deviceWidth !== undefined && observed.deviceHeight !== undefined) {
-                const resolution = resolveDeviceResolution({
+                commitSize(resolveDeviceResolution({
                     deviceWidth: observed.deviceWidth,
                     deviceHeight: observed.deviceHeight,
                     devicePixelRatio,
@@ -286,15 +381,13 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
                     maxPixelCount,
                     pixelRatioOverride: pixelRatio,
                     disableDevicePixelRatio
-                });
-                manager.setDrawingBufferSize(resolution.renderWidth, resolution.renderHeight);
-                controllerRef.current?.invalidate();
+                }));
                 return;
             }
 
             const cssWidth = width ?? observed?.cssWidth ?? canvas.clientWidth;
             const cssHeight = height ?? observed?.cssHeight ?? canvas.clientHeight;
-            const resolution = resolveResolution({
+            commitSize(resolveResolution({
                 displayWidth: cssWidth,
                 displayHeight: cssHeight,
                 devicePixelRatio,
@@ -302,28 +395,95 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
                 maxPixelCount,
                 pixelRatioOverride: pixelRatio,
                 disableDevicePixelRatio
-            });
-            manager.setDrawingBufferSize(resolution.renderWidth, resolution.renderHeight);
-            controllerRef.current?.invalidate();
+            }));
             return;
         }
 
         const displayWidth = width ?? (typeof window === 'object' ? window.innerWidth : 0);
         const displayHeight = height ?? (typeof window === 'object' ? window.innerHeight : 0);
-        const resolution = resolveResolution({
-            displayWidth,
-            displayHeight,
-            devicePixelRatio,
-            dpr: resolvedDpr,
-            maxPixelCount,
-            pixelRatioOverride: pixelRatio,
-            disableDevicePixelRatio
-        });
-        manager.setSize(resolution.renderWidth, resolution.renderHeight, displayWidth, displayHeight);
-        controllerRef.current?.invalidate();
-    }, [width, height, dprMin, dprMax, maxPixelCount, pixelRatio, useDevicePixelRatio, fit]);
+        commitSize(
+            resolveResolution({
+                displayWidth,
+                displayHeight,
+                devicePixelRatio,
+                dpr: resolvedDpr,
+                maxPixelCount,
+                pixelRatioOverride: pixelRatio,
+                disableDevicePixelRatio
+            }),
+            { displayWidth, displayHeight }
+        );
+    }, [width, height, dprMin, dprMax, maxPixelCount, pixelRatio, useDevicePixelRatio, fit, commitSize]);
 
     const applySizeRef = useRef(applySize);
+
+    const postLiveUniforms = useCallback((elapsed: number) => {
+        const bridge = bridgeRef.current;
+        const { programs, programId, names } = liveRef.current;
+        if (!bridge || !programs || names.length === 0) return;
+
+        const { renderWidth, renderHeight } = renderSizeRef.current;
+        bridge.setUniformValues(
+            programId,
+            sampleLiveUniforms(names, programs[programId], elapsed, renderWidth, renderHeight)
+        );
+    }, []);
+
+    const driveFrame = useCallback((elapsed: number) => {
+        if (workerActiveRef.current) {
+            postLiveUniforms(elapsed);
+            return;
+        }
+        renderFrame(elapsed);
+    }, [postLiveUniforms, renderFrame]);
+
+    const startSamplerLoop = useCallback(() => {
+        if (liveRef.current.names.length === 0) return;
+        controllerRef.current?.start();
+    }, []);
+
+    const session = useWorkerBridge({
+        worker,
+        blocked: block !== null,
+        contentKey,
+        canvasRef,
+        controllerRef,
+        bridgeRef,
+        createWorker,
+        programs: workerPrograms,
+        debug,
+        frameloop,
+        speed,
+        motionGate,
+        staticFrame,
+        measure: () => {
+            applySizeRef.current();
+            return renderSizeRef.current;
+        },
+        buildInit: (active): WorkerBridgeInitPayload => {
+            if (!workerPrograms) {
+                throw new Error(workerBlockMessage('ShaderEngine', { kind: 'uniforms-missing' }));
+            }
+            return {
+                kind: 'single',
+                programConfigs,
+                uniforms: workerPrograms,
+                skipDefaultUniforms: workerSkipDefaultUniforms,
+                frameloop,
+                speed,
+                active,
+                renderOptions: { clear: renderOptions.clear },
+                liveUniforms: liveNames.length > 0 ? { [keyProgramId]: liveNames } : undefined
+            };
+        },
+        onConnected: () => {
+            postLiveUniforms(frameToMs(controllerRef.current?.getFrame() ?? 0));
+            startSamplerLoop();
+        }
+    });
+
+    const { active: workerActive, canvasKey, syncActive, setStopped, isStopped } = session;
+    workerActiveRef.current = workerActive;
 
     useEffect(() => {
         initPropsRef.current = { programConfigs, uniformUpdaters, instancing };
@@ -337,16 +497,25 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             requestAnimationFrame: scheduleFrame,
             cancelAnimationFrame: cancelFrame,
             now: readNow,
-            render: renderFrame
+            render: driveFrame
         });
         controllerRef.current = controller;
         return () => {
             controller.stop();
             controllerRef.current = null;
         };
-    }, [renderFrame]);
+    }, [driveFrame]);
 
     useEffect(() => {
+        if (!workerActive || liveKey.length === 0 || isStopped()) return;
+
+        const controller = controllerRef.current;
+        controller?.start();
+        return () => { controller?.stop() };
+    }, [workerActive, liveKey, isStopped]);
+
+    useEffect(() => {
+        if (workerActive) return;
         if (!canvasRef.current) return;
 
         const manager = new WebGLManager(canvasRef.current);
@@ -466,7 +635,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             instanceUploaderRef.current = null;
             emitEngineUnmount(engineIdRef.current);
         };
-    }, [contentKey, epoch, debugPortRef]);
+    }, [workerActive, contentKey, epoch, debugPortRef]);
 
     useEffect(() => {
         applySize();
@@ -505,18 +674,27 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         const onResize = () => { applySize() };
         window.addEventListener('resize', onResize);
         return () => { window.removeEventListener('resize', onResize) };
-    }, [fit, width, height, applySize]);
+    }, [fit, width, height, canvasKey, applySize]);
 
     useEffect(() => {
         const controller = controllerRef.current;
         if (!controller) return;
 
+        const setVisible = (documentVisible: boolean) => {
+            controller.setVisible(documentVisible);
+            syncActive();
+        };
+        const setIntersecting = (intersecting: boolean) => {
+            controller.setIntersecting(intersecting);
+            syncActive();
+        };
+
         const onVisibility = () => {
-            controller.setVisible(typeof document === 'object' ? !document.hidden : true);
+            setVisible(typeof document === 'object' ? !document.hidden : true);
         };
 
         if (typeof document === 'object') {
-            controller.setVisible(!document.hidden);
+            setVisible(!document.hidden);
             document.addEventListener('visibilitychange', onVisibility);
         }
 
@@ -526,12 +704,12 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             observer = new IntersectionObserver(entries => {
                 const entry = entries[entries.length - 1] as IntersectionObserverEntry | undefined;
                 if (entry) {
-                    controller.setIntersecting(entry.isIntersecting);
+                    setIntersecting(entry.isIntersecting);
                 }
             }, { threshold: 0 });
             observer.observe(canvas);
         } else {
-            controller.setIntersecting(true);
+            setIntersecting(true);
         }
 
         return () => {
@@ -540,7 +718,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             }
             observer?.disconnect();
         };
-    }, []);
+    }, [canvasKey, syncActive]);
 
     useEffect(() => {
         const controller = controllerRef.current;
@@ -549,7 +727,8 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         controller.setFrameloop(frameloop);
         controller.setSpeed(speed);
         controller.setPauseWhenHidden(pauseWhenHidden);
-    }, [frameloop, speed, pauseWhenHidden]);
+        syncActive();
+    }, [frameloop, speed, pauseWhenHidden, syncActive]);
 
     useEffect(() => {
         const controller = controllerRef.current;
@@ -562,17 +741,8 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     }, [motionGate, staticFrame]);
 
     useEffect(() => {
-        if (!debug) return;
-        let cancelled = false;
-        void import('@/react/devtools/attach').then(module => {
-            if (!cancelled) {
-                module.ensureDevtoolsMounted();
-            }
-        });
-        return () => { cancelled = true };
-    }, [debug]);
+        if (workerActive) return;
 
-    useEffect(() => {
         const canvas = canvasRef.current;
         if (!canvas) return;
 
@@ -591,7 +761,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             canvas.removeEventListener('webglcontextlost', onLost);
             canvas.removeEventListener('webglcontextrestored', onRestored);
         };
-    }, []);
+    }, [workerActive, canvasKey]);
 
     useEffect(() => {
         if (releaseTimerRef.current !== null) {
@@ -608,7 +778,31 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         };
     }, []);
 
-    useImperativeHandle(ref, () => ({
+    useImperativeHandle(ref, (): ShaderHandle => workerActive ? {
+        invalidate: () => {
+            postLiveUniforms(frameToMs(controllerRef.current?.getFrame() ?? 0));
+            controllerRef.current?.invalidate();
+            bridgeRef.current?.invalidate();
+        },
+        setFrame: (frame: number) => {
+            controllerRef.current?.setFrame(frame);
+            bridgeRef.current?.renderFrame(frameToMs(frame));
+        },
+        getFrame: () => { throw new Error(workerGetFrameMessage('ShaderEngine')) },
+        start: () => {
+            setStopped(false);
+            startSamplerLoop();
+        },
+        stop: () => {
+            setStopped(true);
+            controllerRef.current?.stop();
+        },
+        renderToBlob: deny('renderToBlob'),
+        renderToDataURL: deny('renderToDataURL'),
+        captureStream: deny('captureStream'),
+        record: deny('record'),
+        renderSequence: deny('renderSequence')
+    } : {
         invalidate: () => { controllerRef.current?.invalidate() },
         setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
         getFrame: () => controllerRef.current?.getFrame() ?? 0,
@@ -677,10 +871,26 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
                 }
             });
         }
-    }), [captureStill, renderFrame]);
+    }, [
+        workerActive,
+        captureStill,
+        renderFrame,
+        postLiveUniforms,
+        startSamplerLoop,
+        setStopped
+    ]);
+
+    if (workerActive && block) {
+        throw new Error(workerBlockMessage('ShaderEngine', block));
+    }
+
+    if (session.error) {
+        throw session.error;
+    }
 
     return (
         <canvas
+            key={canvasKey}
             ref={canvasRef}
             className={className}
             style={style}

--- a/src/react/hooks/useWorkerBridge.ts
+++ b/src/react/hooks/useWorkerBridge.ts
@@ -1,0 +1,187 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from 'react';
+
+import type { MotionGate } from '@/react/lib/motionPolicy';
+import type { RenderLoop } from '@/react/lib/renderLoop';
+import { frameToMs } from '@/react/lib/timeKeeper';
+import type { WorkerProgramUniforms } from '@/react/lib/workerMode';
+import {
+    collectWorkerValues,
+    resolveWorkerMode,
+    transferCanvasToWorker,
+    warnWorkerDevtoolsUnavailable,
+    workerModeSupported
+} from '@/react/lib/workerMode';
+import type { Frameloop, WorkerMode } from '@/types';
+import { createMicuglWorker } from '@/worker/createWorker';
+import type { WorkerBridgeInit } from '@/worker/WorkerBridge';
+import { WorkerBridge, workerTransport } from '@/worker/WorkerBridge';
+
+export type WorkerBridgeInitPayload = Omit<WorkerBridgeInit, 'canvas'>;
+
+export interface WorkerRenderSize {
+    renderWidth: number;
+    renderHeight: number;
+}
+
+export interface UseWorkerBridgeOptions {
+    worker: WorkerMode | undefined;
+    blocked: boolean;
+    contentKey: string;
+    canvasRef: RefObject<HTMLCanvasElement | null>;
+    controllerRef: RefObject<RenderLoop | null>;
+    bridgeRef: RefObject<WorkerBridge | null>;
+    createWorker?: () => Worker;
+    programs: WorkerProgramUniforms | undefined;
+    debug: boolean;
+    frameloop: Frameloop;
+    speed: number;
+    motionGate: MotionGate;
+    staticFrame: number;
+    measure: () => WorkerRenderSize;
+    buildInit: (active: boolean) => WorkerBridgeInitPayload;
+    onConnected?: () => void;
+}
+
+export interface WorkerBridgeSession {
+    active: boolean;
+    canvasKey: string;
+    error: Error | null;
+    syncActive: () => void;
+    setStopped: (stopped: boolean) => void;
+    isStopped: () => boolean;
+}
+
+export function useWorkerBridge(options: UseWorkerBridgeOptions): WorkerBridgeSession {
+    const { worker, blocked, contentKey, debug, frameloop, speed, motionGate, staticFrame, bridgeRef } = options;
+
+    const [fallback, setFallback] = useState(false);
+    const [error, setError] = useState<Error | null>(null);
+
+    const stoppedRef = useRef(false);
+    const optionsRef = useRef(options);
+    optionsRef.current = options;
+
+    const active = !fallback && resolveWorkerMode(worker, workerModeSupported(), blocked);
+    const canvasKey = active ? `worker:${contentKey}` : 'main';
+
+    const syncActive = useCallback(() => {
+        const current = optionsRef.current;
+        const visible = current.controllerRef.current?.isVisible() ?? true;
+        current.bridgeRef.current?.setActive(!stoppedRef.current && visible);
+    }, []);
+
+    const setStopped = useCallback((stopped: boolean) => {
+        stoppedRef.current = stopped;
+        syncActive();
+    }, [syncActive]);
+
+    const isStopped = useCallback(() => stoppedRef.current, []);
+
+    useEffect(() => {
+        if (!active) return;
+
+        const canvas = optionsRef.current.canvasRef.current;
+        if (!canvas) return;
+
+        let cancelled = false;
+        let created: Worker | null = null;
+
+        const connect = async (): Promise<void> => {
+            const instance = await createMicuglWorker({ createWorker: optionsRef.current.createWorker });
+
+            if (cancelled) {
+                instance?.terminate();
+                return;
+            }
+            if (!instance) {
+                setFallback(true);
+                return;
+            }
+
+            created = instance;
+            const current = optionsRef.current;
+
+            const { renderWidth, renderHeight } = current.measure();
+            if (renderWidth > 0 && renderHeight > 0) {
+                canvas.width = renderWidth;
+                canvas.height = renderHeight;
+            }
+
+            const isActive = !stoppedRef.current && (current.controllerRef.current?.isVisible() ?? true);
+            const init = current.buildInit(isActive);
+            const offscreen = transferCanvasToWorker(canvas);
+
+            const bridge = new WorkerBridge(
+                workerTransport(instance),
+                { ...init, canvas: offscreen },
+                { onError: message => { setError(new Error(message)) } }
+            );
+            current.bridgeRef.current = bridge;
+
+            bridge.setMotionGate(current.motionGate);
+            if (current.motionGate === 'static') {
+                bridge.renderFrame(frameToMs(current.staticFrame));
+            }
+
+            current.onConnected?.();
+        };
+
+        void connect().catch((cause: unknown) => {
+            created?.terminate();
+            setError(cause instanceof Error ? cause : new Error(String(cause)));
+        });
+
+        return () => {
+            cancelled = true;
+            const current = optionsRef.current;
+            const bridge = current.bridgeRef.current;
+            current.bridgeRef.current = null;
+            current.controllerRef.current?.stop();
+            bridge?.dispose();
+        };
+    }, [active, contentKey]);
+
+    useEffect(() => {
+        const { bridgeRef: bridges, programs } = optionsRef.current;
+        const bridge = bridges.current;
+        if (!bridge || !programs) return;
+
+        for (const [programId, params] of Object.entries(programs)) {
+            bridge.setUniformValues(programId, collectWorkerValues(params));
+        }
+    });
+
+    useEffect(() => {
+        bridgeRef.current?.setFrameloop(frameloop);
+        bridgeRef.current?.setSpeed(speed);
+    }, [frameloop, speed, bridgeRef]);
+
+    useEffect(() => {
+        const bridge = bridgeRef.current;
+        if (!bridge) return;
+
+        bridge.setMotionGate(motionGate);
+        if (motionGate === 'static') {
+            bridge.renderFrame(frameToMs(staticFrame));
+        }
+    }, [motionGate, staticFrame, bridgeRef]);
+
+    useEffect(() => {
+        if (!debug) return;
+
+        if (active) {
+            warnWorkerDevtoolsUnavailable();
+            return;
+        }
+
+        let cancelled = false;
+        void import('@/react/devtools/attach').then(module => {
+            if (!cancelled) {
+                module.ensureDevtoolsMounted();
+            }
+        });
+        return () => { cancelled = true };
+    }, [debug, active]);
+
+    return { active, canvasKey, error, syncActive, setStopped, isStopped };
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -9,4 +9,4 @@ export { useReducedMotion } from './hooks/useReducedMotion';
 export { useSaveData } from './hooks/useSaveData';
 export { useUniformUpdaters } from './hooks/useUniformUpdaters';
 export { createCommonUpdaters, createUniformUpdater, createUniformUpdaters } from './lib/createUniformUpdater';
-export type { InstanceAttribute, InstancingConfig } from '@/types';
+export type { InstanceAttribute, InstancingConfig, WorkerMode } from '@/types';

--- a/src/react/lib/liveUniformUpdaters.ts
+++ b/src/react/lib/liveUniformUpdaters.ts
@@ -146,6 +146,16 @@ export function normalizeUniformName(name: string): string {
     return name.startsWith('u_') ? name : `u_${name}`;
 }
 
+export function normalizeUniformParams(
+    uniforms: Record<string, UniformParam>
+): Record<string, UniformParam> {
+    const normalized: Record<string, UniformParam> = {};
+    for (const [name, param] of Object.entries(uniforms)) {
+        normalized[normalizeUniformName(name)] = param;
+    }
+    return normalized;
+}
+
 export function uniformDescriptors(uniforms: Record<string, UniformParam>): UniformDescriptor[] {
     return Object.entries(uniforms).map(([name, param]) => ({
         name: normalizeUniformName(name),

--- a/src/react/lib/pingPongPasses.ts
+++ b/src/react/lib/pingPongPasses.ts
@@ -46,10 +46,10 @@ export function serializeRenderOptions(options: PingPongRenderOptions): string {
     });
 }
 
-function passUniformsFrom(
-    updaters: UniformUpdaterDef[]
-): Record<string, { type: UniformType; value: RenderPassUniformValue }> {
-    const result: Record<string, { type: UniformType; value: RenderPassUniformValue }> = {};
+export type PassUniforms = Record<string, { type: UniformType; value: RenderPassUniformValue }>;
+
+function passUniformsFrom(updaters: UniformUpdaterDef[]): PassUniforms {
+    const result: PassUniforms = {};
     for (const updater of updaters) {
         result[updater.name] = { type: updater.type, value: updater.updateFn };
     }
@@ -82,6 +82,7 @@ export function buildPasses(
         programId,
         inputTextures: [],
         outputFramebuffer: fbIdA,
+        uniforms: passUniformsFrom(primaryUniforms[programId]),
         renderOptions
     }];
 

--- a/src/react/lib/renderLoop.ts
+++ b/src/react/lib/renderLoop.ts
@@ -157,6 +157,10 @@ export class RenderLoop {
         return this.paused();
     }
 
+    isVisible(): boolean {
+        return this.visible();
+    }
+
     setSpeed(speed: number): void {
         const now = this.deps.now();
         const base = this.cold ? syncTime(this.time, now) : this.time;

--- a/src/react/lib/workerMode.test.ts
+++ b/src/react/lib/workerMode.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it } from 'vitest';
+
+import { vec2, vec3 } from '@/core';
+import {
+    buildLiveUpdaters,
+    collectLiveValues,
+    normalizeUniformParams,
+    parseUniformStructureKey,
+    uniformDescriptors,
+    uniformStructureKey
+} from '@/react/lib/liveUniformUpdaters';
+import {
+    buildPasses,
+    DEFAULT_FRAMEBUFFER_OPTIONS,
+    DEFAULT_RENDER_OPTIONS
+} from '@/react/lib/pingPongPasses';
+import type { WorkerBlockInputs } from '@/react/lib/workerMode';
+import {
+    collectWorkerValues,
+    findWorkerBlock,
+    isWorkerRequested,
+    normalizeLiveUniformNames,
+    normalizeWorkerPrograms,
+    resolveWorkerMode,
+    sampleLiveUniforms,
+    stripPassUniforms,
+    transferCanvasToWorker,
+    workerBlockMessage,
+    workerPingPongUniforms
+} from '@/react/lib/workerMode';
+import type { RenderPass, UniformParam, UniformUpdaterDef } from '@/types';
+import { isWorkerBuiltinUniformName } from '@/worker/protocol';
+
+const PROGRAM_ID = 'sim';
+const SECONDARY_PROGRAM_ID = 'sim-secondary';
+
+function simUniforms(): Record<string, UniformParam> {
+    return {
+        intensity: { type: 'float', value: 0.5 },
+        color1: { type: 'vec3', value: vec3([1, 0, 0]) }
+    };
+}
+
+function realUpdaters(programId: string, uniforms: Record<string, UniformParam>): Record<string, UniformUpdaterDef[]> {
+    const parsed = parseUniformStructureKey(uniformStructureKey(uniformDescriptors(uniforms), false));
+    const valuesRef = { current: collectLiveValues(uniforms) };
+    return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef) };
+}
+
+function realPasses(uniforms = simUniforms()): RenderPass[] {
+    return buildPasses(
+        PROGRAM_ID,
+        undefined,
+        1,
+        realUpdaters(PROGRAM_ID, uniforms),
+        {},
+        DEFAULT_FRAMEBUFFER_OPTIONS,
+        DEFAULT_RENDER_OPTIONS,
+        undefined
+    ).passes;
+}
+
+function blockInputs(overrides: Partial<WorkerBlockInputs> = {}): WorkerBlockInputs {
+    return {
+        uniforms: { [PROGRAM_ID]: normalizeUniformParams(simUniforms()) },
+        fastPath: true,
+        instancing: false,
+        ...overrides
+    };
+}
+
+describe('resolveWorkerMode', () => {
+    it('leaves worker mode off unless it was asked for', () => {
+        expect(resolveWorkerMode(undefined, true, false)).toBe(false);
+        expect(resolveWorkerMode(false, true, false)).toBe(false);
+        expect(isWorkerRequested(undefined)).toBe(false);
+        expect(isWorkerRequested(false)).toBe(false);
+        expect(isWorkerRequested(true)).toBe(true);
+        expect(isWorkerRequested('auto')).toBe(true);
+    });
+
+    it('honours worker={true} even when blocked, so the block throws instead of downgrading silently', () => {
+        expect(resolveWorkerMode(true, true, false)).toBe(true);
+        expect(resolveWorkerMode(true, true, true)).toBe(true);
+    });
+
+    it('keeps worker={true} on in an unsupported environment, leaving the logged fallback to createMicuglWorker', () => {
+        expect(resolveWorkerMode(true, false, false)).toBe(true);
+    });
+
+    it('downgrades worker="auto" to the main thread when unsupported or blocked, and never throws', () => {
+        expect(resolveWorkerMode('auto', true, false)).toBe(true);
+        expect(resolveWorkerMode('auto', false, false)).toBe(false);
+        expect(resolveWorkerMode('auto', true, true)).toBe(false);
+        expect(resolveWorkerMode('auto', false, true)).toBe(false);
+    });
+});
+
+describe('uniform name normalization at the worker boundary', () => {
+    it('prefixes bare names exactly the way the main-thread updaters do', () => {
+        expect(normalizeUniformParams(simUniforms())).toEqual({
+            u_intensity: { type: 'float', value: 0.5 },
+            u_color1: { type: 'vec3', value: vec3([1, 0, 0]) }
+        });
+    });
+
+    it('normalizes the names the main-thread descriptors would use, and is idempotent', () => {
+        const descriptorNames = uniformDescriptors(simUniforms()).map(descriptor => descriptor.name);
+        const workerNames = Object.keys(normalizeUniformParams(simUniforms()));
+
+        expect(workerNames).toEqual(descriptorNames);
+        expect(Object.keys(normalizeUniformParams(normalizeUniformParams(simUniforms())))).toEqual(workerNames);
+    });
+
+    it('normalizes the liveUniforms name list', () => {
+        expect(normalizeLiveUniformNames(['mouse', 'u_scroll'])).toEqual(['u_mouse', 'u_scroll']);
+        expect(normalizeLiveUniformNames(undefined)).toEqual([]);
+    });
+
+    it('normalizes every program in a multi-program map', () => {
+        expect(normalizeWorkerPrograms({
+            [PROGRAM_ID]: { intensity: { type: 'float', value: 1 } },
+            [SECONDARY_PROGRAM_ID]: { u_blur: { type: 'float', value: 2 } }
+        })).toEqual({
+            [PROGRAM_ID]: { u_intensity: { type: 'float', value: 1 } },
+            [SECONDARY_PROGRAM_ID]: { u_blur: { type: 'float', value: 2 } }
+        });
+    });
+});
+
+describe('findWorkerBlock: one list of the reasons a worker cannot run this component', () => {
+    it('finds nothing for a component the worker can run', () => {
+        expect(findWorkerBlock(blockInputs())).toBeNull();
+    });
+
+    it('blocks a component whose worker uniforms were never handed over', () => {
+        expect(findWorkerBlock(blockInputs({ uniforms: undefined })))
+            .toEqual({ kind: 'uniforms-missing' });
+        expect(workerBlockMessage('ShaderEngine', { kind: 'uniforms-missing' })).toMatch(/workerUniforms/);
+    });
+
+    it('blocks a custom renderCallback, which only the main thread can call', () => {
+        expect(findWorkerBlock(blockInputs({ fastPath: false }))).toEqual({ kind: 'fast-path' });
+        expect(workerBlockMessage('ShaderEngine', { kind: 'fast-path' })).toMatch(/useFastPath/);
+    });
+
+    it('blocks instancing in the render body, instead of letting the bridge throw after the worker spawns', () => {
+        expect(findWorkerBlock(blockInputs({ instancing: true }))).toEqual({ kind: 'instancing' });
+        expect(workerBlockMessage('ShaderEngine', { kind: 'instancing' })).toMatch(/instancing/);
+    });
+
+    it('blocks a function uniform that is neither a built-in nor a live uniform', () => {
+        const block = findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: { u_mouse: { type: 'vec2', value: () => vec2([0, 0]) } } }
+        }));
+
+        expect(block).toEqual({ kind: 'uniform-function', programId: PROGRAM_ID, name: 'u_mouse' });
+        expect(workerBlockMessage('ShaderEngine', block!)).toMatch(/liveUniforms/);
+    });
+
+    it('exempts a function uniform that is listed in liveUniforms for that program', () => {
+        expect(findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: { u_mouse: { type: 'vec2', value: () => vec2([0, 0]) } } },
+            liveUniforms: { programId: PROGRAM_ID, names: ['u_mouse'] }
+        }))).toBeNull();
+
+        expect(findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: { u_mouse: { type: 'vec2', value: () => vec2([0, 0]) } } },
+            liveUniforms: { programId: SECONDARY_PROGRAM_ID, names: ['u_mouse'] }
+        }))).not.toBeNull();
+    });
+
+    it('blocks a function-valued built-in, which the worker would compute itself and silently ignore', () => {
+        const block = findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: { u_time: { type: 'float', value: (time = 0) => time * 0.002 } } }
+        }));
+
+        expect(block).toEqual({ kind: 'uniform-builtin-function', programId: PROGRAM_ID, name: 'u_time' });
+        expect(workerBlockMessage('ShaderEngine', block!)).toMatch(/plain value/);
+    });
+
+    it('blocks a function-valued built-in even when it is listed in liveUniforms', () => {
+        expect(findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: { u_time: { type: 'float', value: (time = 0) => time } } },
+            liveUniforms: { programId: PROGRAM_ID, names: ['u_time'] }
+        }))).toEqual({ kind: 'uniform-builtin-function', programId: PROGRAM_ID, name: 'u_time' });
+    });
+
+    it('accepts a plain-value built-in, which the worker prefers over its own clock', () => {
+        expect(findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: { u_time: { type: 'float', value: 0 } } }
+        }))).toBeNull();
+    });
+
+    it('blocks a uniform value that structured clone cannot carry, instead of throwing from the bridge', () => {
+        const block = findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: { u_flag: { type: 'float', value: 'on' as unknown as number } } }
+        }));
+
+        expect(block).toEqual({ kind: 'uniform-not-clone-safe', programId: PROGRAM_ID, name: 'u_flag' });
+        expect(workerBlockMessage('ShaderEngine', block!)).toMatch(/structured-clone-safe/);
+    });
+
+    it('blocks an unknown liveUniforms name in the render body, not from inside the sampler loop', () => {
+        const block = findWorkerBlock(blockInputs({
+            liveUniforms: { programId: PROGRAM_ID, names: ['u_ghost'] }
+        }));
+
+        expect(block).toEqual({ kind: 'live-uniform-unknown', name: 'u_ghost' });
+        expect(workerBlockMessage('ShaderEngine', block!)).toMatch(/u_ghost/);
+    });
+});
+
+describe('findWorkerBlock: render passes', () => {
+    it('lets the auto ping-pong passes through, because the engine strips their uniforms for the worker', () => {
+        const passes = stripPassUniforms(realPasses());
+
+        expect(passes).toHaveLength(3);
+        for (const pass of passes) {
+            expect(pass.uniforms).toBeUndefined();
+        }
+        expect(findWorkerBlock(blockInputs({ passes }))).toBeNull();
+    });
+
+    it('keeps the structure of the auto passes identical apart from the uniforms', () => {
+        const withUniforms = realPasses().map(({ uniforms: _uniforms, ...rest }) => rest);
+
+        expect(stripPassUniforms(realPasses())).toEqual(withUniforms);
+    });
+
+    it('gives the seed pass the same uniforms as the other passes, so the worker cannot diverge from main', () => {
+        const passes = realPasses();
+        const names = passes.map(pass => Object.keys(pass.uniforms ?? {}).sort());
+
+        expect(names[0]).toEqual(['u_color1', 'u_intensity', 'u_resolution', 'u_time']);
+        expect(names[1]).toEqual(names[0]);
+        expect(names[2]).toEqual(names[0]);
+    });
+
+    it('leaves no uniform behind: every uniform the main-thread passes apply is a built-in or a posted value', () => {
+        const uniforms = simUniforms();
+        const mainThreadNames = new Set(
+            realPasses(uniforms).flatMap(pass => Object.keys(pass.uniforms ?? {}))
+        );
+        const posted = normalizeUniformParams(uniforms);
+
+        expect(mainThreadNames).toContain('u_time');
+        expect(mainThreadNames).toContain('u_resolution');
+        expect(mainThreadNames).toContain('u_intensity');
+
+        for (const name of mainThreadNames) {
+            expect(isWorkerBuiltinUniformName(name) || name in posted).toBe(true);
+        }
+    });
+
+    it('accepts a custom pass whose uniforms are plain values', () => {
+        const custom: RenderPass[] = [{
+            programId: PROGRAM_ID,
+            inputTextures: [],
+            outputFramebuffer: null,
+            uniforms: { u_amount: { type: 'float', value: 0.25 } }
+        }];
+
+        expect(buildPasses(
+            PROGRAM_ID,
+            undefined,
+            1,
+            {},
+            {},
+            DEFAULT_FRAMEBUFFER_OPTIONS,
+            DEFAULT_RENDER_OPTIONS,
+            custom
+        ).passes).toBe(custom);
+
+        expect(findWorkerBlock(blockInputs({ uniforms: { [PROGRAM_ID]: {} }, passes: custom }))).toBeNull();
+    });
+
+    it('blocks a function-valued pass uniform', () => {
+        const block = findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: {} },
+            passes: [{
+                programId: PROGRAM_ID,
+                inputTextures: [],
+                uniforms: { u_amount: { type: 'float', value: () => 1 } }
+            }]
+        }));
+
+        expect(block).toEqual({
+            kind: 'pass-uniform-function',
+            programId: PROGRAM_ID,
+            passIndex: 0,
+            name: 'u_amount'
+        });
+    });
+
+    it('blocks a function-valued built-in pass uniform, which the worker would silently replace', () => {
+        const block = findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: {} },
+            passes: [
+                { programId: PROGRAM_ID, inputTextures: [] },
+                {
+                    programId: PROGRAM_ID,
+                    inputTextures: [],
+                    uniforms: { u_time: { type: 'float', value: (time: number) => time } }
+                }
+            ]
+        }));
+
+        expect(block).toEqual({
+            kind: 'pass-uniform-function',
+            programId: PROGRAM_ID,
+            passIndex: 1,
+            name: 'u_time'
+        });
+        expect(workerBlockMessage('PingPongShaderEngine', block!)).toMatch(/pass 1/);
+        expect(workerBlockMessage('PingPongShaderEngine', block!)).toMatch(/u_time/);
+    });
+
+    it('blocks a pass uniform that structured clone cannot carry', () => {
+        const block = findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: {} },
+            passes: [{
+                programId: PROGRAM_ID,
+                inputTextures: [],
+                uniforms: { u_amount: { type: 'float', value: 'loud' as unknown as number } }
+            }]
+        }));
+
+        expect(block).toEqual({
+            kind: 'pass-uniform-not-clone-safe',
+            programId: PROGRAM_ID,
+            passIndex: 0,
+            name: 'u_amount'
+        });
+    });
+});
+
+describe('workerPingPongUniforms', () => {
+    it('declares an entry per program, populated from the uniform props', () => {
+        expect(workerPingPongUniforms({
+            programId: PROGRAM_ID,
+            uniforms: simUniforms(),
+            secondaryProgramId: SECONDARY_PROGRAM_ID,
+            secondaryUniforms: { blur: { type: 'float', value: 2 } },
+            customPasses: false
+        })).toEqual({
+            [PROGRAM_ID]: simUniforms(),
+            [SECONDARY_PROGRAM_ID]: { blur: { type: 'float', value: 2 } }
+        });
+    });
+
+    it('declares an empty entry per program under customPasses, which the main thread also ignores', () => {
+        expect(workerPingPongUniforms({
+            programId: PROGRAM_ID,
+            uniforms: simUniforms(),
+            secondaryProgramId: SECONDARY_PROGRAM_ID,
+            secondaryUniforms: { blur: { type: 'float', value: 2 } },
+            customPasses: true
+        })).toEqual({
+            [PROGRAM_ID]: {},
+            [SECONDARY_PROGRAM_ID]: {}
+        });
+    });
+
+    it('declares no secondary program when there is no secondary shader', () => {
+        expect(workerPingPongUniforms({
+            programId: PROGRAM_ID,
+            uniforms: simUniforms(),
+            customPasses: false
+        })).toEqual({ [PROGRAM_ID]: simUniforms() });
+    });
+});
+
+describe('collectWorkerValues', () => {
+    it('collects plain values and leaves functions to the worker or the live loop', () => {
+        expect(collectWorkerValues({
+            u_intensity: { type: 'float', value: 0.5 },
+            u_color1: { type: 'vec3', value: vec3([1, 0, 0]) },
+            u_mouse: { type: 'vec2', value: () => vec2([0, 0]) }
+        })).toEqual({
+            u_intensity: 0.5,
+            u_color1: vec3([1, 0, 0])
+        });
+    });
+});
+
+describe('sampleLiveUniforms', () => {
+    it('evaluates function values with the frame time and the render size', () => {
+        const values = sampleLiveUniforms(
+            ['u_mouse'],
+            { u_mouse: { type: 'vec2', value: (time = 0, width = 0, height = 0) => vec2([time + width, height]) } },
+            1000,
+            640,
+            480
+        );
+
+        expect(Array.from(values.u_mouse as Float32Array)).toEqual([1640, 480]);
+    });
+
+    it('passes plain values through', () => {
+        expect(sampleLiveUniforms(
+            ['u_intensity'],
+            { u_intensity: { type: 'float', value: 0.5 } },
+            0,
+            1,
+            1
+        )).toEqual({ u_intensity: 0.5 });
+    });
+});
+
+describe('transferCanvasToWorker', () => {
+    it('throws on a second transfer of the same canvas instead of losing the canvas for good', () => {
+        const offscreen = {} as unknown as OffscreenCanvas;
+        const canvas = {
+            transferControlToOffscreen: () => offscreen
+        } as unknown as HTMLCanvasElement;
+
+        expect(transferCanvasToWorker(canvas)).toBe(offscreen);
+        expect(() => transferCanvasToWorker(canvas)).toThrow(/already transferred/);
+    });
+});

--- a/src/react/lib/workerMode.ts
+++ b/src/react/lib/workerMode.ts
@@ -1,0 +1,313 @@
+import { normalizeUniformName, normalizeUniformParams } from '@/react/lib/liveUniformUpdaters';
+import type { RenderPass, UniformParam, WorkerMode } from '@/types';
+import type { WorkerSupportScope } from '@/worker/createWorker';
+import { createOnceLogger, isWorkerModeSupported } from '@/worker/createWorker';
+import type { UniformScalar, UniformVector } from '@/worker/protocol';
+import {
+    isWorkerBuiltinUniformName,
+    normalizeCloneSafeUniformValue,
+    WORKER_BUILTIN_UNIFORM_NAMES
+} from '@/worker/protocol';
+import { functionUniformErrorMessage } from '@/worker/WorkerBridge';
+
+export type WorkerProgramUniforms = Record<string, Record<string, UniformParam>>;
+
+export type WorkerUniformValues = Record<string, UniformScalar | UniformVector | ArrayBufferView>;
+
+export interface WorkerLiveUniforms {
+    programId: string;
+    names: string[];
+}
+
+export type WorkerBlock =
+    | { kind: 'uniforms-missing' }
+    | { kind: 'fast-path' }
+    | { kind: 'instancing' }
+    | { kind: 'live-uniform-unknown'; name: string }
+    | { kind: 'uniform-function'; programId: string; name: string }
+    | { kind: 'uniform-builtin-function'; programId: string; name: string }
+    | { kind: 'uniform-not-clone-safe'; programId: string; name: string }
+    | { kind: 'pass-uniform-function'; programId: string; passIndex: number; name: string }
+    | { kind: 'pass-uniform-not-clone-safe'; programId: string; passIndex: number; name: string };
+
+export interface WorkerBlockInputs {
+    uniforms: WorkerProgramUniforms | undefined;
+    fastPath: boolean;
+    instancing: boolean;
+    liveUniforms?: WorkerLiveUniforms;
+    passes?: RenderPass[];
+}
+
+const transferredCanvases = new WeakSet<HTMLCanvasElement>();
+
+const logOnce = createOnceLogger(message => { console.warn(message) });
+
+let workerModeSupportedMemo: boolean | undefined;
+
+export function workerModeSupported(): boolean {
+    workerModeSupportedMemo ??= isWorkerModeSupported(globalThis as WorkerSupportScope);
+    return workerModeSupportedMemo;
+}
+
+export function resolveWorkerMode(mode: WorkerMode | undefined, supported: boolean, blocked: boolean): boolean {
+    if (mode === undefined || mode === false) {
+        return false;
+    }
+    if (mode === true) {
+        return true;
+    }
+    return supported && !blocked;
+}
+
+export function isWorkerRequested(mode: WorkerMode | undefined): boolean {
+    return mode === true || mode === 'auto';
+}
+
+export function normalizeLiveUniformNames(names: string[] | undefined): string[] {
+    return (names ?? []).map(normalizeUniformName);
+}
+
+export function normalizeWorkerPrograms(uniforms: WorkerProgramUniforms): WorkerProgramUniforms {
+    const normalized: WorkerProgramUniforms = {};
+    for (const [programId, params] of Object.entries(uniforms)) {
+        normalized[programId] = normalizeUniformParams(params);
+    }
+    return normalized;
+}
+
+export function stripPassUniforms(passes: RenderPass[]): RenderPass[] {
+    return passes.map(({ uniforms: _uniforms, ...pass }) => pass);
+}
+
+function isLiveName(live: WorkerLiveUniforms | undefined, programId: string, name: string): boolean {
+    return live !== undefined && live.programId === programId && live.names.includes(name);
+}
+
+function findLiveUniformBlock(inputs: WorkerBlockInputs): WorkerBlock | null {
+    const live = inputs.liveUniforms;
+    if (!live || !inputs.uniforms) {
+        return null;
+    }
+
+    const params = inputs.uniforms[live.programId] as Record<string, UniformParam> | undefined;
+    for (const name of live.names) {
+        if (!params || !(name in params)) {
+            return { kind: 'live-uniform-unknown', name };
+        }
+    }
+    return null;
+}
+
+function findProgramUniformBlock(inputs: WorkerBlockInputs): WorkerBlock | null {
+    for (const [programId, params] of Object.entries(inputs.uniforms ?? {})) {
+        for (const [name, param] of Object.entries(params)) {
+            if (typeof param.value === 'function') {
+                if (isWorkerBuiltinUniformName(name)) {
+                    return { kind: 'uniform-builtin-function', programId, name };
+                }
+                if (isLiveName(inputs.liveUniforms, programId, name)) {
+                    continue;
+                }
+                return { kind: 'uniform-function', programId, name };
+            }
+            if (normalizeCloneSafeUniformValue(param.value) === null) {
+                return { kind: 'uniform-not-clone-safe', programId, name };
+            }
+        }
+    }
+    return null;
+}
+
+function findPassUniformBlock(passes: RenderPass[]): WorkerBlock | null {
+    for (let passIndex = 0; passIndex < passes.length; passIndex++) {
+        const pass = passes[passIndex];
+        for (const [name, uniform] of Object.entries(pass.uniforms ?? {})) {
+            if (typeof uniform.value === 'function') {
+                return { kind: 'pass-uniform-function', programId: pass.programId, passIndex, name };
+            }
+            if (normalizeCloneSafeUniformValue(uniform.value) === null) {
+                return { kind: 'pass-uniform-not-clone-safe', programId: pass.programId, passIndex, name };
+            }
+        }
+    }
+    return null;
+}
+
+export function findWorkerBlock(inputs: WorkerBlockInputs): WorkerBlock | null {
+    if (!inputs.uniforms) {
+        return { kind: 'uniforms-missing' };
+    }
+    if (!inputs.fastPath) {
+        return { kind: 'fast-path' };
+    }
+    if (inputs.instancing) {
+        return { kind: 'instancing' };
+    }
+
+    return findLiveUniformBlock(inputs)
+        ?? findProgramUniformBlock(inputs)
+        ?? findPassUniformBlock(inputs.passes ?? []);
+}
+
+function passLabel(programId: string, passIndex: number): string {
+    return `pass ${String(passIndex)} (program "${programId}")`;
+}
+
+function builtinUniformFunctionMessage(programId: string, name: string): string {
+    const builtins = WORKER_BUILTIN_UNIFORM_NAMES.join(', ');
+    return `micugl worker: uniform "${name}" on program "${programId}" is a function, but `
+        + `${builtins} are computed inside the worker from the frame clock and the canvas size. A worker cannot `
+        + `call your function, so it would be ignored and "${name}" would not be the value you wrote. `
+        + `Give "${name}" a plain value (number, number[], or typed array), or turn off worker mode on `
+        + 'this component so the main thread can call it every frame.';
+}
+
+function notCloneSafeMessage(programId: string, name: string): string {
+    return `micugl worker: uniform "${name}" on program "${programId}" is not structured-clone-safe, so it `
+        + 'cannot be posted to a worker. Worker-mode uniform values must be a number, a number[], or a typed '
+        + 'array. Convert it, or turn off worker mode on this component.';
+}
+
+function passUniformFunctionMessage(programId: string, passIndex: number, name: string): string {
+    return `micugl worker: pass uniform "${name}" on ${passLabel(programId, passIndex)} is a function, and a `
+        + 'worker cannot call it. Sending the pass without it would silently render a different picture: micugl '
+        + `would either drop "${name}" or substitute its own built-in, which is not the value your function `
+        + `returns. Give "${name}" a plain value (number, number[], or typed array), drop "customPasses" so `
+        + 'micugl builds the ping-pong passes (their uniforms are posted to the worker for you), or turn off '
+        + 'worker mode on this component.';
+}
+
+function passUniformNotCloneSafeMessage(programId: string, passIndex: number, name: string): string {
+    return `micugl worker: pass uniform "${name}" on ${passLabel(programId, passIndex)} is not `
+        + 'structured-clone-safe, so it cannot be posted to a worker. Render-pass uniform values must be a '
+        + 'number, a number[], or a typed array. Convert it, or turn off worker mode on this component.';
+}
+
+function uniformsMissingMessage(component: string): string {
+    return `${component}: worker mode needs the raw uniform params in the "workerUniforms" prop, because uniform `
+        + 'updater functions cannot cross a worker boundary. Pass workerUniforms, or turn off worker mode.';
+}
+
+function fastPathMessage(component: string): string {
+    return `${component}: worker mode requires useFastPath. A custom renderCallback runs on the main thread and `
+        + 'cannot be sent to a worker. Set useFastPath, or turn off worker mode.';
+}
+
+function instancingMessage(component: string): string {
+    return `${component}: "instancing" is not supported in worker mode (v1). Remove the "instancing" prop, or `
+        + 'turn off worker mode on this component.';
+}
+
+function missingLiveUniformMessage(name: string): string {
+    return `micugl worker: "${name}" is listed in the "liveUniforms" prop but is not one of the component's `
+        + 'uniforms, so nothing would ever be sent for it. Add it to "uniforms", or remove it from "liveUniforms".';
+}
+
+export function workerBlockMessage(component: string, block: WorkerBlock): string {
+    switch (block.kind) {
+        case 'uniforms-missing':
+            return uniformsMissingMessage(component);
+        case 'fast-path':
+            return fastPathMessage(component);
+        case 'instancing':
+            return instancingMessage(component);
+        case 'live-uniform-unknown':
+            return missingLiveUniformMessage(block.name);
+        case 'uniform-function':
+            return functionUniformErrorMessage(block.programId, block.name);
+        case 'uniform-builtin-function':
+            return builtinUniformFunctionMessage(block.programId, block.name);
+        case 'uniform-not-clone-safe':
+            return notCloneSafeMessage(block.programId, block.name);
+        case 'pass-uniform-function':
+            return passUniformFunctionMessage(block.programId, block.passIndex, block.name);
+        case 'pass-uniform-not-clone-safe':
+            return passUniformNotCloneSafeMessage(block.programId, block.passIndex, block.name);
+    }
+}
+
+export interface WorkerPingPongUniformsOptions {
+    programId: string;
+    uniforms: Record<string, UniformParam>;
+    secondaryProgramId?: string;
+    secondaryUniforms?: Record<string, UniformParam>;
+    customPasses: boolean;
+}
+
+export function workerPingPongUniforms(options: WorkerPingPongUniformsOptions): WorkerProgramUniforms {
+    const programs: WorkerProgramUniforms = {
+        [options.programId]: options.customPasses ? {} : options.uniforms
+    };
+
+    if (options.secondaryProgramId !== undefined) {
+        programs[options.secondaryProgramId] = options.customPasses
+            ? {}
+            : (options.secondaryUniforms ?? {});
+    }
+
+    return programs;
+}
+
+export function workerHandleUnsupportedMessage(component: string, method: string): string {
+    return `${component}.${method}: not supported in worker mode (v1). It needs a WebGL context on the main `
+        + 'thread, and in worker mode the context lives in the worker. Turn off worker mode on this component to '
+        + `use ${method}.`;
+}
+
+export function workerGetFrameMessage(component: string): string {
+    return `${component}.getFrame: not available in worker mode. The render clock lives in the worker and cannot `
+        + 'be read synchronously from the main thread. Drive the clock instead: setFrame(frame) posts a '
+        + 'deterministic frame to the worker.';
+}
+
+export function warnWorkerDevtoolsUnavailable(): void {
+    logOnce(
+        'micugl worker: "debug" is set on a worker-rendered component, but worker-rendered engines cannot be '
+        + 'inspected: the devtools read a main-thread WebGL context and in worker mode the context lives in the '
+        + 'worker. Turn off worker mode on this component to inspect it.'
+    );
+}
+
+function alreadyTransferredMessage(): string {
+    return 'micugl worker: this <canvas> was already transferred to a worker. transferControlToOffscreen() is '
+        + 'permanent, so it can only ever be called once per element, and micugl gives each worker session a '
+        + 'fresh <canvas>. Reaching this means a micugl lifecycle bug: please report it.';
+}
+
+export function transferCanvasToWorker(canvas: HTMLCanvasElement): OffscreenCanvas {
+    if (transferredCanvases.has(canvas)) {
+        throw new Error(alreadyTransferredMessage());
+    }
+    transferredCanvases.add(canvas);
+    return canvas.transferControlToOffscreen();
+}
+
+export function collectWorkerValues(uniforms: Record<string, UniformParam>): WorkerUniformValues {
+    const values: WorkerUniformValues = {};
+    for (const [name, param] of Object.entries(uniforms)) {
+        if (typeof param.value === 'function') {
+            continue;
+        }
+        values[name] = param.value;
+    }
+    return values;
+}
+
+export function sampleLiveUniforms(
+    names: string[],
+    uniforms: Record<string, UniformParam>,
+    time: number,
+    width: number,
+    height: number
+): WorkerUniformValues {
+    const values: WorkerUniformValues = {};
+
+    for (const name of names) {
+        const param = uniforms[name];
+        values[name] = typeof param.value === 'function'
+            ? param.value(time, width, height)
+            : param.value;
+    }
+
+    return values;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,8 @@ export interface PingPongShaderHandle extends ShaderHandle {
   resetSimulation: (seed?: SeedOptions) => void;
 }
 
+export type WorkerMode = boolean | 'auto';
+
 export interface RenderControlProps {
   frameloop?: Frameloop;
   speed?: number;
@@ -173,6 +175,8 @@ export interface RenderControlProps {
   reducedMotion?: MotionPolicy;
   saveData?: MotionPolicy;
   staticFrame?: number;
+  worker?: WorkerMode;
+  createWorker?: () => Worker;
 }
 
 export interface WebGLExtensionTypes {

--- a/src/worker/WorkerBridge.test.ts
+++ b/src/worker/WorkerBridge.test.ts
@@ -334,6 +334,81 @@ describe('WorkerBridge value-diff posting', () => {
     });
 });
 
+describe('WorkerBridge unknown programs', () => {
+    it('throws instead of inventing a dirty-check entry for a program that was never declared', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit({
+            uniforms: { main: { u_a: { type: 'float', value: 1 } } }
+        }));
+        fake.postMessage.mockClear();
+
+        expect(() => { bridge.setUniformValues('blur', { u_a: 2 }) }).toThrow(/blur/);
+        expect(() => { bridge.setUniformValues('blur', { u_a: 2 }) }).toThrow(/main/);
+        expect(fake.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('accepts a program declared with an empty uniform map', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, pingPongInit([{ programId: 'main', inputTextures: [] }]));
+        fake.postMessage.mockClear();
+
+        expect(() => { bridge.setUniformValues('blur', {}) }).not.toThrow();
+        expect(fake.postMessage).not.toHaveBeenCalled();
+    });
+});
+
+describe('WorkerBridge ready idempotency', () => {
+    it('only flushes the queued resize and calls onReady for the first ready message', () => {
+        const fake = createFakeTransport();
+        const onReady = vi.fn();
+        const bridge = new WorkerBridge(fake.transport, baseInit(), { onReady });
+
+        bridge.resize(100, 200);
+        emitReady(fake);
+        emitReady(fake);
+
+        expect(onReady).toHaveBeenCalledTimes(1);
+        const resizeCalls = fake.postMessage.mock.calls.filter(
+            call => (call[0] as MainToWorker).type === 'resize'
+        );
+        expect(resizeCalls).toHaveLength(1);
+    });
+});
+
+describe('WorkerBridge motion gate', () => {
+    it('forwards the motion gate so the worker loop applies the same motion semantics', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.setMotionGate('static');
+        bridge.setMotionGate('none');
+
+        expect(fake.postMessage).toHaveBeenNthCalledWith(1, { type: 'setMotionGate', gate: 'static' }, undefined);
+        expect(fake.postMessage).toHaveBeenNthCalledWith(2, { type: 'setMotionGate', gate: 'none' }, undefined);
+    });
+
+    it('goes inert after dispose', () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        bridge.dispose();
+        fake.postMessage.mockClear();
+
+        bridge.setMotionGate('pause');
+
+        expect(fake.postMessage).not.toHaveBeenCalled();
+    });
+});
+
+describe('WorkerBridge skipDefaultUniforms', () => {
+    it('forwards skipDefaultUniforms so the worker does not auto-register u_time / u_resolution', () => {
+        const fake = createFakeTransport();
+        new WorkerBridge(fake.transport, baseInit({ skipDefaultUniforms: true }));
+
+        expect(initMessage(fake).config.skipDefaultUniforms).toBe(true);
+    });
+});
+
 describe('WorkerBridge setPasses', () => {
     it('posts serialized passes, applying the same built-in exemption and fail-loud rules', () => {
         const fake = createFakeTransport();

--- a/src/worker/WorkerBridge.ts
+++ b/src/worker/WorkerBridge.ts
@@ -1,3 +1,4 @@
+import type { MotionGate } from '@/react/lib/motionPolicy';
 import type {
     FramebufferOptions,
     Frameloop,
@@ -43,6 +44,21 @@ export interface WorkerTransport {
     terminate?: () => void;
 }
 
+export function workerTransport(worker: Worker): WorkerTransport {
+    return {
+        postMessage: (message, transfer) => {
+            if (transfer) {
+                worker.postMessage(message, transfer);
+                return;
+            }
+            worker.postMessage(message);
+        },
+        addEventListener: (type, listener) => { worker.addEventListener(type, listener) },
+        removeEventListener: (type, listener) => { worker.removeEventListener(type, listener) },
+        terminate: () => { worker.terminate() }
+    };
+}
+
 export interface WorkerBridgeCallbacks {
     onReady?: (capabilities: WorkerCapabilities) => void;
     onContextLost?: () => void;
@@ -59,6 +75,7 @@ export interface WorkerBridgeInit {
     uniforms: Record<string, WorkerBridgeProgramUniforms>;
     passes?: RenderPass[];
     framebuffers?: Record<string, FramebufferOptions>;
+    skipDefaultUniforms?: boolean;
     frameloop: Frameloop;
     speed: number;
     active?: boolean;
@@ -76,11 +93,16 @@ function isLiveUniformName(
     return liveUniforms?.[programId]?.includes(name) ?? false;
 }
 
-function functionUniformErrorMessage(programId: string, name: string): string {
+export function functionUniformErrorMessage(programId: string, name: string): string {
     return `micugl worker: uniform "${name}" on program "${programId}" is a function and cannot be `
         + 'sent to a worker. Either give it a plain value (number, number[], or typed array) so it is '
         + `posted on change, or list "${name}" in the "liveUniforms" prop for program "${programId}" `
         + 'to have it evaluated on the main thread each frame.';
+}
+
+function unknownProgramErrorMessage(programId: string, known: string[]): string {
+    return `micugl worker: setUniformValues was called for program "${programId}", which was not declared at `
+        + `init. Programs are fixed when the worker starts; the declared programs are: ${known.join(', ')}.`;
 }
 
 function notCloneSafeErrorMessage(programId: string, name: string): string {
@@ -212,6 +234,7 @@ export class WorkerBridge {
             framebuffers: init.framebuffers,
             initialValues,
             descriptors,
+            skipDefaultUniforms: init.skipDefaultUniforms,
             frameloop: init.frameloop,
             speed: init.speed,
             active: this.lastActive,
@@ -233,6 +256,9 @@ export class WorkerBridge {
         }
         switch (message.type) {
             case 'ready':
+                if (this.ready) {
+                    break;
+                }
                 this.ready = true;
                 if (this.pendingResize) {
                     this.post({ type: 'resize', ...this.pendingResize });
@@ -257,7 +283,11 @@ export class WorkerBridge {
             return;
         }
 
-        const last = this.lastPostedValues.get(programId) ?? {};
+        const last = this.lastPostedValues.get(programId);
+        if (!last) {
+            throw new Error(unknownProgramErrorMessage(programId, [...this.lastPostedValues.keys()]));
+        }
+
         const diff: UniformValueMap = {};
 
         for (const [name, rawValue] of Object.entries(values)) {
@@ -349,6 +379,13 @@ export class WorkerBridge {
             return;
         }
         this.post({ type: 'setSpeed', speed });
+    }
+
+    setMotionGate(gate: MotionGate): void {
+        if (this.disposed) {
+            return;
+        }
+        this.post({ type: 'setMotionGate', gate });
     }
 
     renderFrame(time: number): void {

--- a/src/worker/WorkerRuntime.test.ts
+++ b/src/worker/WorkerRuntime.test.ts
@@ -351,6 +351,81 @@ describe('WorkerRuntime uniforms', () => {
     });
 });
 
+describe('WorkerRuntime skipDefaultUniforms', () => {
+    it('registers no built-in updaters, matching a main-thread engine that skips the defaults', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas, { skipDefaultUniforms: true }));
+        harness.send({ type: 'resize', renderWidth: 640, renderHeight: 480 });
+        harness.tick(1000);
+        harness.tick(2000);
+
+        expect(drawCount(offscreen.gl)).toBe(2);
+        expect(vec2Uploads(offscreen.gl)).toEqual([]);
+        expect(floatUploads(offscreen.gl)).toEqual([0.25]);
+    });
+
+    it('still uploads posted values for the uniforms the main thread did declare', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas, { skipDefaultUniforms: true }));
+        harness.tick(0);
+        offscreen.gl.reset();
+
+        harness.send({ type: 'setUniformValues', programId: 'main', values: { u_intensity: 0.75 } });
+        harness.tick(16);
+
+        expect(floatUploads(offscreen.gl)).toEqual([0.75]);
+    });
+});
+
+describe('WorkerRuntime motion gate', () => {
+    it('stops free-running and freezes the clock when the main thread gates motion', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.tick(16);
+        expect(harness.pendingHandles()).toHaveLength(1);
+
+        harness.send({ type: 'setMotionGate', gate: 'static' });
+        expect(harness.pendingHandles()).toHaveLength(0);
+
+        harness.send({ type: 'renderFrame', time: 2000 });
+        expect(floatUploads(offscreen.gl)).toContain(2);
+        offscreen.gl.reset();
+
+        harness.send({ type: 'invalidate', frames: 1 });
+        harness.tick(9999);
+        harness.send({ type: 'invalidate', frames: 1 });
+        harness.tick(10999);
+
+        expect(drawCount(offscreen.gl)).toBe(2);
+        expect(floatUploads(offscreen.gl)).toEqual([]);
+    });
+
+    it('resumes free-running when the gate is released', () => {
+        const offscreen = createOffscreenStub();
+        const harness = createHarness();
+
+        harness.send(initMessage(offscreen.canvas));
+        harness.tick(16);
+
+        harness.send({ type: 'setMotionGate', gate: 'pause' });
+        expect(harness.pendingHandles()).toHaveLength(0);
+
+        harness.send({ type: 'setMotionGate', gate: 'none' });
+        expect(harness.pendingHandles()).toHaveLength(1);
+
+        harness.tick(1000);
+        harness.tick(2000);
+
+        expect(floatUploads(offscreen.gl)).toEqual(expect.arrayContaining([1]));
+    });
+});
+
 describe('WorkerRuntime scheduling', () => {
     it('cancels the scheduled frame when the main thread deactivates it, and resumes on reactivation', () => {
         const offscreen = createOffscreenStub();

--- a/src/worker/WorkerRuntime.ts
+++ b/src/worker/WorkerRuntime.ts
@@ -166,6 +166,9 @@ export class WorkerRuntime {
             case 'setSpeed':
                 loop.setSpeed(message.speed);
                 break;
+            case 'setMotionGate':
+                loop.setMotionGate(message.gate);
+                break;
             case 'renderFrame':
                 loop.setFrame(msToFrame(message.time));
                 break;
@@ -336,11 +339,13 @@ export class WorkerRuntime {
     private registerUniformUpdaters(manager: WebGLManager): void {
         const config = this.requireConfig();
 
-        for (const [programId, programConfig] of Object.entries(config.programConfigs)) {
-            for (const uniform of programConfig.uniforms) {
-                const hasPostedValue = this.values.get(programId)?.[uniform.name] !== undefined;
-                if (isWorkerBuiltinUniformName(uniform.name) && !hasPostedValue) {
-                    this.ensureBuiltinUpdater(manager, programId, uniform.name);
+        if (!config.skipDefaultUniforms) {
+            for (const [programId, programConfig] of Object.entries(config.programConfigs)) {
+                for (const uniform of programConfig.uniforms) {
+                    const hasPostedValue = this.values.get(programId)?.[uniform.name] !== undefined;
+                    if (isWorkerBuiltinUniformName(uniform.name) && !hasPostedValue) {
+                        this.ensureBuiltinUpdater(manager, programId, uniform.name);
+                    }
                 }
             }
         }

--- a/src/worker/protocol.test.ts
+++ b/src/worker/protocol.test.ts
@@ -30,6 +30,7 @@ describe('message type tag constants', () => {
             'invalidate',
             'setFrameloop',
             'setSpeed',
+            'setMotionGate',
             'renderFrame',
             'dispose'
         ]);

--- a/src/worker/protocol.ts
+++ b/src/worker/protocol.ts
@@ -1,3 +1,4 @@
+import type { MotionGate } from '@/react/lib/motionPolicy';
 import type {
     FramebufferOptions,
     Frameloop,
@@ -24,6 +25,7 @@ export const MAIN_TO_WORKER_MESSAGE_TYPES = [
     'invalidate',
     'setFrameloop',
     'setSpeed',
+    'setMotionGate',
     'renderFrame',
     'dispose'
 ] as const;
@@ -76,6 +78,7 @@ export interface WorkerInitConfig {
     framebuffers?: Record<string, FramebufferOptions>;
     initialValues: Record<string, UniformValueMap>;
     descriptors: Record<string, UniformDescriptor[]>;
+    skipDefaultUniforms?: boolean;
     frameloop: Frameloop;
     speed: number;
     active: boolean;
@@ -97,6 +100,7 @@ export type MainToWorker =
     | { type: 'invalidate'; frames?: number }
     | { type: 'setFrameloop'; mode: Frameloop }
     | { type: 'setSpeed'; speed: number }
+    | { type: 'setMotionGate'; gate: MotionGate }
     | { type: 'renderFrame'; time: number }
     | { type: 'dispose' };
 

--- a/src/worker/workerPipeline.test.ts
+++ b/src/worker/workerPipeline.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+
+import { vec3 } from '@/core';
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { GL_FLOAT, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
+import { WebGLManager } from '@/core/managers/WebGLManager';
+import { Passes } from '@/core/systems/Passes';
+import {
+    buildLiveUpdaters,
+    collectLiveValues,
+    parseUniformStructureKey,
+    uniformDescriptors,
+    uniformStructureKey
+} from '@/react/lib/liveUniformUpdaters';
+import {
+    buildPasses,
+    DEFAULT_FRAMEBUFFER_OPTIONS,
+    DEFAULT_RENDER_OPTIONS
+} from '@/react/lib/pingPongPasses';
+import { normalizeWorkerPrograms, stripPassUniforms, workerPingPongUniforms } from '@/react/lib/workerMode';
+import type { GLStubConfig, GLStubHandle } from '@/testing';
+import { createCanvasStub, createGLStub } from '@/testing';
+import type { FramebufferOptions, RenderPass, UniformParam, UniformUpdaterDef } from '@/types';
+import type { MainToWorker, WorkerToMain } from '@/worker/protocol';
+import type { WorkerBridgeMessageEvent, WorkerTransport } from '@/worker/WorkerBridge';
+import { WorkerBridge } from '@/worker/WorkerBridge';
+import type { WorkerRuntimeHost } from '@/worker/WorkerRuntime';
+import { WorkerRuntime } from '@/worker/WorkerRuntime';
+
+const PROGRAM_ID = 'sim';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_intensity: 'float', u_color1: 'vec3' }
+});
+
+const UNIFORM_NAMES = ['u_time', 'u_resolution', 'u_intensity', 'u_color1', 'u_texture0'];
+
+const GL_STUB_CONFIG: GLStubConfig = {
+    extensions: { OES_texture_float: true, OES_texture_float_linear: true },
+    renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT]
+};
+
+function simUniforms(): Record<string, UniformParam> {
+    return {
+        intensity: { type: 'float', value: 0.5 },
+        color1: { type: 'vec3', value: vec3([1, 0, 0]) }
+    };
+}
+
+function realUpdaters(
+    programId: string,
+    uniforms: Record<string, UniformParam>
+): Record<string, UniformUpdaterDef[]> {
+    const parsed = parseUniformStructureKey(uniformStructureKey(uniformDescriptors(uniforms), false));
+    const valuesRef = { current: collectLiveValues(uniforms) };
+    return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef) };
+}
+
+function realPingPong(uniforms: Record<string, UniformParam>): {
+    passes: RenderPass[];
+    framebuffers: Record<string, FramebufferOptions>;
+} {
+    return buildPasses(
+        PROGRAM_ID,
+        undefined,
+        1,
+        realUpdaters(PROGRAM_ID, uniforms),
+        {},
+        DEFAULT_FRAMEBUFFER_OPTIONS,
+        DEFAULT_RENDER_OPTIONS,
+        undefined
+    );
+}
+
+function readable(value: unknown): unknown {
+    if (value instanceof Float32Array) {
+        return Array.from(value);
+    }
+    if (Array.isArray(value)) {
+        return Array.from(value as unknown[]);
+    }
+    return value;
+}
+
+function uniformStateAtEachDraw(handle: GLStubHandle): Record<string, unknown>[] {
+    const names = new Map<unknown, string>();
+    for (const name of UNIFORM_NAMES) {
+        names.set(handle.gl.getUniformLocation({} as WebGLProgram, name), name);
+    }
+
+    const draws: Record<string, unknown>[] = [];
+    const state: Record<string, unknown> = {};
+
+    for (const call of handle.calls) {
+        if (call.name === 'drawArrays') {
+            draws.push({ ...state });
+            continue;
+        }
+        if (!call.name.startsWith('uniform')) {
+            continue;
+        }
+        const [location, value] = call.args;
+        const name = names.get(location);
+        if (name !== undefined) {
+            state[name] = readable(value);
+        }
+    }
+
+    return draws;
+}
+
+function renderOnMainThread(
+    passes: RenderPass[],
+    framebuffers: Record<string, FramebufferOptions>,
+    times: number[]
+): GLStubHandle {
+    const stub = createCanvasStub(GL_STUB_CONFIG);
+    const manager = new WebGLManager(stub.canvas);
+    manager.createProgram(PROGRAM_ID, CONFIG);
+
+    for (const [id, options] of Object.entries(framebuffers)) {
+        manager.fbo.createFramebuffer(id, options);
+    }
+
+    const passSystem = new Passes(manager);
+    for (const pass of passes) {
+        passSystem.addPass(pass);
+    }
+    passSystem.initializeResources();
+
+    manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+    for (const [id, options] of Object.entries(framebuffers)) {
+        manager.fbo.resizeFramebuffer(id, options.width || WIDTH, options.height || HEIGHT);
+    }
+
+    stub.reset();
+    for (const time of times) {
+        passSystem.execute(time);
+    }
+
+    return stub;
+}
+
+interface WorkerHarness {
+    gl: GLStubHandle;
+    tick: (now: number) => void;
+    errors: string[];
+}
+
+function renderInWorker(
+    passes: RenderPass[],
+    framebuffers: Record<string, FramebufferOptions>,
+    uniforms: Record<string, UniformParam>,
+    times: number[]
+): WorkerHarness {
+    const canvas = {
+        width: WIDTH,
+        height: HEIGHT,
+        getContext: (): WebGLRenderingContext => stub.gl,
+        addEventListener: (): void => undefined,
+        removeEventListener: (): void => undefined
+    };
+    const offscreen = canvas as unknown as OffscreenCanvas;
+    const stub = createGLStub({ ...GL_STUB_CONFIG, overrides: { canvas: offscreen } });
+
+    const scheduled = new Map<number, (now: number) => void>();
+    let nextHandle = 1;
+    const errors: string[] = [];
+    const listeners: ((event: WorkerBridgeMessageEvent<WorkerToMain>) => void)[] = [];
+
+    const host: WorkerRuntimeHost = {
+        postMessage: message => { listeners.forEach(listener => { listener({ data: message }) }) },
+        requestAnimationFrame: callback => {
+            const handle = nextHandle;
+            nextHandle += 1;
+            scheduled.set(handle, callback);
+            return handle;
+        },
+        cancelAnimationFrame: handle => { scheduled.delete(handle) },
+        now: () => 0
+    };
+
+    const runtime = new WorkerRuntime(host);
+    const transport: WorkerTransport = {
+        postMessage: (message: MainToWorker) => { runtime.handleMessage(message) },
+        addEventListener: (_type, listener) => { listeners.push(listener) }
+    };
+
+    const bridge = new WorkerBridge(
+        transport,
+        {
+            canvas: offscreen,
+            kind: 'pingpong',
+            programConfigs: { [PROGRAM_ID]: CONFIG },
+            uniforms: normalizeWorkerPrograms(workerPingPongUniforms({
+                programId: PROGRAM_ID,
+                uniforms,
+                customPasses: false
+            })),
+            passes: stripPassUniforms(passes),
+            framebuffers,
+            skipDefaultUniforms: false,
+            frameloop: 'always',
+            speed: 1,
+            active: true
+        },
+        { onError: message => { errors.push(message) } }
+    );
+
+    expect(bridge).toBeDefined();
+    stub.reset();
+
+    const tick = (now: number): void => {
+        const callbacks = Array.from(scheduled.values());
+        scheduled.clear();
+        callbacks.forEach(callback => { callback(now) });
+    };
+
+    for (const time of times) {
+        tick(time);
+    }
+
+    return { gl: stub, tick, errors };
+}
+
+describe('worker ping-pong pipeline, driven by the real pass and uniform builders', () => {
+    it('uploads the user uniform value the main thread would have uploaded, not a default', () => {
+        const uniforms = simUniforms();
+        const { passes, framebuffers } = realPingPong(uniforms);
+
+        const worker = renderInWorker(passes, framebuffers, uniforms, [0]);
+
+        expect(worker.errors).toEqual([]);
+        expect(uniformStateAtEachDraw(worker.gl)[0]).toEqual({
+            u_time: 0,
+            u_resolution: [WIDTH, HEIGHT],
+            u_intensity: 0.5,
+            u_color1: [1, 0, 0]
+        });
+    });
+
+    it('advances u_time in the worker instead of freezing it at the value of the first frame', () => {
+        const uniforms = simUniforms();
+        const { passes, framebuffers } = realPingPong(uniforms);
+
+        const worker = renderInWorker(passes, framebuffers, uniforms, [1000, 2000, 4000]);
+
+        expect(worker.errors).toEqual([]);
+        expect(uniformStateAtEachDraw(worker.gl).map(draw => draw.u_time))
+            .toEqual([0, 0, 0, 1, 1, 1, 3, 3, 3]);
+    });
+
+    it('gives the seed pass the same uniforms as every other pass, on both threads', () => {
+        const uniforms = simUniforms();
+        const { passes, framebuffers } = realPingPong(uniforms);
+
+        const main = uniformStateAtEachDraw(renderOnMainThread(passes, framebuffers, [0]));
+        const worker = uniformStateAtEachDraw(renderInWorker(passes, framebuffers, uniforms, [0]).gl);
+
+        expect(main).toHaveLength(3);
+        expect(main[0]).toEqual({
+            u_time: 0,
+            u_resolution: [WIDTH, HEIGHT],
+            u_intensity: 0.5,
+            u_color1: [1, 0, 0]
+        });
+        expect(worker.map(draw => ({ ...draw, u_texture0: undefined })))
+            .toEqual(main.map(draw => ({ ...draw, u_texture0: undefined })));
+    });
+
+    it('keeps worker and main thread in step as the clock advances', () => {
+        const uniforms = simUniforms();
+        const built = realPingPong(uniforms);
+
+        const main = uniformStateAtEachDraw(renderOnMainThread(built.passes, built.framebuffers, [0, 1000, 2000]));
+        const worker = uniformStateAtEachDraw(
+            renderInWorker(built.passes, built.framebuffers, uniforms, [0, 1000, 2000]).gl
+        );
+
+        expect(worker.map(draw => ({ ...draw, u_texture0: undefined })))
+            .toEqual(main.map(draw => ({ ...draw, u_texture0: undefined })));
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,23 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
     resolve: { alias: { '@': resolve(__dirname, 'src') } },
     test: {
-        include: ['src/**/*.test.{ts,tsx}'],
-        environment: 'node'
+        projects: [
+            {
+                extends: true,
+                test: {
+                    name: 'node',
+                    include: ['src/**/*.test.ts'],
+                    environment: 'node'
+                }
+            },
+            {
+                extends: true,
+                test: {
+                    name: 'dom',
+                    include: ['src/**/*.test.tsx'],
+                    environment: 'jsdom'
+                }
+            }
+        ]
     }
 });


### PR DESCRIPTION
Third worker slice (after #49 protocol/bridge and #50 runtime/shipping). Wires worker mode into the components: `worker`, `createWorker` and `liveUniforms` props on `ShaderEngine`, `PingPongShaderEngine`, `BaseShaderComponent` and `BasePingPongShaderComponent`. **The main-thread path is unchanged** apart from one deliberate fix (the ping-pong seed pass, below).

## Transfer ordering

`transferControlToOffscreen()` is one-shot and permanent — after it the main thread can never get a context from that canvas, so a fallback *after* a transfer is a dead canvas forever. Everything is therefore decided before the transfer:

1. `createMicuglWorker()` (async) returns `null` on unsupported browser / CSP-blocked blob worker, logging once with the remedy — it does not throw.
2. The canvas is captured synchronously *before* the await; the `cancelled` flag is checked *after* it. StrictMode's cleanup runs before the awaited dynamic import resolves, so the first mount always bails and only the second transfers.
3. A `null` worker sets a fallback flag → re-render → normal `WebGLManager` on a canvas that was never touched.
4. In worker mode the `<canvas>` carries a React key, so a shader-source change mints a fresh DOM element rather than re-transferring a transferred one. A `WeakSet` backstop turns a double transfer into a named error instead of a cryptic `InvalidStateError`.

## The uniform boundary fails loud, before the transfer

Uniforms cross as plain values or as worker-computed built-ins. Every other shape is rejected up front: function uniforms not listed in `liveUniforms`, **function-valued built-ins**, **function-valued pass uniforms in `customPasses`**, non-clone-safe values, `instancing`, and a custom `renderCallback`. `worker={true}` throws; `worker="auto"` downgrades to the main thread.

`liveUniforms` (the documented, costly escape hatch for pointer-like inputs) are sampled on a main-thread `RenderLoop` — started *only* when the list is non-empty, so the common case runs no main-thread rAF at all — and posted through the bridge's value diff.

## Ping-pong

Uniforms route through program-level updaters: `Passes.execute` calls `updateUniforms` before applying pass uniforms, so the worker's passes need carry none of their own. This reuses the already-tested dirty-checked value path instead of a parallel one.

**The seed pass now carries its uniforms on both threads.** It previously carried none and drew with whatever GL state the previous frame left behind — `u_resolution = (0,0)` on frame 0, last frame's `u_time` after that. This is a small main-thread pixel change and a latent-bug fix. The committed visual golden (`visual-fixed`) is a single-program scene and is unaffected.

## Worker v1 non-goals — all fail loud, none silently degrade

`renderToBlob` / `renderToDataURL` / `captureStream` / `record` / `renderSequence` / `resetSimulation` throw (they need a main-thread GL context). `getFrame()` throws — the render clock lives in the worker and cannot be read synchronously without a per-frame message back, which is the exact cost worker mode exists to avoid; `setFrame()` still works. Devtools logs once and skips registration. Worker errors surface through a render-time throw so an error boundary catches them, rather than leaving a blank canvas.

## Protocol

Adds `setMotionGate` (so worker motion semantics reuse `RenderLoop.setMotionGate` rather than being re-implemented main-side) and `WorkerInitConfig.skipDefaultUniforms` — without which the worker would auto-register `u_time`/`u_resolution` from the program config and **animate a shader the main thread deliberately freezes**. `WorkerBridge` now throws on `setUniformValues` for an unknown program, and `ready` is idempotent.

## Review

Two parallel Opus reviews (correctness; style/scope), then one applying pass. Between them they caught, pre-merge:

- **A function-valued `u_time` in a `customPasses` entry was silently discarded and replaced with the library's built-in** — the user's function returns milliseconds, the built-in emits seconds, so the same shader rendered differently depending on whether the visitor's browser got a worker. A test in the diff explicitly blessed this. It now throws. (This is the *fourth* distinct way this feature has tried to silently freeze or substitute a built-in uniform.)
- `invalidate()` in worker mode drove only the bridge, not the sampler loop — so under `frameloop="demand"`, `liveUniforms` posted once at connect and the worker redrew with that first pointer value forever. The flagship `liveUniforms` use case, silently frozen.
- A typo'd `liveUniforms` name threw from inside a rAF callback: no error boundary could catch it, the loop was never rescheduled, and every live uniform froze at 0 for the session. Now validated in render, once.
- Switching `liveUniforms` on after connect never started the sampler loop.
- The "can this run in a worker?" reasons were enumerated in two hand-maintained lists that had already drifted; they are now one `WorkerBlock` union with one message function. `workerUniforms` was optional in the type but required at runtime — now a discriminated union makes the illegal states compile errors.
- Every non-worker user paid for worker mode on every render (uniform-map copies, violation scans, a fresh `transferControlToOffscreen` probe). Now gated on intent.

**Test honesty:** no test in the first draft proved a uniform *value* reaches GL in worker mode — the fixtures asserted names, and passed cleanly under two of the bugs above. There is now an end-to-end pipeline test driving the real builders through the real `WorkerBridge` into the real `WorkerRuntime`, asserting real values land (`u_intensity=0.5`, `u_color1=[1,0,0]`), that `u_time` actually advances, and that worker and main agree on the uniform state at every draw.

606 tests (+51). Adds `jsdom` (dev-only) for three component tests covering effect-wiring bugs that pure-logic tests structurally cannot reach — each verified to fail when its fix is reverted.

Next: **W4** — worker demo scene + a thin Playwright e2e behind `test:e2e`, and docs leading with the CSP remedy (`worker-src 'self' blob:`, or pass `createWorker` / use the `micugl/worker` export).