### PR TITLE
worker: W4 demo + e2e — and fix the CSP fallback, which never fired in Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,31 @@ that. Two supported fixes, both first-class:
    />
    ```
 
-If the worker cannot be constructed (no `OffscreenCanvas` support, or a CSP that forbids it),
-micugl logs once, explains the remedy, and renders on the main thread instead. The canvas is
-never transferred in that case, so the fallback is complete: same picture, no worker.
+If the worker cannot be started, micugl logs once, explains the remedy, and renders on the main
+thread instead: same picture, no worker. Two ways that happens, and they are detected at
+different moments:
+
+- **No `OffscreenCanvas` / `Worker` support**: decided before anything is transferred.
+- **A CSP that forbids the worker**: Chromium does *not* throw from `new Worker(blob:...)` — it
+  blocks the worker asynchronously, so a page under a strict CSP hands back a `Worker` object
+  whose script never runs. micugl only learns this when that worker fires `error` without ever
+  having started, which is necessarily after the canvas was transferred to it. micugl then
+  discards the transferred canvas, mounts a fresh one, and renders on the main thread.
+
+A component that has fallen back stays on the main thread for the rest of its life, even if you
+toggle `worker` back on: whatever stopped the worker from starting (no support, a CSP) will not
+have changed. Remount the component if you need it to try again.
+
+The fallback is always safe because **worker mode's uniform rules are a strict subset of
+main-thread mode's**: anything that can run in a worker can also run on the main thread, so
+falling back can only cost you the threading benefit, never the picture.
+
+Those two are the *only* fallbacks. A worker that started and then threw an uncaught error is a
+bug, not a configuration problem, so micugl surfaces it: the error is thrown from the
+component's render (catchable by an error boundary) and there is no fallback, because a fallback
+would hide it. The two cases are told apart by the `error` event itself — a worker whose script
+was never allowed to run fires a bare `Event`, while a worker that ran and threw fires an
+`ErrorEvent` carrying the exception's message.
 
 ### Uniforms in worker mode
 
@@ -211,12 +233,29 @@ In worker mode they throw, naming the remedy (turn worker mode off on that compo
   main thread. Drive the clock instead with `setFrame(frame)`.
 - Devtools (`debug`): there is no main-thread context to inspect. `debug` + `worker` logs once
   and inspects nothing.
-- Instancing, and a custom `renderCallback` on `ShaderEngine` (worker mode requires the fast
-  path). Both throw under `worker={true}`.
+- A custom `renderCallback` on `ShaderEngine`: worker mode requires the fast path, so it throws
+  under `worker={true}`.
+- Instancing: `worker` and `instancing` together are a **compile error** on `ShaderEngine` (the
+  worker props are a discriminated union), and throw at runtime if the types are bypassed.
 
 `invalidate()`, `setFrame()`, `start()`, `stop()`, `frameloop`, `speed`, `pauseWhenHidden`,
 `dpr`, `fit`, `reducedMotion` / `saveData` and the IntersectionObserver / visibility pausing all
 work exactly as they do on the main thread.
+
+### Seeing it work
+
+The demo app has a side-by-side scene: the same shader rendered by a worker component and a
+main-thread component, with a button that blocks the main thread with a synchronous busy loop.
+The worker canvas keeps animating through the block; the main-thread canvas freezes.
+
+```
+bun run dev
+# then open /?scene=worker-jank
+```
+
+`?scene=worker-context-loss` renders a worker component whose worker is built by a
+`createWorker` prop (a real module worker, no blob), and exposes hooks that force a WebGL
+context loss and restore inside the worker.
 
 ## Deterministic capture
 
@@ -416,3 +455,27 @@ script), drive the canvas with Playwright instead of `renderSequence`:
    ```
    ffmpeg -framerate 30 -i frame_%d.png -pix_fmt yuv420p out.mp4
    ```
+
+## Development
+
+| Script                | What it does                                                            |
+| --------------------- | ----------------------------------------------------------------------- |
+| `bun run dev`         | demo app (scenes live in `demo/scenes`, selected with `?scene=`)         |
+| `bun run typecheck`   | `tsc --noEmit`                                                          |
+| `bun run lint`        | eslint (`strictTypeChecked`, no `eslint-disable`, ASCII-only source)     |
+| `bun run test`        | vitest: pure-logic + jsdom component tests                               |
+| `bun run build`       | library build + worker build + tree-shaking assertions                   |
+| `bun run bench`       | Playwright GL-counter benchmarks over the demo scenes (`bench/`)         |
+| `bun run test:e2e`    | Playwright browser tests for worker mode (`e2e/`)                        |
+
+CI runs `typecheck + lint + test + build`. `bench` and `test:e2e` need a browser, so they are
+run on demand rather than in the gate.
+
+`test:e2e` is the only place the real `transferControlToOffscreen()` path is exercised: jsdom
+has no OffscreenCanvas, so the component tests stub it. It boots two servers — the dev server
+(React in dev mode, so `StrictMode` double-invokes effects) and a production build served by
+`vite preview` (where the worker really is an inlined blob, as it is for consumers) — and every
+worker assertion is gated behind positive proof that a worker is driving the canvas: a `Worker`
+was constructed, the canvas throws `InvalidStateError` from `getContext` because it was
+transferred, and no main-thread GL context exists for it. A silent fallback to main-thread
+rendering fails those tests instead of quietly passing them.

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -1,5 +1,11 @@
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { App } from './App';
+import { getQueryString } from './scenes/query';
 
-createRoot(document.getElementById('root')!).render(<App />);
+const strict = getQueryString('strict') === '1';
+
+createRoot(document.getElementById('root')!).render(
+    strict ? <StrictMode><App /></StrictMode> : <App />
+);

--- a/demo/scenes/WorkerContextLoss.tsx
+++ b/demo/scenes/WorkerContextLoss.tsx
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { vec3 } from '../../src/core/lib/vectorUtils';
+import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
+import type { UniformParam } from '../../src/types';
+import type { ContextLossMessage } from '../workers/contextLossWorker';
+import { QUAD_VERTEX, WORKER_BARS_FRAGMENT } from './shaders';
+
+export interface WorkerContextLossHandles {
+    loseContext: () => void;
+    restoreContext: () => void;
+}
+
+declare global {
+    interface Window {
+        __workerContextLoss?: WorkerContextLossHandles;
+    }
+}
+
+const config = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: WORKER_BARS_FRAGMENT,
+    uniformNames: {
+        u_color: 'vec3'
+    }
+});
+
+const uniforms: Record<string, UniformParam> = {
+    u_color: { type: 'vec3', value: vec3([0.15, 1, 0.4]) }
+};
+
+const CANVAS_WIDTH = 320;
+const CANVAS_HEIGHT = 240;
+
+const canvasStyle = {
+    width: `${String(CANVAS_WIDTH)}px`,
+    height: `${String(CANVAS_HEIGHT)}px`,
+    display: 'block'
+};
+
+export const WorkerContextLoss = () => {
+    const workerRef = useRef<Worker | null>(null);
+
+    const createWorker = useCallback(() => {
+        const instance = new Worker(new URL('../workers/contextLossWorker.ts', import.meta.url), {
+            type: 'module'
+        });
+        workerRef.current = instance;
+        return instance;
+    }, []);
+
+    useEffect(() => {
+        const post = (message: ContextLossMessage) => {
+            workerRef.current?.postMessage(message);
+        };
+
+        window.__workerContextLoss = {
+            loseContext: () => { post({ type: 'demo:losecontext' }) },
+            restoreContext: () => { post({ type: 'demo:restorecontext' }) }
+        };
+        return () => {
+            window.__workerContextLoss = undefined;
+        };
+    }, []);
+
+    return (
+        <div style={{ padding: '16px' }}>
+            <figure id='worker-host' style={{ margin: 0 }}>
+                <figcaption>worker (module worker via createWorker)</figcaption>
+                <BaseShaderComponent
+                    worker
+                    createWorker={createWorker}
+                    programId='worker-context-loss'
+                    shaderConfig={config}
+                    uniforms={uniforms}
+                    width={CANVAS_WIDTH}
+                    height={CANVAS_HEIGHT}
+                    useDevicePixelRatio={false}
+                    reducedMotion='ignore'
+                    saveData='ignore'
+                    style={canvasStyle}
+                />
+            </figure>
+        </div>
+    );
+};

--- a/demo/scenes/WorkerJank.tsx
+++ b/demo/scenes/WorkerJank.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { vec3 } from '../../src/core/lib/vectorUtils';
+import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
+import type { ShaderHandle, UniformParam } from '../../src/types';
+import { getIntQuery, getQueryString } from './query';
+import { QUAD_VERTEX, WORKER_BARS_FRAGMENT } from './shaders';
+
+export type WorkerDemoColor = 'green' | 'red';
+
+export interface WorkerDemoHandles {
+    startAll: () => void;
+    stopAll: () => void;
+    blockMainThread: (ms: number) => number;
+    setColor: (color: WorkerDemoColor) => void;
+}
+
+declare global {
+    interface Window {
+        __workerDemo?: WorkerDemoHandles;
+    }
+}
+
+const config = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: WORKER_BARS_FRAGMENT,
+    uniformNames: {
+        u_color: 'vec3'
+    }
+});
+
+const COLORS: Record<WorkerDemoColor, [number, number, number]> = {
+    green: [0.15, 1, 0.4],
+    red: [1, 0.2, 0.15]
+};
+
+const CANVAS_WIDTH = 320;
+const CANVAS_HEIGHT = 240;
+
+const canvasStyle = {
+    width: `${String(CANVAS_WIDTH)}px`,
+    height: `${String(CANVAS_HEIGHT)}px`,
+    display: 'block'
+};
+
+const blockMainThread = (ms: number): number => {
+    const until = performance.now() + ms;
+    let spins = 0;
+    while (performance.now() < until) {
+        spins += 1;
+    }
+    return spins;
+};
+
+export const WorkerJank = () => {
+    const mode = getQueryString('mode') ?? 'both';
+    const blockMs = getIntQuery('blockMs', 500);
+    const [color, setColor] = useState<WorkerDemoColor>('green');
+
+    const workerHandleRef = useRef<ShaderHandle>(null);
+    const mainHandleRef = useRef<ShaderHandle>(null);
+
+    const showWorker = mode !== 'main';
+    const showMain = mode !== 'worker';
+
+    useEffect(() => {
+        window.__workerDemo = {
+            startAll: () => {
+                workerHandleRef.current?.start();
+                mainHandleRef.current?.start();
+            },
+            stopAll: () => {
+                workerHandleRef.current?.stop();
+                mainHandleRef.current?.stop();
+            },
+            blockMainThread,
+            setColor
+        };
+        return () => {
+            window.__workerDemo = undefined;
+        };
+    }, []);
+
+    const onBlock = useCallback(() => {
+        blockMainThread(blockMs);
+    }, [blockMs]);
+
+    const onToggleColor = useCallback(() => {
+        setColor(current => current === 'green' ? 'red' : 'green');
+    }, []);
+
+    const uniforms: Record<string, UniformParam> = {
+        u_color: { type: 'vec3', value: vec3(COLORS[color]) }
+    };
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', padding: '16px' }}>
+            <div style={{ display: 'flex', gap: '12px' }}>
+                <button type='button' id='block-main-thread' onClick={onBlock}>
+                    Block the main thread for {blockMs}ms
+                </button>
+                <button type='button' id='toggle-color' onClick={onToggleColor}>
+                    Toggle color (now: {color})
+                </button>
+            </div>
+
+            <div style={{ display: 'flex', gap: '24px' }}>
+                {showWorker && (
+                    <figure id='worker-host' style={{ margin: 0 }}>
+                        <figcaption>worker</figcaption>
+                        <BaseShaderComponent
+                            ref={workerHandleRef}
+                            worker
+                            programId='worker-bars'
+                            shaderConfig={config}
+                            uniforms={uniforms}
+                            width={CANVAS_WIDTH}
+                            height={CANVAS_HEIGHT}
+                            useDevicePixelRatio={false}
+                            reducedMotion='ignore'
+                            saveData='ignore'
+                            style={canvasStyle}
+                        />
+                    </figure>
+                )}
+
+                {showMain && (
+                    <figure id='main-host' style={{ margin: 0 }}>
+                        <figcaption>main thread</figcaption>
+                        <BaseShaderComponent
+                            ref={mainHandleRef}
+                            programId='main-bars'
+                            shaderConfig={config}
+                            uniforms={uniforms}
+                            width={CANVAS_WIDTH}
+                            height={CANVAS_HEIGHT}
+                            useDevicePixelRatio={false}
+                            reducedMotion='ignore'
+                            saveData='ignore'
+                            style={canvasStyle}
+                        />
+                    </figure>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -13,6 +13,8 @@ import { ReducedMotion } from './ReducedMotion';
 import { RerenderStorm } from './RerenderStorm';
 import { StaticIdle } from './StaticIdle';
 import { VisualFixed } from './VisualFixed';
+import { WorkerContextLoss } from './WorkerContextLoss';
+import { WorkerJank } from './WorkerJank';
 
 export const scenes: Record<string, ComponentType> = {
     'rerender-storm': RerenderStorm,
@@ -26,7 +28,9 @@ export const scenes: Record<string, ComponentType> = {
     'visual-fixed': VisualFixed,
     'export-demo': ExportDemo,
     'instanced-particles': InstancedParticles,
-    'particles-components': ParticlesComponents
+    'particles-components': ParticlesComponents,
+    'worker-jank': WorkerJank,
+    'worker-context-loss': WorkerContextLoss
 };
 
 export const getSceneComponent = (): ComponentType | null => {

--- a/demo/scenes/shaders.ts
+++ b/demo/scenes/shaders.ts
@@ -44,6 +44,20 @@ export const GRADIENT_FRAGMENT = `
     }
 `;
 
+export const WORKER_BARS_FRAGMENT = `
+    precision highp float;
+    uniform float u_time;
+    uniform vec2 u_resolution;
+    uniform vec3 u_color;
+    varying vec2 v_uv;
+    void main() {
+        float bars = step(0.5, fract(v_uv.x * 4.0 - u_time * 3.0));
+        float pulse = 0.5 + 0.5 * sin(u_time * 1.7 + v_uv.y * 6.0);
+        vec3 col = mix(u_color * 0.08, u_color, bars) * (0.3 + 0.7 * pulse);
+        gl_FragColor = vec4(col, 1.0);
+    }
+`;
+
 export const PINGPONG_VERTEX = `
     attribute vec2 a_position;
     varying vec2 v_texCoord;

--- a/demo/workers/contextLossWorker.ts
+++ b/demo/workers/contextLossWorker.ts
@@ -1,0 +1,65 @@
+import type { MainToWorker, WorkerToMain } from '../../src/worker/protocol';
+import { WorkerRuntime } from '../../src/worker/WorkerRuntime';
+
+export type ContextLossMessage = { type: 'demo:losecontext' } | { type: 'demo:restorecontext' };
+
+interface WorkerScope {
+    postMessage: (message: WorkerToMain) => void;
+    addEventListener: (
+        type: 'message',
+        listener: (event: { data: MainToWorker | ContextLossMessage }) => void
+    ) => void;
+    requestAnimationFrame: (callback: (now: number) => void) => number;
+    cancelAnimationFrame: (handle: number) => void;
+    close: () => void;
+}
+
+type ContextGetter = (contextId: string, options?: unknown) => unknown;
+
+const scope = globalThis as unknown as WorkerScope;
+
+let capturedExtension: WEBGL_lose_context | null = null;
+
+const canvasPrototype = OffscreenCanvas.prototype as unknown as { getContext: ContextGetter };
+const originalGetContext = canvasPrototype.getContext;
+
+canvasPrototype.getContext = function (this: OffscreenCanvas, contextId: string, options?: unknown): unknown {
+    const context = originalGetContext.call(this, contextId, options);
+    if (context !== null && (contextId === 'webgl' || contextId === 'experimental-webgl')) {
+        capturedExtension = (context as WebGLRenderingContext).getExtension('WEBGL_lose_context');
+    }
+    return context;
+};
+
+const runtime = new WorkerRuntime({
+    postMessage: message => { scope.postMessage(message) },
+    requestAnimationFrame: callback => scope.requestAnimationFrame(callback),
+    cancelAnimationFrame: handle => { scope.cancelAnimationFrame(handle) },
+    now: () => performance.now(),
+    close: () => { scope.close() }
+});
+
+const loseContextExtension = (): WEBGL_lose_context => {
+    if (!capturedExtension) {
+        throw new Error(
+            'demo worker: no WEBGL_lose_context extension was captured, so this worker has either not created '
+            + 'its WebGL context yet or the extension is unavailable'
+        );
+    }
+    return capturedExtension;
+};
+
+scope.addEventListener('message', event => {
+    const message = event.data;
+
+    if (message.type === 'demo:losecontext') {
+        loseContextExtension().loseContext();
+        return;
+    }
+    if (message.type === 'demo:restorecontext') {
+        loseContextExtension().restoreContext();
+        return;
+    }
+
+    runtime.handleMessage(message);
+});

--- a/e2e/pixels.ts
+++ b/e2e/pixels.ts
@@ -1,0 +1,170 @@
+import { inflateSync } from 'node:zlib';
+
+export interface Bitmap {
+    width: number;
+    height: number;
+    channels: number;
+    data: Uint8Array;
+}
+
+const SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+
+const paeth = (a: number, b: number, c: number): number => {
+    const p = a + b - c;
+    const pa = Math.abs(p - a);
+    const pb = Math.abs(p - b);
+    const pc = Math.abs(p - c);
+    if (pa <= pb && pa <= pc) {
+        return a;
+    }
+    return pb <= pc ? b : c;
+};
+
+const unfilter = (raw: Buffer, width: number, height: number, channels: number): Uint8Array => {
+    const stride = width * channels;
+    const out = new Uint8Array(stride * height);
+
+    for (let y = 0; y < height; y++) {
+        const filter = raw[y * (stride + 1)];
+        const line = y * (stride + 1) + 1;
+        const target = y * stride;
+
+        for (let x = 0; x < stride; x++) {
+            const value = raw[line + x];
+            const left = x >= channels ? out[target + x - channels] : 0;
+            const up = y > 0 ? out[target - stride + x] : 0;
+            const upLeft = y > 0 && x >= channels ? out[target - stride + x - channels] : 0;
+
+            let restored: number;
+            switch (filter) {
+                case 0: restored = value; break;
+                case 1: restored = value + left; break;
+                case 2: restored = value + up; break;
+                case 3: restored = value + ((left + up) >> 1); break;
+                case 4: restored = value + paeth(left, up, upLeft); break;
+                default: throw new Error(`unsupported PNG filter type ${String(filter)} on row ${String(y)}`);
+            }
+
+            out[target + x] = restored & 0xff;
+        }
+    }
+
+    return out;
+};
+
+export function decodePng(png: Buffer): Bitmap {
+    for (let i = 0; i < SIGNATURE.length; i++) {
+        if (png[i] !== SIGNATURE[i]) {
+            throw new Error('not a PNG: bad signature');
+        }
+    }
+
+    let offset = 8;
+    let width = 0;
+    let height = 0;
+    let channels = 0;
+    const chunks: Buffer[] = [];
+
+    while (offset + 8 <= png.length) {
+        const length = png.readUInt32BE(offset);
+        const type = png.toString('ascii', offset + 4, offset + 8);
+        const data = png.subarray(offset + 8, offset + 8 + length);
+        offset += 12 + length;
+
+        if (type === 'IHDR') {
+            width = data.readUInt32BE(0);
+            height = data.readUInt32BE(4);
+            const bitDepth = data[8];
+            const colorType = data[9];
+            const interlace = data[12];
+
+            if (bitDepth !== 8) {
+                throw new Error(`unsupported PNG bit depth ${String(bitDepth)}`);
+            }
+            if (interlace !== 0) {
+                throw new Error('unsupported interlaced PNG');
+            }
+            if (colorType === 6) {
+                channels = 4;
+            } else if (colorType === 2) {
+                channels = 3;
+            } else {
+                throw new Error(`unsupported PNG color type ${String(colorType)}`);
+            }
+        } else if (type === 'IDAT') {
+            chunks.push(Buffer.from(data));
+        } else if (type === 'IEND') {
+            break;
+        }
+    }
+
+    if (width === 0 || height === 0 || channels === 0) {
+        throw new Error('PNG has no IHDR chunk');
+    }
+
+    const raw = inflateSync(Buffer.concat(chunks));
+    const expected = height * (width * channels + 1);
+    if (raw.length !== expected) {
+        throw new Error(`PNG payload is ${String(raw.length)} bytes, expected ${String(expected)}`);
+    }
+
+    return { width, height, channels, data: unfilter(raw, width, height, channels) };
+}
+
+const requireSameShape = (a: Bitmap, b: Bitmap): void => {
+    if (a.width !== b.width || a.height !== b.height || a.channels !== b.channels) {
+        throw new Error(
+            `cannot compare bitmaps of different shapes: ${String(a.width)}x${String(a.height)}x`
+            + `${String(a.channels)} vs ${String(b.width)}x${String(b.height)}x${String(b.channels)}`
+        );
+    }
+};
+
+export function differingPixelFraction(first: Buffer, second: Buffer, tolerance = 0): number {
+    const a = decodePng(first);
+    const b = decodePng(second);
+    requireSameShape(a, b);
+
+    const pixels = a.width * a.height;
+    let differing = 0;
+
+    for (let pixel = 0; pixel < pixels; pixel++) {
+        const base = pixel * a.channels;
+        for (let channel = 0; channel < 3; channel++) {
+            if (Math.abs(a.data[base + channel] - b.data[base + channel]) > tolerance) {
+                differing += 1;
+                break;
+            }
+        }
+    }
+
+    return differing / pixels;
+}
+
+export function meanRgb(png: Buffer): [number, number, number] {
+    const bitmap = decodePng(png);
+    const pixels = bitmap.width * bitmap.height;
+    const totals = [0, 0, 0];
+
+    for (let pixel = 0; pixel < pixels; pixel++) {
+        const base = pixel * bitmap.channels;
+        totals[0] += bitmap.data[base];
+        totals[1] += bitmap.data[base + 1];
+        totals[2] += bitmap.data[base + 2];
+    }
+
+    return [totals[0] / pixels, totals[1] / pixels, totals[2] / pixels];
+}
+
+export function distinctColors(png: Buffer): number {
+    const bitmap = decodePng(png);
+    const pixels = bitmap.width * bitmap.height;
+    const seen = new Set<number>();
+
+    for (let pixel = 0; pixel < pixels; pixel++) {
+        const base = pixel * bitmap.channels;
+        seen.add((bitmap.data[base] << 16) | (bitmap.data[base + 1] << 8) | bitmap.data[base + 2]);
+    }
+
+    return seen.size;
+}

--- a/e2e/probes.ts
+++ b/e2e/probes.ts
@@ -1,0 +1,28 @@
+export interface WorkerProbeData {
+    urls: string[];
+}
+
+declare global {
+    interface Window {
+        __workerProbe: WorkerProbeData;
+    }
+}
+
+export function installWorkerProbe(target: Window & typeof globalThis): WorkerProbeData {
+    const urls: string[] = [];
+    const OriginalWorker = target.Worker;
+
+    class ProbedWorker extends OriginalWorker {
+        constructor(scriptURL: string | URL, options?: WorkerOptions) {
+            urls.push(String(scriptURL));
+            super(scriptURL, options);
+        }
+    }
+
+    target.Worker = ProbedWorker;
+    target.__workerProbe = { urls };
+
+    return target.__workerProbe;
+}
+
+export const workerProbeInitScript = '(' + installWorkerProbe.toString() + ')(window);';

--- a/e2e/servers.ts
+++ b/e2e/servers.ts
@@ -1,0 +1,5 @@
+export const DEV_PORT = 5599;
+export const BUILT_PORT = 5602;
+
+export const DEV_URL = `http://localhost:${String(DEV_PORT)}`;
+export const BUILT_URL = `http://localhost:${String(BUILT_PORT)}`;

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "composite": false
+  },
+  "include": ["**/*.ts"],
+  "references": []
+}

--- a/e2e/worker.spec.ts
+++ b/e2e/worker.spec.ts
@@ -1,0 +1,350 @@
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import type { WorkerContextLossHandles } from '../demo/scenes/WorkerContextLoss';
+import type { WorkerDemoHandles } from '../demo/scenes/WorkerJank';
+import type { GlCountersData } from '../src/testing/glCounters';
+import { instrumentationInitScript } from '../src/testing/glCounters';
+import { differingPixelFraction, distinctColors, meanRgb } from './pixels';
+import { workerProbeInitScript } from './probes';
+import { BUILT_URL, DEV_URL } from './servers';
+
+const BLOCK_MS = 500;
+const SETTLE_MS = 800;
+const IDLE_MS = 300;
+
+const MOVED_FRACTION = 0.2;
+const NOISE_TOLERANCE = 24;
+
+type CanvasProbe = 'transferred-to-worker' | 'main-thread-context' | 'no-context' | 'no-canvas';
+
+interface WorkerEvidence {
+    workerUrls: string[];
+    mainThreadContexts: number;
+    workerCanvas: CanvasProbe;
+    mainCanvas: CanvasProbe;
+}
+
+interface PageWatch {
+    pageErrors: string[];
+    consoleErrors: string[];
+}
+
+const watchPage = (page: Page): PageWatch => {
+    const watch: PageWatch = { pageErrors: [], consoleErrors: [] };
+    page.on('pageerror', error => watch.pageErrors.push(error.message));
+    page.on('console', message => {
+        if (message.type() === 'error') {
+            watch.consoleErrors.push(message.text());
+        }
+    });
+    return watch;
+};
+
+const bootstrap = async (page: Page): Promise<void> => {
+    await page.addInitScript({ content: workerProbeInitScript });
+    await page.addInitScript({ content: instrumentationInitScript });
+};
+
+const probeCanvases = (): { worker: CanvasProbe; main: CanvasProbe } => {
+    const probe = (hostId: string): CanvasProbe => {
+        const canvas = document.querySelector(`#${hostId} canvas`);
+        if (!(canvas instanceof HTMLCanvasElement)) {
+            return 'no-canvas';
+        }
+        try {
+            return canvas.getContext('webgl') === null ? 'no-context' : 'main-thread-context';
+        } catch {
+            return 'transferred-to-worker';
+        }
+    };
+    return { worker: probe('worker-host'), main: probe('main-host') };
+};
+
+const readEvidence = async (page: Page): Promise<WorkerEvidence> => {
+    const counters: GlCountersData = await page.evaluate(
+        () => window.__micuglInstrumentation.counters.snapshot()
+    );
+    const workerUrls = await page.evaluate(() => window.__workerProbe.urls);
+    const canvases = await page.evaluate(probeCanvases);
+
+    return {
+        workerUrls,
+        mainThreadContexts: counters.contextsCreated,
+        workerCanvas: canvases.worker,
+        mainCanvas: canvases.main
+    };
+};
+
+const waitForPaint = async (canvas: Locator): Promise<void> => {
+    await expect.poll(
+        async () => distinctColors(await canvas.screenshot()),
+        { message: 'canvas never painted anything but a single flat color', timeout: 10_000 }
+    ).toBeGreaterThan(4);
+};
+
+const openScene = async (page: Page, url: string): Promise<void> => {
+    await bootstrap(page);
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#worker-host canvas', { state: 'attached' });
+    await page.waitForTimeout(SETTLE_MS);
+};
+
+const serveWithCsp = async (page: Page, csp: string): Promise<void> => {
+    await page.route('**/*', async route => {
+        if (route.request().resourceType() !== 'document') {
+            await route.continue();
+            return;
+        }
+        const response = await route.fetch();
+        await route.fulfill({
+            response,
+            headers: { ...response.headers(), 'content-security-policy': csp }
+        });
+    });
+};
+
+const jankBurst = (page: Page): Promise<number> => page.evaluate(blockMs => {
+    const demo: WorkerDemoHandles | undefined = window.__workerDemo;
+    if (!demo) {
+        throw new Error('the worker-jank scene did not expose window.__workerDemo');
+    }
+    demo.startAll();
+    const spins = demo.blockMainThread(blockMs);
+    demo.stopAll();
+    return spins;
+}, BLOCK_MS);
+
+const stopAll = (page: Page): Promise<void> => page.evaluate(() => {
+    const demo: WorkerDemoHandles | undefined = window.__workerDemo;
+    if (!demo) {
+        throw new Error('the worker-jank scene did not expose window.__workerDemo');
+    }
+    demo.stopAll();
+});
+
+interface Target {
+    name: string;
+    url: string;
+    workerUrlPattern: RegExp;
+}
+
+const DEV_WORKER_URL = /^\/.*workerEntry\.ts\?worker_file/;
+const BLOB_WORKER_URL = /^blob:/;
+
+const targets: Target[] = [
+    { name: 'dev server, module worker', url: DEV_URL, workerUrlPattern: DEV_WORKER_URL },
+    { name: 'production build, inlined blob worker', url: BUILT_URL, workerUrlPattern: BLOB_WORKER_URL }
+];
+
+test.describe.configure({ mode: 'serial' });
+
+for (const target of targets) {
+    test(`worker mode renders from a real worker (${target.name})`, async ({ page }) => {
+        const watch = watchPage(page);
+        await openScene(page, `${target.url}/?scene=worker-jank`);
+
+        const evidence = await readEvidence(page);
+
+        expect(evidence.workerUrls).toHaveLength(1);
+        expect(evidence.workerUrls[0]).toMatch(target.workerUrlPattern);
+        expect(evidence.workerCanvas).toBe('transferred-to-worker');
+        expect(evidence.mainCanvas).toBe('main-thread-context');
+        expect(evidence.mainThreadContexts).toBe(1);
+
+        await waitForPaint(page.locator('#worker-host canvas'));
+
+        expect(watch.pageErrors).toEqual([]);
+        expect(watch.consoleErrors).toEqual([]);
+    });
+
+    test(`main-thread jank does not stall the worker canvas (${target.name})`, async ({ page }) => {
+        const watch = watchPage(page);
+        await openScene(page, `${target.url}/?scene=worker-jank`);
+
+        const workerCanvas = page.locator('#worker-host canvas');
+        const mainCanvas = page.locator('#main-host canvas');
+
+        const evidence = await readEvidence(page);
+        expect(evidence.workerCanvas).toBe('transferred-to-worker');
+        expect(evidence.mainThreadContexts).toBe(1);
+
+        await stopAll(page);
+        await page.waitForTimeout(IDLE_MS);
+
+        const workerBefore = await workerCanvas.screenshot();
+        const mainBefore = await mainCanvas.screenshot();
+        await page.waitForTimeout(IDLE_MS);
+
+        expect(differingPixelFraction(workerBefore, await workerCanvas.screenshot())).toBe(0);
+        expect(differingPixelFraction(mainBefore, await mainCanvas.screenshot())).toBe(0);
+
+        const spins = await jankBurst(page);
+        expect(spins).toBeGreaterThan(0);
+        await page.waitForTimeout(IDLE_MS);
+
+        const workerAfter = await workerCanvas.screenshot();
+        const mainAfter = await mainCanvas.screenshot();
+
+        expect(differingPixelFraction(workerBefore, workerAfter, NOISE_TOLERANCE))
+            .toBeGreaterThan(MOVED_FRACTION);
+        expect(differingPixelFraction(mainBefore, mainAfter)).toBe(0);
+
+        expect(watch.pageErrors).toEqual([]);
+        expect(watch.consoleErrors).toEqual([]);
+    });
+}
+
+test('StrictMode double mount transfers the canvas exactly once (dev server)', async ({ page }) => {
+    const watch = watchPage(page);
+    await openScene(page, `${DEV_URL}/?scene=worker-jank&mode=worker&strict=1`);
+
+    const evidence = await readEvidence(page);
+
+    expect(evidence.workerUrls).toHaveLength(2);
+    expect(await page.locator('#worker-host canvas').count()).toBe(1);
+    expect(evidence.workerCanvas).toBe('transferred-to-worker');
+    expect(evidence.mainThreadContexts).toBe(0);
+
+    await waitForPaint(page.locator('#worker-host canvas'));
+
+    expect(watch.pageErrors).toEqual([]);
+    expect(watch.consoleErrors).toEqual([]);
+});
+
+test('a React state change reaches a worker uniform (dev server)', async ({ page }) => {
+    const watch = watchPage(page);
+    await openScene(page, `${DEV_URL}/?scene=worker-jank`);
+
+    const workerCanvas = page.locator('#worker-host canvas');
+    const evidence = await readEvidence(page);
+    expect(evidence.workerCanvas).toBe('transferred-to-worker');
+
+    const [greenRed, greenGreen] = meanRgb(await workerCanvas.screenshot());
+    expect(greenGreen).toBeGreaterThan(greenRed);
+
+    await page.evaluate(() => {
+        const demo: WorkerDemoHandles | undefined = window.__workerDemo;
+        if (!demo) {
+            throw new Error('the worker-jank scene did not expose window.__workerDemo');
+        }
+        demo.setColor('red');
+    });
+    await page.waitForTimeout(IDLE_MS);
+
+    const [redRed, redGreen] = meanRgb(await workerCanvas.screenshot());
+    expect(redRed).toBeGreaterThan(redGreen);
+
+    expect(watch.pageErrors).toEqual([]);
+    expect(watch.consoleErrors).toEqual([]);
+});
+
+test('a worker context loss is recovered on restore (dev server)', async ({ page }) => {
+    const watch = watchPage(page);
+    await bootstrap(page);
+    await page.goto(`${DEV_URL}/?scene=worker-context-loss`, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#worker-host canvas', { state: 'attached' });
+    await page.waitForTimeout(SETTLE_MS);
+
+    const canvas = page.locator('#worker-host canvas');
+
+    const workerUrls = await page.evaluate(() => window.__workerProbe.urls);
+    expect(workerUrls).toHaveLength(1);
+    expect(workerUrls[0]).toMatch(/^http:\/\/localhost:.*contextLossWorker/);
+
+    const canvasProbe = await page.evaluate(probeCanvases);
+    expect(canvasProbe.worker).toBe('transferred-to-worker');
+
+    const running = await canvas.screenshot();
+    await page.waitForTimeout(IDLE_MS);
+    expect(differingPixelFraction(running, await canvas.screenshot(), NOISE_TOLERANCE))
+        .toBeGreaterThan(0);
+
+    await page.evaluate(() => {
+        const handles: WorkerContextLossHandles | undefined = window.__workerContextLoss;
+        if (!handles) {
+            throw new Error('the worker-context-loss scene did not expose window.__workerContextLoss');
+        }
+        handles.loseContext();
+    });
+    await page.waitForTimeout(SETTLE_MS);
+
+    const lost = await canvas.screenshot();
+    await page.waitForTimeout(IDLE_MS);
+    expect(differingPixelFraction(lost, await canvas.screenshot())).toBe(0);
+
+    await page.evaluate(() => {
+        const handles: WorkerContextLossHandles | undefined = window.__workerContextLoss;
+        if (!handles) {
+            throw new Error('the worker-context-loss scene did not expose window.__workerContextLoss');
+        }
+        handles.restoreContext();
+    });
+    await page.waitForTimeout(SETTLE_MS);
+
+    const restored = await canvas.screenshot();
+    await page.waitForTimeout(IDLE_MS);
+    expect(differingPixelFraction(restored, await canvas.screenshot(), NOISE_TOLERANCE))
+        .toBeGreaterThan(0);
+
+    expect(await page.locator('#worker-host canvas').count()).toBe(1);
+    expect(watch.pageErrors).toEqual([]);
+    expect(watch.consoleErrors).toEqual([]);
+});
+
+test('a CSP that forbids blob workers falls back to the main thread (production build)', async ({ page }) => {
+    const watch = watchPage(page);
+    await bootstrap(page);
+    await serveWithCsp(page, "worker-src 'self';");
+    await page.goto(`${BUILT_URL}/?scene=worker-jank`, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#worker-host canvas', { state: 'attached' });
+    await page.waitForTimeout(SETTLE_MS);
+
+    const evidence = await readEvidence(page);
+
+    expect(evidence.workerUrls).toHaveLength(1);
+    expect(evidence.workerUrls[0]).toMatch(/^blob:/);
+    expect(evidence.workerCanvas).toBe('main-thread-context');
+    expect(evidence.mainCanvas).toBe('main-thread-context');
+    expect(evidence.mainThreadContexts).toBe(2);
+
+    await waitForPaint(page.locator('#worker-host canvas'));
+
+    const canvas = page.locator('#worker-host canvas');
+    const first = await canvas.screenshot();
+    await page.waitForTimeout(IDLE_MS);
+    expect(differingPixelFraction(first, await canvas.screenshot(), NOISE_TOLERANCE)).toBeGreaterThan(0);
+
+    const refusals = watch.consoleErrors.filter(text => text.includes('Content Security Policy'));
+    const micuglLogs = watch.consoleErrors.filter(text => text.startsWith('micugl worker:'));
+    const others = watch.consoleErrors.filter(
+        text => !text.includes('Content Security Policy') && !text.startsWith('micugl worker:')
+    );
+
+    expect(refusals).toHaveLength(1);
+    expect(micuglLogs).toHaveLength(1);
+    expect(micuglLogs[0]).toContain('worker-src \'self\' blob:');
+    expect(micuglLogs[0]).toContain('createWorker');
+    expect(micuglLogs[0]).toContain('Rendering on the main thread instead');
+    expect(others).toEqual([]);
+    expect(watch.pageErrors).toEqual([]);
+});
+
+test('the documented CSP remedy lets the blob worker start (production build)', async ({ page }) => {
+    const watch = watchPage(page);
+    await bootstrap(page);
+    await serveWithCsp(page, "worker-src 'self' blob:;");
+    await page.goto(`${BUILT_URL}/?scene=worker-jank`, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#worker-host canvas', { state: 'attached' });
+    await page.waitForTimeout(SETTLE_MS);
+
+    const evidence = await readEvidence(page);
+
+    expect(evidence.workerUrls[0]).toMatch(/^blob:/);
+    expect(evidence.workerCanvas).toBe('transferred-to-worker');
+    expect(evidence.mainThreadContexts).toBe(1);
+
+    await waitForPaint(page.locator('#worker-host canvas'));
+
+    expect(watch.pageErrors).toEqual([]);
+    expect(watch.consoleErrors).toEqual([]);
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -176,7 +176,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['bench/**/*.{ts,tsx}', 'playwright.config.ts'],
+    files: ['bench/**/*.{ts,tsx}', 'e2e/**/*.{ts,tsx}', 'playwright.config.ts'],
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
     "bench": "playwright test --project=counters",
-    "bench:timing": "playwright test --project=timing"
+    "bench:timing": "playwright test --project=timing",
+    "test:e2e": "MICUGL_E2E=1 playwright test --project=e2e"
   },
   "peerDependencies": {
     "mp4-muxer": "^5.2.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,14 +2,36 @@ import { execSync } from 'node:child_process';
 
 import { defineConfig, devices } from '@playwright/test';
 
+import { BUILT_PORT, BUILT_URL, DEV_PORT, DEV_URL } from './e2e/servers';
+
 const sha = execSync('git rev-parse HEAD', { cwd: process.cwd() }).toString().trim();
 
-const PORT = 5599;
-const baseURL = `http://localhost:${PORT}`;
+const e2e = process.env.MICUGL_E2E === '1';
 
 const timingProject = {
     name: 'timing',
     use: { ...devices['Desktop Chrome'], headless: false }
+};
+
+const e2eProject = {
+    name: 'e2e',
+    testDir: './e2e',
+    use: { ...devices['Desktop Chrome'], headless: true }
+};
+
+const devServer = {
+    command: `bunx vite --config demo/vite.config.ts --port ${String(DEV_PORT)} --strictPort --no-open`,
+    url: DEV_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+};
+
+const builtDemoServer = {
+    command: 'bunx vite build --config demo/vite.config.ts'
+        + ` && bunx vite preview --config demo/vite.config.ts --port ${String(BUILT_PORT)} --strictPort`,
+    url: BUILT_URL,
+    reuseExistingServer: false,
+    timeout: 120_000
 };
 
 export default defineConfig({
@@ -21,19 +43,15 @@ export default defineConfig({
     reporter: [['list']],
     metadata: { sha },
     use: {
-        baseURL
+        baseURL: DEV_URL
     },
-    webServer: {
-        command: `bunx vite --config demo/vite.config.ts --port ${String(PORT)} --strictPort --no-open`,
-        url: baseURL,
-        reuseExistingServer: !process.env.CI,
-        timeout: 120_000
-    },
+    webServer: e2e ? [devServer, builtDemoServer] : [devServer],
     projects: [
         {
             name: 'counters',
             use: { ...devices['Desktop Chrome'], headless: true }
         },
-        ...(process.env.CI ? [] : [timingProject])
+        ...(process.env.CI ? [] : [timingProject]),
+        ...(e2e ? [e2eProject] : [])
     ]
 });

--- a/src/react/components/base/BaseShaderComponent.worker.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.worker.test.tsx
@@ -56,9 +56,17 @@ interface WorkerHarness {
     frames: FrameQueue;
     errors: string[];
     uploads: (name: string) => unknown[];
+    transfers: () => number;
+    mainThreadContexts: () => number;
+    failToStart: () => void;
+    crash: (message: string) => void;
 }
 
-function createWorkerHarness(): WorkerHarness {
+interface WorkerHarnessOptions {
+    startsScript?: boolean;
+}
+
+function createWorkerHarness({ startsScript = true }: WorkerHarnessOptions = {}): WorkerHarness {
     const offscreenCanvas = {
         width: 0,
         height: 0,
@@ -72,6 +80,10 @@ function createWorkerHarness(): WorkerHarness {
     const frames = createFrameQueue();
     const errors: string[] = [];
     const listeners: ((event: MessageEvent<WorkerToMain>) => void)[] = [];
+    const errorListeners: ((event: Event) => void)[] = [];
+
+    let transferCount = 0;
+    let mainThreadContextCount = 0;
 
     const host: WorkerRuntimeHost = {
         postMessage: message => {
@@ -88,9 +100,17 @@ function createWorkerHarness(): WorkerHarness {
     const runtime = new WorkerRuntime(host);
 
     const worker = {
-        postMessage: (message: MainToWorker) => { runtime.handleMessage(message) },
-        addEventListener: (_type: string, listener: (event: MessageEvent<WorkerToMain>) => void) => {
-            listeners.push(listener);
+        postMessage: (message: MainToWorker) => {
+            if (startsScript) {
+                runtime.handleMessage(message);
+            }
+        },
+        addEventListener: (type: string, listener: (event: never) => void) => {
+            if (type === 'error') {
+                errorListeners.push(listener as (event: Event) => void);
+                return;
+            }
+            listeners.push(listener as (event: MessageEvent<WorkerToMain>) => void);
         },
         removeEventListener: () => undefined,
         terminate: () => undefined
@@ -101,9 +121,16 @@ function createWorkerHarness(): WorkerHarness {
     (HTMLCanvasElement.prototype as unknown as {
         transferControlToOffscreen: () => OffscreenCanvas;
     }).transferControlToOffscreen = function transferControlToOffscreen(this: HTMLCanvasElement) {
+        transferCount += 1;
         offscreenCanvas.width = this.width;
         offscreenCanvas.height = this.height;
         return offscreen;
+    };
+    (HTMLCanvasElement.prototype as unknown as {
+        getContext: () => WebGLRenderingContext;
+    }).getContext = function getContext() {
+        mainThreadContextCount += 1;
+        return stub.gl;
     };
 
     return {
@@ -116,6 +143,14 @@ function createWorkerHarness(): WorkerHarness {
             return stub.uniformCalls
                 .filter(call => call.location === location)
                 .map(call => call.value);
+        },
+        transfers: () => transferCount,
+        mainThreadContexts: () => mainThreadContextCount,
+        failToStart: () => {
+            errorListeners.forEach(listener => { listener(new Event('error')) });
+        },
+        crash: (message: string) => {
+            errorListeners.forEach(listener => { listener(new ErrorEvent('error', { message })) });
         }
     };
 }
@@ -224,6 +259,72 @@ describe('BaseShaderComponent in worker mode', () => {
 
             expect(worker.errors).toEqual([]);
             expect(worker.uploads('u_level')).toEqual([0, 0.75]);
+        });
+
+    it('falls back to a fresh main-thread canvas when the worker never starts its script', async () => {
+        const worker = createWorkerHarness({ startsScript: false });
+        const handleRef = { current: null as ShaderHandle | null };
+
+        await mount(
+            <Scene
+                worker={worker}
+                handleRef={handleRef}
+                uniforms={{ level: { type: 'float', value: 0.5 } }}
+                frameloop='always'
+            />
+        );
+
+        const transferred = container.querySelector('canvas');
+        expect(worker.transfers()).toBe(1);
+        expect(worker.mainThreadContexts()).toBe(0);
+        expect(mainFrames.pending()).toBe(0);
+
+        await act(async () => {
+            worker.failToStart();
+            await Promise.resolve();
+        });
+
+        const replacement = container.querySelector('canvas');
+        expect(replacement).not.toBe(transferred);
+        expect(worker.transfers()).toBe(1);
+        expect(worker.mainThreadContexts()).toBe(1);
+
+        act(() => { mainFrames.tick(16) });
+
+        expect(worker.errors).toEqual([]);
+        expect(worker.uploads('u_level')).toEqual([0.5]);
+    });
+
+    it('surfaces an uncaught worker error instead of blaming a CSP and falling back to the main thread',
+        async () => {
+            const worker = createWorkerHarness({ startsScript: false });
+            const handleRef = { current: null as ShaderHandle | null };
+
+            await mount(
+                <Scene
+                    worker={worker}
+                    handleRef={handleRef}
+                    uniforms={{ level: { type: 'float', value: 0.5 } }}
+                    frameloop='always'
+                />
+            );
+
+            let failure: Error | null = null;
+            try {
+                await act(async () => {
+                    worker.crash('u_level is not a function');
+                    await Promise.resolve();
+                });
+            } catch (error) {
+                failure = error as Error;
+            }
+
+            expect(failure?.message).toContain('u_level is not a function');
+            expect(failure?.message).toContain('createWorker() factory');
+            expect(failure?.message).not.toContain('Content-Security-Policy');
+            expect(failure?.message).not.toContain('Rendering on the main thread');
+            expect(worker.mainThreadContexts()).toBe(0);
+            expect(worker.transfers()).toBe(1);
         });
 
     it('starts the sampler loop when liveUniforms is switched on after the worker connected', async () => {

--- a/src/react/hooks/useWorkerBridge.ts
+++ b/src/react/hooks/useWorkerBridge.ts
@@ -12,7 +12,14 @@ import {
     workerModeSupported
 } from '@/react/lib/workerMode';
 import type { Frameloop, WorkerMode } from '@/types';
-import { createMicuglWorker } from '@/worker/createWorker';
+import {
+    createMicuglWorker,
+    inlineWorkerNeverStartedMessage,
+    logWorkerIssue,
+    overrideWorkerCrashedMessage,
+    overrideWorkerNeverStartedMessage,
+    workerCrashedMessage
+} from '@/worker/createWorker';
 import type { WorkerBridgeInit } from '@/worker/WorkerBridge';
 import { WorkerBridge, workerTransport } from '@/worker/WorkerBridge';
 
@@ -85,6 +92,27 @@ export function useWorkerBridge(options: UseWorkerBridgeOptions): WorkerBridgeSe
 
         let cancelled = false;
         let created: Worker | null = null;
+        let ready = false;
+
+        const onWorkerError = (event: Event): void => {
+            if (cancelled) return;
+
+            const override = optionsRef.current.createWorker !== undefined;
+            const thrown = event instanceof ErrorEvent ? event.message : '';
+
+            if (thrown === '' && !ready) {
+                logWorkerIssue(override
+                    ? overrideWorkerNeverStartedMessage()
+                    : inlineWorkerNeverStartedMessage());
+                setFallback(true);
+                return;
+            }
+
+            const detail = thrown === '' ? 'no detail given' : thrown;
+            setError(new Error(override
+                ? overrideWorkerCrashedMessage(detail)
+                : workerCrashedMessage(detail)));
+        };
 
         const connect = async (): Promise<void> => {
             const instance = await createMicuglWorker({ createWorker: optionsRef.current.createWorker });
@@ -99,6 +127,8 @@ export function useWorkerBridge(options: UseWorkerBridgeOptions): WorkerBridgeSe
             }
 
             created = instance;
+            instance.addEventListener('error', onWorkerError);
+
             const current = optionsRef.current;
 
             const { renderWidth, renderHeight } = current.measure();
@@ -114,7 +144,10 @@ export function useWorkerBridge(options: UseWorkerBridgeOptions): WorkerBridgeSe
             const bridge = new WorkerBridge(
                 workerTransport(instance),
                 { ...init, canvas: offscreen },
-                { onError: message => { setError(new Error(message)) } }
+                {
+                    onReady: () => { ready = true },
+                    onError: message => { setError(new Error(message)) }
+                }
             );
             current.bridgeRef.current = bridge;
 
@@ -133,6 +166,7 @@ export function useWorkerBridge(options: UseWorkerBridgeOptions): WorkerBridgeSe
 
         return () => {
             cancelled = true;
+            created?.removeEventListener('error', onWorkerError);
             const current = optionsRef.current;
             const bridge = current.bridgeRef.current;
             current.bridgeRef.current = null;

--- a/src/worker/createWorker.test.ts
+++ b/src/worker/createWorker.test.ts
@@ -5,11 +5,15 @@ import {
     blobWorkerFailedMessage,
     createOnceLogger,
     createWorkerWithDeps,
+    inlineWorkerNeverStartedMessage,
     isWorkerModeSupported,
+    overrideWorkerCrashedMessage,
     overrideWorkerFailedMessage,
+    overrideWorkerNeverStartedMessage,
     requireInlineWorkerConstructor,
     unsupportedMessage,
-    unusableInlineWorkerMessage
+    unusableInlineWorkerMessage,
+    workerCrashedMessage
 } from '@/worker/createWorker';
 
 const WORKER = { name: 'worker' } as unknown as Worker;
@@ -195,6 +199,29 @@ describe('createWorkerWithDeps createWorker override', () => {
         expect(worker).toBeNull();
         expect(custom).not.toHaveBeenCalled();
         expect(log).toHaveBeenCalledWith(unsupportedMessage());
+    });
+});
+
+describe('worker error messages', () => {
+    it('blames a blob CSP only for the worker micugl built itself', () => {
+        expect(inlineWorkerNeverStartedMessage()).toContain('worker-src \'self\' blob:');
+        expect(overrideWorkerNeverStartedMessage()).not.toContain('blob:');
+        expect(overrideWorkerNeverStartedMessage()).toContain('createWorker() factory');
+    });
+
+    it('never offers a main-thread fallback for a worker that started and then threw', () => {
+        const inline = workerCrashedMessage('u_level is not a function');
+        const override = overrideWorkerCrashedMessage('u_level is not a function');
+
+        for (const message of [inline, override]) {
+            expect(message).toContain('u_level is not a function');
+            expect(message).toContain('not falling back to the main thread');
+            expect(message).not.toContain('Content-Security-Policy');
+        }
+
+        expect(inline).toContain('this build of micugl is broken');
+        expect(override).toContain('createWorker() factory');
+        expect(override).not.toContain('micugl is broken');
     });
 });
 

--- a/src/worker/createWorker.ts
+++ b/src/worker/createWorker.ts
@@ -72,6 +72,33 @@ export function overrideWorkerFailedMessage(error: unknown): string {
         + `origin, with "worker-src 'self'" in your CSP. ${MAIN_THREAD_FALLBACK}`;
 }
 
+export function inlineWorkerNeverStartedMessage(): string {
+    return 'micugl worker: the render worker was constructed but its script never started, so it can never '
+        + 'drive the canvas. The usual cause is a Content-Security-Policy that forbids blob: workers: Chromium '
+        + 'blocks such a worker asynchronously rather than throwing from the Worker constructor. Remedy: add '
+        + `"worker-src 'self' blob:" to your CSP. ${ESCAPE_HATCHES} ${MAIN_THREAD_FALLBACK}`;
+}
+
+export function overrideWorkerNeverStartedMessage(): string {
+    return 'micugl worker: the worker returned by the createWorker() factory you passed never started its '
+        + 'script, so it can never drive the canvas. micugl did not build this worker and cannot fix it: make '
+        + 'the factory return a worker your page is allowed to load and that resolves to a real script, for '
+        + 'example new Worker(new URL(\'micugl/worker\', import.meta.url), { type: \'module\' }) served from '
+        + `your own origin, with "worker-src 'self'" in your CSP. ${MAIN_THREAD_FALLBACK}`;
+}
+
+export function workerCrashedMessage(detail: string): string {
+    return `micugl worker: the render worker threw an uncaught error (${detail}). The worker runtime reports `
+        + 'its own failures as messages, so an uncaught error means this build of micugl is broken. micugl is '
+        + 'not falling back to the main thread, because that would hide the failure. Please report it.';
+}
+
+export function overrideWorkerCrashedMessage(detail: string): string {
+    return 'micugl worker: the worker returned by the createWorker() factory you passed threw an uncaught error '
+        + `(${detail}). The error came from that worker's own code, which micugl did not build and cannot fix. `
+        + 'micugl is not falling back to the main thread, because that would hide the failure.';
+}
+
 export function unusableInlineWorkerMessage(): string {
     return 'micugl worker: the inlined worker module has no default export to construct, so a worker built '
         + 'from it would run no code and paint nothing. This build of micugl is broken: its '
@@ -122,11 +149,11 @@ export async function createWorkerWithDeps(
     }
 }
 
-const defaultLog = createOnceLogger(message => { console.error(message) });
+export const logWorkerIssue = createOnceLogger(message => { console.error(message) });
 
 const defaultDeps: WorkerFactoryDeps = {
     loadInlineWorker: () => import('@/worker/workerEntry?worker&inline'),
-    log: defaultLog
+    log: logWorkerIssue
 };
 
 export function createMicuglWorker(options: CreateWorkerOptions = {}): Promise<Worker | null> {


### PR DESCRIPTION
Final worker slice (after #49 protocol/bridge, #50 runtime/shipping, #51 react wiring). Adds a worker demo scene, a Playwright e2e behind `test:e2e`, and docs — **and fixes a real bug shipped in #50/#51 that only a real browser could find.**

## The bug the e2e found

**`new Worker(blob:...)` does not throw under a CSP in Chromium.** The worker is blocked *asynchronously* and fires an `error` event. So the `try { new InlineWorker() } catch` that the entire CSP fallback was built on **never ran**. A page under a strict CSP transferred its canvas to a worker whose script never executed, and then sat **permanently blank — no log, no error, no fallback.** The README asserted this path worked.

This is the same silent-failure class the feature has now hit repeatedly: the failure mode is indistinguishable from success right up until you look at real pixels in a real browser.

### The fix, and the design change it forces

The fallback now listens for the worker's `error` event. It *cannot* happen before the transfer — there is nothing to catch until the worker fails asynchronously — so it discards the transferred canvas and mounts a fresh one (worker-mode canvases were already React-keyed in #51, so React does this cleanly) and renders main-thread.

The rule was never really "decide before the transfer". It is **"never fall back *onto* a transferred canvas"** — and mounting a fresh element satisfies that. Approved explicitly, since it revises the invariant agreed in #50.

### And the trap inside the fix

A worker `error` event has two causes, and conflating them would have been the next silent failure:

- a **bare `Event`** (no `.message`) = the script never loaded (CSP, network) → the one justified fail-open: log once with the remedy, render main-thread;
- an **`ErrorEvent` with a `.message`** = the script ran and **threw** → a genuine crash, surfaced from render, *not* swallowed.

The first draft branched only on "has `ready` arrived?", so an uncaught exception in the worker's startup — a broken micugl build, or a user's `createWorker` module worker throwing at eval — would have been logged as *"a Content-Security-Policy that forbids blob: workers"* and silently rendered main-thread. **A real crash, hidden, with the user's CSP blamed for it.** Caught in review. Chromium confirms the two are distinguishable by execution: after narrowing the fallback to bare-`Event`-only, the CSP e2e still falls back and still passes.

The inline-worker and `createWorker`-override paths now get separate messages, so neither blames blob CSP for a path that never touches blob (the mirror of a bug #50's review caught in prose).

## The e2e — and why it is honest

`e2e/`, run via `bun run test:e2e`, its own Playwright project, **deliberately outside the CI gate** (the gate stays pure-logic; the e2e is local-only, like the bench harness).

The dominant risk in testing worker mode is that **an e2e which silently falls back to the main thread passes every assertion anyway** — because worker mode's whole promise is that the picture is identical. A green suite that never started a worker is worse than no suite.

So every worker assertion is gated on **positive proof the worker is live**: `getContext('webgl')` on a transferred canvas *throws* `InvalidStateError` in Chromium, which is direct evidence the transfer happened, corroborated by a `Worker`-constructor probe and GL context counters. A silent fallback flips that probe and fails the gate **before any pixel assertion runs**. Verified by forcing a silent fallback and watching all 9 tests go red.

Nine tests: worker actually renders from a real worker (2 origins) · **the headline claim, differentially** — block the main thread for ~500ms, the worker canvas's pixels change and the main-thread canvas's do not · StrictMode double-mount (exactly 2 Worker constructions, 1 canvas, 0 main-thread contexts — no double transfer) · uniform change reflects · real context loss/restore inside the worker · CSP blocks blob worker → falls back and paints (exactly 1 CSP refusal, exactly 1 micugl log naming `worker-src 'self' blob:`, no page errors) · the documented remedy actually works.

Two origins are required, and this is not incidental: **the CSP test is vacuous on the dev server** (no blob worker in dev) and **the StrictMode test is vacuous on a production build** (React does not double-invoke effects in prod). A single-origin e2e would have silently proved nothing in one of the two.

## Demo

`?scene=worker-jank` — the same shader side by side, one in a worker, one on the main thread, with a button that blocks the main thread for ~500ms. The worker canvas animates straight through it. `?scene=worker-context-loss` drives a real GL context loss inside the worker.

## Not covered — stated plainly

- **Chromium only.** Other browsers may throw synchronously from `new Worker`; that path still exists and is unit-tested only.
- **The published `micugl/worker` exports-map resolution** is not exercised — the demo imports `src/` directly. The context-loss scene proves a real module worker works via `createWorker`, but not that the packed tarball resolves. That needs a packed-fixture app.
- Vite's inline wrapper falls back to a `data:` URL worker if blob creation throws; a CSP allowing `data:` but not `blob:` would silently succeed there. Untested, and outside our control.

610 tests (+4, including a jsdom regression test that guards the crash-vs-load distinction on every PR, since the e2e does not run in CI). 9 e2e.

**Feature 1 (worker rendering) is now complete: W1 #49, W2 #50, W3 #51, W4 #52.**