### PR TITLE
transitions: T1 tween uniform transitions - hook-level invalidation relay, gate snaps, fail loud in worker mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ deterministic frame instead of animating continuously.
 - `reducedMotion` / `saveData`: `'static-frame' | 'pause' | 'ignore'` (default `'static-frame'`
   for both). When either axis is active, the most restrictive configured policy wins.
 - `'static-frame'` draws one poster frame (at `staticFrame`, default `0`) and stops the
-  continuous render loop entirely; `invalidate()` calls are ignored.
+  continuous render loop entirely. The clock stays pinned to `staticFrame`, so nothing
+  time-driven advances; an explicit `invalidate()` still redraws that one pinned frame, so
+  value changes (theme, resize, a snapped transition) reach the canvas.
 - `'pause'` freezes the clock at its current value but keeps responding to `invalidate()` —
   useful for content that should stay interactive (theme changes, resize) without
   autonomous time-driven motion.
@@ -120,6 +122,62 @@ deterministic frame instead of animating continuously.
 - `staticFrame` (default `0`) is the poster frame number, on the same 60fps timebase as
   `setFrame`/`ShaderHandle`. Pick a frame that looks good as a static image for shaders
   that are dull at frame 0.
+
+## Uniform transitions
+
+Give a uniform param a `transition` and a change to its `value` animates to the new value
+instead of stepping to it:
+
+```tsx
+<BaseShaderComponent
+    programId='marble'
+    shaderConfig={config}
+    uniforms={{
+        swirl: { type: 'float', value: hovered ? 1 : 0, transition: { duration: 400 } },
+        color: {
+            type: 'vec3',
+            value: dark ? DARK : LIGHT,
+            transition: { duration: 600, easing: 'easeInOut', delay: 100 }
+        }
+    }}
+/>
+```
+
+- `transition: { duration, easing?, delay?, interpolate? }`. `duration` and `delay` are in
+  milliseconds. `easing` is one of `'linear' | 'easeIn' | 'easeOut' | 'easeInOut'` (default
+  `'linear'`), or your own `(t: number) => number`. `interpolate` replaces the default
+  component-wise lerp, for cases like color-space-aware blending.
+- Supported on `float`, `vec2`, `vec3` and `vec4`. A transition on any other type, or on a
+  function-valued uniform, throws: there is no sensible interpolation to fall back to, and a
+  silently ignored transition is worse than an error.
+- Interpolation happens at frame time, inside the uniform read. A transition costs no React
+  renders and no GL re-initialization, and the existing dirty check still means only changed
+  values are uploaded.
+- Mounting snaps: the first value a uniform is given is its starting value, never animated
+  from zero. Retargeting mid-flight starts the new leg from the current interpolated value.
+
+**Transitions run on the engine clock, not on wall time.** `speed` scales them (`speed={0.5}`
+halves their pace, `speed={0}` freezes them), and `setFrame(n)` pins them, which is what makes
+them deterministic: the same frame number always produces the same interpolated value, so
+`renderSequence()` and `renderToBlob({ frame })` capture transitions exactly.
+
+**A motion gate snaps them.** Under `reducedMotion="static-frame"`/`"pause"` (the default, when
+the user has `prefers-reduced-motion: reduce` or Save-Data on) the render clock is frozen, so a
+tween sampled on engine time physically cannot advance; micugl snaps the uniform to its target
+and repaints once rather than leaving it stuck at its old value. The deliberate consequence:
+`reducedMotion="ignore"` (the user has told you their motion is fine) keeps transitions
+animating.
+
+**`frameloop='never'` still animates them.** A transition wakes the loop through the same
+invalidate channel `handle.invalidate()` uses, and keeps it awake until it settles, then lets it
+go idle again. `'never'` means "render only when something invalidates", not "never render" -
+the prop for never advancing anything is `speed={0}`.
+
+**Worker mode rejects them.** Transitions are interpolated on the main thread every frame and
+worker mode posts plain values, so a `transition` under `worker` would be silently ignored and
+the uniform would jump. That combination throws with the remedy in the message. Sampling
+transitions on the main thread and posting them through the `liveUniforms` channel is a
+follow-up.
 
 ## Worker rendering (OffscreenCanvas)
 

--- a/demo/scenes/Transitions.tsx
+++ b/demo/scenes/Transitions.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { vec3 } from '../../src/core/lib/vectorUtils';
+import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
+import { useReducedMotion } from '../../src/react/hooks/useReducedMotion';
+import type { UniformParam } from '../../src/types';
+import { QUAD_VERTEX, TRANSITION_FRAGMENT } from './shaders';
+
+interface Palette {
+    name: string;
+    colorStart: [number, number, number];
+    colorEnd: [number, number, number];
+    swirl: number;
+}
+
+const PALETTES: Palette[] = [
+    { name: 'Sunset', colorStart: [0.95, 0.4, 0.2], colorEnd: [0.9, 0.75, 0.2], swirl: 4 },
+    { name: 'Ocean', colorStart: [0.05, 0.2, 0.5], colorEnd: [0.1, 0.7, 0.75], swirl: 8 },
+    { name: 'Forest', colorStart: [0.05, 0.3, 0.1], colorEnd: [0.6, 0.8, 0.2], swirl: 2 },
+    { name: 'Mono', colorStart: [0.1, 0.1, 0.12], colorEnd: [0.85, 0.85, 0.9], swirl: 12 }
+];
+
+const config = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: TRANSITION_FRAGMENT,
+    uniformNames: {
+        u_swirl: 'float',
+        u_colorStart: 'vec3',
+        u_colorEnd: 'vec3'
+    }
+});
+
+export const Transitions = () => {
+    const [paletteIndex, setPaletteIndex] = useState(0);
+    const reducedMotionActive = useReducedMotion();
+    const palette = PALETTES[paletteIndex];
+
+    const uniforms: Record<string, UniformParam> = {
+        swirl: { type: 'float', value: palette.swirl, transition: { duration: 600, easing: 'easeInOut' } },
+        colorStart: {
+            type: 'vec3',
+            value: vec3(palette.colorStart),
+            transition: { duration: 600, easing: 'easeInOut' }
+        },
+        colorEnd: {
+            type: 'vec3',
+            value: vec3(palette.colorEnd),
+            transition: { duration: 600, easing: 'easeInOut' }
+        }
+    };
+
+    return (
+        <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
+            <BaseShaderComponent
+                programId='transitions-demo'
+                shaderConfig={config}
+                uniforms={uniforms}
+                style={{ width: '100%', height: '100%', display: 'block' }}
+            />
+            <div
+                style={{
+                    position: 'absolute',
+                    top: '12px',
+                    left: '12px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '8px',
+                    padding: '12px',
+                    background: 'rgba(0, 0, 0, 0.6)',
+                    color: '#fff',
+                    fontFamily: 'monospace',
+                    fontSize: '12px',
+                    borderRadius: '4px',
+                    maxWidth: '260px'
+                }}
+            >
+                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                    {PALETTES.map((entry, index) => (
+                        <button
+                            key={entry.name}
+                            type='button'
+                            onClick={() => { setPaletteIndex(index) }}
+                            style={{
+                                padding: '6px 10px',
+                                background: index === paletteIndex ? '#e94560' : '#0f3460',
+                                border: 'none',
+                                borderRadius: '4px',
+                                color: '#fff',
+                                cursor: 'pointer'
+                            }}
+                        >
+                            {entry.name}
+                        </button>
+                    ))}
+                </div>
+                <div>
+                    Click palettes fast to see mid-flight retargeting: each click starts a new 600ms
+                    tween from wherever the current colors and swirl amount already are, not from the start.
+                </div>
+                <div>
+                    useReducedMotion(): {String(reducedMotionActive)}
+                    {reducedMotionActive
+                        ? ' (OS reduced-motion is on, so transitions snap instantly instead of tweening.)'
+                        : ''}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -12,6 +12,7 @@ import { getQueryString } from './query';
 import { ReducedMotion } from './ReducedMotion';
 import { RerenderStorm } from './RerenderStorm';
 import { StaticIdle } from './StaticIdle';
+import { Transitions } from './Transitions';
 import { VisualFixed } from './VisualFixed';
 import { WorkerContextLoss } from './WorkerContextLoss';
 import { WorkerJank } from './WorkerJank';
@@ -25,6 +26,7 @@ export const scenes: Record<string, ComponentType> = {
     'many-canvases-devtools': ManyCanvasesDevtools,
     'devtools-debug': DevtoolsDebug,
     'reduced-motion': ReducedMotion,
+    'transitions': Transitions,
     'visual-fixed': VisualFixed,
     'export-demo': ExportDemo,
     'instanced-particles': InstancedParticles,

--- a/demo/scenes/shaders.ts
+++ b/demo/scenes/shaders.ts
@@ -154,3 +154,20 @@ export const PARTICLES_COMPONENT_FRAGMENT = `
         gl_FragColor = vec4(vec3(v), 1.0);
     }
 `;
+
+export const TRANSITION_FRAGMENT = `
+    precision highp float;
+    uniform vec2 u_resolution;
+    uniform float u_swirl;
+    uniform vec3 u_colorStart;
+    uniform vec3 u_colorEnd;
+    varying vec2 v_uv;
+    void main() {
+        vec2 uv = v_uv * 2.0 - 1.0;
+        float angle = atan(uv.y, uv.x) + u_swirl * length(uv);
+        float radius = length(uv);
+        float band = 0.5 + 0.5 * sin(angle * 6.0 - radius * 8.0);
+        vec3 color = mix(u_colorStart, u_colorEnd, band);
+        gl_FragColor = vec4(color, 1.0);
+    }
+`;

--- a/examples/Marble/MarbleScene.tsx
+++ b/examples/Marble/MarbleScene.tsx
@@ -4,6 +4,7 @@ import { createShaderConfig } from '@/core/lib/createShaderConfig';
 import { vec3 } from '@/core/lib/vectorUtils';
 import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
 import { useDarkMode } from '@/react/hooks/useDarkMode';
+import type { UniformTransitionConfig } from '@/types';
 
 import { marbleFragmentShader, marbleVertexShader } from './marbleShaders';
 
@@ -29,6 +30,7 @@ export interface MarbleProps {
     veinColorDark?: Vec3;
     veinFrequency?: number;
     veinWidth?: number;
+    colorTransition?: UniformTransitionConfig;
     className?: string;
     style?: CSSProperties;
 }
@@ -46,6 +48,7 @@ export const Marble = ({
     colorStartDark = COLOR_START_DARK,
     colorEndDark = COLOR_END_DARK,
     veinColorDark = VEIN_COLOR_DARK,
+    colorTransition,
     className = '',
     style
 }: MarbleProps) => {
@@ -81,15 +84,18 @@ export const Marble = ({
                 veinWidth: { value: veinWidth, type: 'float' },
                 colorStart: {
                     type: 'vec3',
-                    value: vec3(isDarkMode ? colorStartDark : colorStart)
+                    value: vec3(isDarkMode ? colorStartDark : colorStart),
+                    transition: colorTransition
                 },
                 colorEnd: {
                     type: 'vec3',
-                    value: vec3(isDarkMode ? colorEndDark : colorEnd)
+                    value: vec3(isDarkMode ? colorEndDark : colorEnd),
+                    transition: colorTransition
                 },
                 veinColor: {
                     type: 'vec3',
-                    value: vec3(isDarkMode ? veinColorDark : veinColor)
+                    value: vec3(isDarkMode ? veinColorDark : veinColor),
+                    transition: colorTransition
                 }
             }}
         />

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,6 @@
 export { createTypedFloat32Array,mat2, mat3, mat4, vec2, vec3, vec4 } from './lib/vectorUtils';
 export { createShaderConfig } from '@/core/lib/createShaderConfig';
+export type { FrameInvalidation } from '@/core/lib/frameInvalidation';
 export {
     GL_CLAMP_TO_EDGE,
     GL_FLOAT,

--- a/src/core/lib/easing.test.ts
+++ b/src/core/lib/easing.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveEasing } from '@/core/lib/easing';
+
+describe('resolveEasing', () => {
+    it('defaults to linear when no easing is given', () => {
+        const fn = resolveEasing(undefined);
+        expect(fn(0)).toBe(0);
+        expect(fn(0.5)).toBe(0.5);
+        expect(fn(1)).toBe(1);
+    });
+
+    it('every named easing is exact at the endpoints', () => {
+        for (const name of ['linear', 'easeIn', 'easeOut', 'easeInOut'] as const) {
+            const fn = resolveEasing(name);
+            expect(fn(0)).toBe(0);
+            expect(fn(1)).toBe(1);
+        }
+    });
+
+    it('easeIn starts slower than linear at the midpoint', () => {
+        expect(resolveEasing('easeIn')(0.5)).toBeLessThan(0.5);
+    });
+
+    it('easeOut starts faster than linear at the midpoint', () => {
+        expect(resolveEasing('easeOut')(0.5)).toBeGreaterThan(0.5);
+    });
+
+    it('easeInOut is symmetric around the midpoint', () => {
+        expect(resolveEasing('easeInOut')(0.5)).toBe(0.5);
+    });
+
+    it('returns a custom easing function unchanged', () => {
+        const custom = (t: number): number => t * t * t;
+        expect(resolveEasing(custom)).toBe(custom);
+    });
+
+    it('throws on an unknown easing name', () => {
+        expect(() => { resolveEasing('bounce' as unknown as 'linear') }).toThrow(/unknown easing/);
+    });
+});

--- a/src/core/lib/easing.ts
+++ b/src/core/lib/easing.ts
@@ -1,0 +1,21 @@
+import type { EasingFn, EasingName } from '@/types';
+
+const EASINGS: Record<EasingName, EasingFn> = {
+    linear: t => t,
+    easeIn: t => t * t,
+    easeOut: t => 1 - (1 - t) * (1 - t),
+    easeInOut: t => t < 0.5 ? 2 * t * t : 1 - ((-2 * t + 2) ** 2) / 2
+};
+
+export function resolveEasing(easing: EasingName | EasingFn | undefined): EasingFn {
+    if (easing === undefined) {
+        return EASINGS.linear;
+    }
+    if (typeof easing === 'function') {
+        return easing;
+    }
+    if (!Object.prototype.hasOwnProperty.call(EASINGS, easing)) {
+        throw new Error(`micugl transitions: unknown easing "${String(easing)}"`);
+    }
+    return EASINGS[easing];
+}

--- a/src/core/lib/frameInvalidation.test.ts
+++ b/src/core/lib/frameInvalidation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { combineFrameInvalidation, createFrameInvalidation } from '@/core/lib/frameInvalidation';
+
+describe('createFrameInvalidation', () => {
+    it('fans out request() to every connected listener', () => {
+        const invalidation = createFrameInvalidation();
+        const calls: string[] = [];
+        invalidation.connect(() => { calls.push('a') });
+        invalidation.connect(() => { calls.push('b') });
+
+        invalidation.request();
+
+        expect(calls).toEqual(['a', 'b']);
+    });
+
+    it('dedupes the same listener connected twice', () => {
+        const invalidation = createFrameInvalidation();
+        let count = 0;
+        const listener = () => { count += 1 };
+
+        invalidation.connect(listener);
+        invalidation.connect(listener);
+        invalidation.request();
+
+        expect(count).toBe(1);
+    });
+
+    it('the disposer removes exactly that listener', () => {
+        const invalidation = createFrameInvalidation();
+        const calls: string[] = [];
+        invalidation.connect(() => { calls.push('a') });
+        const disposeB = invalidation.connect(() => { calls.push('b') });
+
+        disposeB();
+        invalidation.request();
+
+        expect(calls).toEqual(['a']);
+    });
+
+    it('request() before any connect() is a harmless no-op', () => {
+        const invalidation = createFrameInvalidation();
+        expect(() => { invalidation.request() }).not.toThrow();
+    });
+});
+
+describe('combineFrameInvalidation', () => {
+    it('connect() wires the same listener into every source', () => {
+        const sourceA = createFrameInvalidation();
+        const sourceB = createFrameInvalidation();
+        const combined = combineFrameInvalidation([sourceA, sourceB]);
+
+        let count = 0;
+        combined.connect(() => { count += 1 });
+
+        sourceA.request();
+        sourceB.request();
+
+        expect(count).toBe(2);
+    });
+
+    it('request() forwards to every source', () => {
+        const sourceA = createFrameInvalidation();
+        const sourceB = createFrameInvalidation();
+        const combined = combineFrameInvalidation([sourceA, sourceB]);
+
+        const calls: string[] = [];
+        sourceA.connect(() => { calls.push('a') });
+        sourceB.connect(() => { calls.push('b') });
+
+        combined.request();
+
+        expect(calls).toEqual(['a', 'b']);
+    });
+
+    it('the disposer from connect() disconnects from every source', () => {
+        const sourceA = createFrameInvalidation();
+        const sourceB = createFrameInvalidation();
+        const combined = combineFrameInvalidation([sourceA, sourceB]);
+
+        let count = 0;
+        const dispose = combined.connect(() => { count += 1 });
+        dispose();
+
+        sourceA.request();
+        sourceB.request();
+
+        expect(count).toBe(0);
+    });
+});

--- a/src/core/lib/frameInvalidation.ts
+++ b/src/core/lib/frameInvalidation.ts
@@ -1,0 +1,30 @@
+export interface FrameInvalidation {
+    connect(invalidate: () => void): () => void;
+    request(): void;
+}
+
+export function createFrameInvalidation(): FrameInvalidation {
+    const listeners = new Set<() => void>();
+
+    return {
+        connect(invalidate) {
+            listeners.add(invalidate);
+            return () => { listeners.delete(invalidate) };
+        },
+        request() {
+            listeners.forEach(listener => { listener() });
+        }
+    };
+}
+
+export function combineFrameInvalidation(sources: FrameInvalidation[]): FrameInvalidation {
+    return {
+        connect(invalidate) {
+            const disposers = sources.map(source => source.connect(invalidate));
+            return () => { disposers.forEach(dispose => { dispose() }) };
+        },
+        request() {
+            sources.forEach(source => { source.request() });
+        }
+    };
+}

--- a/src/core/lib/motionDrivers.test.ts
+++ b/src/core/lib/motionDrivers.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    createMotionState,
+    resolveTransitionConfig,
+    retargetMotion,
+    sampleMotion
+} from '@/core/lib/motionDrivers';
+import type { UniformTransitionConfig } from '@/types';
+
+function tween(config: UniformTransitionConfig) {
+    return resolveTransitionConfig(config);
+}
+
+describe('resolveTransitionConfig', () => {
+    it('defaults delay to 0 and resolves the named easing', () => {
+        const resolved = tween({ duration: 200 });
+        expect(resolved.duration).toBe(200);
+        expect(resolved.delay).toBe(0);
+        expect(resolved.easing(0.5)).toBe(0.5);
+    });
+
+    it('duration: 0 is legal (snap)', () => {
+        expect(() => tween({ duration: 0 })).not.toThrow();
+    });
+
+    it('throws on a negative duration', () => {
+        expect(() => tween({ duration: -1 })).toThrow(/duration/);
+    });
+
+    it('throws on a non-finite duration', () => {
+        expect(() => tween({ duration: Number.NaN })).toThrow(/duration/);
+    });
+
+    it('throws on a negative delay', () => {
+        expect(() => tween({ duration: 100, delay: -5 })).toThrow(/delay/);
+    });
+
+    it('throws on an unknown easing name', () => {
+        expect(() => tween({ duration: 100, easing: 'bounce' as unknown as 'linear' })).toThrow(/easing/);
+    });
+});
+
+describe('retargetMotion + sampleMotion (tween)', () => {
+    it('reaches the exact target value at t >= 1 and reports settled', () => {
+        const config = tween({ duration: 100 });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        const settledAtStart = sampleMotion(state, 0);
+        expect(settledAtStart).toBe(false);
+        expect(Array.from(state.current)).toEqual([0]);
+
+        const settledAtEnd = sampleMotion(state, 100);
+        expect(settledAtEnd).toBe(true);
+        expect(Array.from(state.current)).toEqual([10]);
+        expect(state.settled).toBe(true);
+    });
+
+    it('linear easing hits the exact midpoint at half the duration', () => {
+        const config = tween({ duration: 100, easing: 'linear' });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        sampleMotion(state, 0);
+        sampleMotion(state, 50);
+
+        expect(state.current[0]).toBeCloseTo(5);
+    });
+
+    it('clamps sampling past the end of the duration to the exact target', () => {
+        const config = tween({ duration: 100 });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        sampleMotion(state, 0);
+        const settled = sampleMotion(state, 10_000);
+
+        expect(settled).toBe(true);
+        expect(Array.from(state.current)).toEqual([10]);
+    });
+
+    it('a delay holds the value at "from" until the delay elapses', () => {
+        const config = tween({ duration: 100, delay: 50 });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        sampleMotion(state, 0);
+        sampleMotion(state, 25);
+        expect(state.current[0]).toBe(0);
+
+        sampleMotion(state, 100);
+        expect(state.current[0]).toBeCloseTo(5);
+
+        const settled = sampleMotion(state, 150);
+        expect(settled).toBe(true);
+        expect(state.current[0]).toBe(10);
+    });
+
+    it('duration: 0 snaps to the target on the first sample', () => {
+        const config = tween({ duration: 0 });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        const settled = sampleMotion(state, 0);
+
+        expect(settled).toBe(true);
+        expect(Array.from(state.current)).toEqual([10]);
+    });
+
+    it('mid-flight retarget starts the new leg from the interpolated current value, not the old "from"', () => {
+        const config = tween({ duration: 100, easing: 'linear' });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        sampleMotion(state, 0);
+        sampleMotion(state, 50);
+        expect(state.current[0]).toBeCloseTo(5);
+
+        retargetMotion(state, [20], config);
+        expect(Array.from(state.from)).toEqual([5]);
+
+        sampleMotion(state, 50);
+        expect(state.current[0]).toBeCloseTo(5);
+
+        sampleMotion(state, 100);
+        expect(state.current[0]).toBeCloseTo(12.5);
+    });
+
+    it('lazily captures startTime on the first sample after a retarget, not at retarget time', () => {
+        const config = tween({ duration: 100 });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        expect(state.startTime).toBeNull();
+
+        sampleMotion(state, 500);
+        expect(state.startTime).toBe(500);
+
+        sampleMotion(state, 600);
+        expect(state.current[0]).toBeCloseTo(10);
+    });
+
+    it('calls a custom interpolate hook with (from, to, easedT, out)', () => {
+        const calls: { from: number[]; to: number[]; t: number }[] = [];
+        const config = tween({
+            duration: 100,
+            easing: 'linear',
+            interpolate: (from, to, t, out) => {
+                calls.push({ from: Array.from(from), to: Array.from(to), t });
+                out[0] = from[0] + (to[0] - from[0]) * t;
+            }
+        });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        sampleMotion(state, 0);
+        sampleMotion(state, 25);
+
+        expect(calls).toHaveLength(2);
+        expect(calls[1]).toEqual({ from: [0], to: [10], t: 0.25 });
+        expect(state.current[0]).toBeCloseTo(2.5);
+    });
+
+    it('throws on a target longer than the state, instead of silently truncating it', () => {
+        const config = tween({ duration: 100 });
+        const state = createMotionState(config, new Float32Array([0]));
+
+        expect(() => { retargetMotion(state, [1, 2, 3], config) }).toThrow(RangeError);
+    });
+
+    it('sampling an already-settled state is a no-op that reports settled', () => {
+        const config = tween({ duration: 100 });
+        const state = createMotionState(config, new Float32Array([5]));
+
+        expect(state.settled).toBe(true);
+        const settled = sampleMotion(state, 999);
+
+        expect(settled).toBe(true);
+        expect(state.current[0]).toBe(5);
+    });
+});

--- a/src/core/lib/motionDrivers.ts
+++ b/src/core/lib/motionDrivers.ts
@@ -1,0 +1,106 @@
+import { resolveEasing } from '@/core/lib/easing';
+import type { EasingFn, UniformTransitionConfig } from '@/types';
+
+export interface ResolvedTweenConfig {
+    duration: number;
+    delay: number;
+    easing: EasingFn;
+    interpolate?: (from: ArrayLike<number>, to: ArrayLike<number>, t: number, out: Float32Array) => void;
+}
+
+export type ResolvedTransitionConfig = ResolvedTweenConfig;
+
+export interface MotionState {
+    from: Float32Array;
+    to: Float32Array;
+    current: Float32Array;
+    startTime: number | null;
+    settled: boolean;
+    config: ResolvedTransitionConfig;
+}
+
+function clamp01(value: number): number {
+    if (value < 0) return 0;
+    if (value > 1) return 1;
+    return value;
+}
+
+function lerpInto(from: Float32Array, to: Float32Array, t: number, out: Float32Array): void {
+    for (let i = 0; i < out.length; i++) {
+        out[i] = from[i] + (to[i] - from[i]) * t;
+    }
+}
+
+export function resolveTransitionConfig(config: UniformTransitionConfig): ResolvedTransitionConfig {
+    const duration = config.duration;
+    if (!Number.isFinite(duration) || duration < 0) {
+        throw new Error(
+            `micugl transitions: "duration" must be a finite number >= 0, received ${JSON.stringify(duration)}`
+        );
+    }
+
+    const delay = config.delay ?? 0;
+    if (!Number.isFinite(delay) || delay < 0) {
+        throw new Error(
+            `micugl transitions: "delay" must be a finite number >= 0, received ${JSON.stringify(delay)}`
+        );
+    }
+
+    return {
+        duration,
+        delay,
+        easing: resolveEasing(config.easing),
+        interpolate: config.interpolate
+    };
+}
+
+export function createMotionState(config: ResolvedTransitionConfig, initial: Float32Array): MotionState {
+    return {
+        from: initial.slice(),
+        to: initial.slice(),
+        current: initial.slice(),
+        startTime: null,
+        settled: true,
+        config
+    };
+}
+
+export function retargetMotion(
+    state: MotionState,
+    target: ArrayLike<number>,
+    config: ResolvedTransitionConfig
+): void {
+    state.from.set(state.current);
+    state.to.set(target);
+    state.startTime = null;
+    state.settled = false;
+    state.config = config;
+}
+
+export function sampleMotion(state: MotionState, timeMs: number): boolean {
+    if (state.settled) {
+        return true;
+    }
+
+    const { duration, delay, easing, interpolate } = state.config;
+
+    state.startTime ??= timeMs;
+
+    const elapsed = timeMs - state.startTime;
+    const t = duration <= 0 ? 1 : clamp01((elapsed - delay) / duration);
+    const easedT = easing(t);
+
+    if (interpolate) {
+        interpolate(state.from, state.to, easedT, state.current);
+    } else {
+        lerpInto(state.from, state.to, easedT, state.current);
+    }
+
+    if (t >= 1) {
+        state.current.set(state.to);
+        state.settled = true;
+        return true;
+    }
+
+    return false;
+}

--- a/src/core/lib/uniformComponents.ts
+++ b/src/core/lib/uniformComponents.ts
@@ -1,0 +1,13 @@
+import type { UniformType } from '@/types';
+
+export const UNIFORM_COMPONENTS = {
+    float: 1,
+    int: 1,
+    sampler2D: 1,
+    vec2: 2,
+    vec3: 3,
+    vec4: 4,
+    mat2: 4,
+    mat3: 9,
+    mat4: 16
+} as const satisfies Record<UniformType, number>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export type { FrameInvalidation } from './core';
 export {
     createShaderConfig,
     createTypedFloat32Array,
@@ -39,6 +40,8 @@ export type {
     AttributeType,
     BufferData,
     Dpr,
+    EasingFn,
+    EasingName,
     Fit,
     Float32Array2,
     Float32Array3,
@@ -73,10 +76,12 @@ export type {
     ShaderUniformLocations,
     TextureBinding,
     TextureOptions,
+    TweenTransitionConfig,
     TypedFloat32Array,
     UniformConfig,
     UniformParam,
     UniformParamMap,
+    UniformTransitionConfig,
     UniformType,
     UniformTypeMap,
     UniformUpdateFn,

--- a/src/react/components/base/BaseInstancedShaderComponent.tsx
+++ b/src/react/components/base/BaseInstancedShaderComponent.tsx
@@ -64,7 +64,11 @@ const BaseInstancedShaderComponentImpl = forwardRef<ShaderHandle, BaseInstancedS
     renderOptions = RENDER_OPTIONS
 }, ref) => {
     const programConfigs = { [programId]: shaderConfig };
-    const { updaters, port } = useUniformUpdaters(programId, uniforms, { skipDefaultUniforms });
+    const { updaters, port, invalidation } = useUniformUpdaters(
+        programId,
+        uniforms,
+        { skipDefaultUniforms, reducedMotion, saveData }
+    );
     const debugPortRef = useRef<UniformDebugPort | null>(null);
     debugPortRef.current = port;
 
@@ -77,6 +81,7 @@ const BaseInstancedShaderComponentImpl = forwardRef<ShaderHandle, BaseInstancedS
             renderCallback={renderFullscreenQuad}
             uniformUpdaters={updaters}
             debugPortRef={debugPortRef}
+            invalidation={invalidation}
             width={width}
             height={height}
             pixelRatio={pixelRatio}

--- a/src/react/components/base/BasePingPongShaderComponent.tsx
+++ b/src/react/components/base/BasePingPongShaderComponent.tsx
@@ -79,7 +79,7 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
         programConfigs[actualSecondaryProgramId] = secondaryShaderConfig;
     }
 
-    const { passes, framebuffers, port } = usePingPongPasses({
+    const { passes, framebuffers, port, invalidation } = usePingPongPasses({
         programId,
         secondaryProgramId: secondaryShaderConfig ? actualSecondaryProgramId : undefined,
         iterations,
@@ -88,7 +88,9 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
         framebufferOptions,
         renderOptions,
         customPasses,
-        framebuffers: framebuffersOverride
+        framebuffers: framebuffersOverride,
+        reducedMotion,
+        saveData
     });
     const debugPortRef = useRef<UniformDebugPort | null>(null);
     debugPortRef.current = port;
@@ -115,6 +117,7 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
             passes={passes}
             framebuffers={framebuffers}
             debugPortRef={debugPortRef}
+            invalidation={invalidation}
             {...workerProps}
             className={className}
             style={style}

--- a/src/react/components/base/BaseShaderComponent.transition.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.transition.test.tsx
@@ -1,0 +1,176 @@
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type { Frameloop, MotionPolicy } from '@/types';
+
+const PROGRAM_ID = 'transition-demo';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_swirl: 'float' }
+});
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let originalGetContext: unknown;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stub = createGLStub();
+    originalGetContext = (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext;
+    (HTMLCanvasElement.prototype as unknown as { getContext: () => WebGLRenderingContext }).getContext =
+        function stubGetContext() { return stub.gl };
+
+    originalMatchMedia = window.matchMedia;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext = originalGetContext;
+    if (originalMatchMedia) {
+        window.matchMedia = originalMatchMedia;
+    }
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+function uploads(name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+interface SceneProps {
+    value: number;
+    frameloop?: Frameloop;
+    reducedMotion?: MotionPolicy;
+    saveData?: MotionPolicy;
+}
+
+const Scene = ({
+    value,
+    frameloop = 'always',
+    reducedMotion = 'ignore',
+    saveData = 'ignore'
+}: SceneProps) => (
+    <BaseShaderComponent
+        programId={PROGRAM_ID}
+        shaderConfig={CONFIG}
+        uniforms={{
+            swirl: { type: 'float', value, transition: { duration: 100, easing: 'linear' } }
+        }}
+        width={WIDTH}
+        height={HEIGHT}
+        useDevicePixelRatio={false}
+        frameloop={frameloop}
+        reducedMotion={reducedMotion}
+        saveData={saveData}
+    />
+);
+
+function mockReducedMotionActive(): void {
+    window.matchMedia = ((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false
+    })) as unknown as typeof window.matchMedia;
+}
+
+describe('a real uniform transition, driven through a mounted BaseShaderComponent (no mocked runtime)', () => {
+    it('a uniform prop change animates through advancing intermediate values before landing exactly on the target', async () => {
+        await mount(<Scene value={0} />);
+        frames.tick(0);
+        expect(uploads('u_swirl')).toEqual([0]);
+
+        await mount(<Scene value={10} />);
+        frames.tick(25);
+        frames.tick(50);
+        frames.tick(75);
+        frames.tick(100);
+        frames.tick(125);
+
+        const values = uploads('u_swirl') as number[];
+        expect(values).not.toEqual([0, 10]);
+        expect(values[values.length - 1]).toBe(10);
+        expect(values.length).toBeGreaterThan(2);
+        for (let i = 1; i < values.length; i++) {
+            expect(values[i]).toBeGreaterThan(values[i - 1]);
+        }
+    });
+
+    it('frameloop="demand": a retarget keeps scheduling frames until settle, then the rAF queue drains', async () => {
+        await mount(<Scene value={0} frameloop='demand' />);
+        frames.tick(0);
+        expect(uploads('u_swirl')).toEqual([0]);
+        expect(frames.pending()).toBe(0);
+
+        await mount(<Scene value={10} frameloop='demand' />);
+        expect(frames.pending()).toBe(1);
+
+        frames.tick(25);
+        expect(frames.pending()).toBe(1);
+
+        frames.tick(50);
+        frames.tick(75);
+        frames.tick(100);
+        frames.tick(125);
+
+        expect(frames.pending()).toBe(0);
+        const values = uploads('u_swirl') as number[];
+        expect(values[values.length - 1]).toBe(10);
+        expect(values.length).toBeGreaterThan(2);
+    });
+
+    it('a "static-frame" motion gate snaps to the target on its own, without anything else invalidating', async () => {
+        mockReducedMotionActive();
+
+        await mount(<Scene value={0} reducedMotion='static-frame' saveData='ignore' />);
+        frames.tick(0);
+        expect(uploads('u_swirl')).toEqual([0]);
+        expect(frames.pending()).toBe(0);
+
+        await mount(<Scene value={10} reducedMotion='static-frame' saveData='ignore' />);
+
+        expect(frames.pending()).toBe(1);
+
+        frames.tick(1_000_000);
+
+        expect(uploads('u_swirl')).toEqual([0, 10]);
+        expect(frames.pending()).toBe(0);
+
+        frames.tick(2_000_000);
+        expect(uploads('u_swirl')).toEqual([0, 10]);
+    });
+});

--- a/src/react/components/base/BaseShaderComponent.tsx
+++ b/src/react/components/base/BaseShaderComponent.tsx
@@ -59,7 +59,11 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     renderOptions = RENDER_OPTIONS
 }, ref) => {
     const programConfigs = { [programId]: shaderConfig };
-    const { updaters, port } = useUniformUpdaters(programId, uniforms, { skipDefaultUniforms });
+    const { updaters, port, invalidation } = useUniformUpdaters(
+        programId,
+        uniforms,
+        { skipDefaultUniforms, reducedMotion, saveData }
+    );
     const debugPortRef = useRef<UniformDebugPort | null>(null);
     debugPortRef.current = port;
 
@@ -74,6 +78,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
             renderCallback={renderFullscreenQuad}
             uniformUpdaters={updaters}
             debugPortRef={debugPortRef}
+            invalidation={invalidation}
             {...workerProps}
             workerSkipDefaultUniforms={skipDefaultUniforms}
             width={width}

--- a/src/react/components/base/BaseShaderComponent.worker.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.worker.test.tsx
@@ -7,6 +7,8 @@ import { createShaderConfig } from '@/core/lib/createShaderConfig';
 import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
 import type { GLStubHandle } from '@/testing';
 import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
 import type { Frameloop, ShaderHandle, UniformParam } from '@/types';
 import type { MainToWorker, WorkerToMain } from '@/worker/protocol';
 import type { WorkerRuntimeHost } from '@/worker/WorkerRuntime';
@@ -21,34 +23,6 @@ const CONFIG = createShaderConfig({
     fragmentShader: 'void main() {}',
     uniformNames: { u_level: 'float' }
 });
-
-interface FrameQueue {
-    schedule: (callback: (now: number) => void) => number;
-    cancel: (handle: number) => void;
-    pending: () => number;
-    tick: (now: number) => void;
-}
-
-function createFrameQueue(): FrameQueue {
-    const scheduled = new Map<number, (now: number) => void>();
-    let nextHandle = 1;
-
-    return {
-        schedule: callback => {
-            const handle = nextHandle;
-            nextHandle += 1;
-            scheduled.set(handle, callback);
-            return handle;
-        },
-        cancel: handle => { scheduled.delete(handle) },
-        pending: () => scheduled.size,
-        tick: now => {
-            const callbacks = Array.from(scheduled.values());
-            scheduled.clear();
-            callbacks.forEach(callback => { callback(now) });
-        }
-    };
-}
 
 interface WorkerHarness {
     createWorker: () => Worker;
@@ -222,6 +196,23 @@ describe('BaseShaderComponent in worker mode', () => {
                 frameloop='always'
             />
         )).rejects.toThrow(/u_ghost/);
+
+        expect(worker.frames.pending()).toBe(0);
+        expect(mainFrames.pending()).toBe(0);
+    });
+
+    it('throws once, in render, for a uniform with a "transition", instead of silently ignoring it', async () => {
+        const worker = createWorkerHarness();
+        const handleRef = { current: null as ShaderHandle | null };
+
+        await expect(mount(
+            <Scene
+                worker={worker}
+                handleRef={handleRef}
+                uniforms={{ level: { type: 'float', value: 0, transition: { duration: 300 } } }}
+                frameloop='always'
+            />
+        )).rejects.toThrow(/u_level/);
 
         expect(worker.frames.pending()).toBe(0);
         expect(mainFrames.pending()).toBe(0);

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -18,18 +18,17 @@ import type {
 } from '@/core';
 import { CAPTURE_SCRATCH_FRAMEBUFFER_ID, captureFrame } from '@/core/lib/captureFrame';
 import { resolveExportDimensions, validateRenderToBlobOptions } from '@/core/lib/captureOptions';
+import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import { Passes } from '@/core/systems/Passes';
 import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
-import { useReducedMotion } from '@/react/hooks/useReducedMotion';
-import { useSaveData } from '@/react/hooks/useSaveData';
+import { useMotionGate } from '@/react/hooks/useMotionGate';
 import type { WorkerBridgeInitPayload } from '@/react/hooks/useWorkerBridge';
 import { useWorkerBridge } from '@/react/hooks/useWorkerBridge';
 import { pixelsToBlob, pixelsToDataURL } from '@/react/lib/captureBlob';
 import { framebuffersContentKey, programConfigsContentKey } from '@/react/lib/contentKeys';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
-import { resolveMotionGate } from '@/react/lib/motionPolicy';
 import { createRecording } from '@/react/lib/record';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import { runRenderSequence } from '@/react/lib/renderSequence';
@@ -72,6 +71,7 @@ interface PingPongShaderEngineBaseProps extends Omit<RenderControlProps, 'worker
     renderHeight?: number;
     debug?: boolean;
     debugPortRef?: RefObject<UniformDebugPort | null>;
+    invalidation?: FrameInvalidation;
 }
 
 export type PingPongShaderEngineWorkerProps =
@@ -153,6 +153,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     debugPortRef,
     workerUniforms,
     workerCustomPasses = false,
+    invalidation,
     worker,
     createWorker,
     useDevicePixelRatio,
@@ -163,13 +164,11 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     dpr = DEFAULT_DPR,
     maxPixelCount = DEFAULT_MAX_PIXEL_COUNT,
     fit = 'window',
-    reducedMotion = 'static-frame',
-    saveData = 'static-frame',
+    reducedMotion,
+    saveData,
     staticFrame = 0
 }, ref) => {
-    const reducedMotionActive = useReducedMotion();
-    const saveDataActive = useSaveData();
-    const motionGate = resolveMotionGate({ reducedMotionActive, saveDataActive, reducedMotion, saveData });
+    const motionGate = useMotionGate(reducedMotion, saveData);
 
     const contentKey = `${programConfigsContentKey(programConfigs)}\u0002${framebuffersContentKey(framebuffers)}`;
 
@@ -395,6 +394,14 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
 
     const applySizeRef = useRef(applySize);
 
+    const invalidateAll = useCallback(() => {
+        if (workerActiveRef.current) {
+            bridgeRef.current?.invalidate();
+            return;
+        }
+        controllerRef.current?.invalidate();
+    }, []);
+
     const session = useWorkerBridge({
         worker,
         blocked: block !== null,
@@ -455,6 +462,11 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             controllerRef.current = null;
         };
     }, [renderFrame]);
+
+    useEffect(() => {
+        if (!invalidation) return;
+        return invalidation.connect(invalidateAll);
+    }, [invalidation, invalidateAll]);
 
     useEffect(() => {
         if (workerActive) return;
@@ -712,7 +724,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     }, []);
 
     useImperativeHandle(ref, (): PingPongShaderHandle => workerActive ? {
-        invalidate: () => { bridgeRef.current?.invalidate() },
+        invalidate: invalidateAll,
         setFrame: (frame: number) => { bridgeRef.current?.renderFrame(frameToMs(frame)) },
         getFrame: () => { throw new Error(workerGetFrameMessage('PingPongShaderEngine')) },
         start: () => { setStopped(false) },
@@ -724,7 +736,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         record: deny('record'),
         renderSequence: deny('renderSequence')
     } : {
-        invalidate: () => { controllerRef.current?.invalidate() },
+        invalidate: invalidateAll,
         setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
         getFrame: () => controllerRef.current?.getFrame() ?? 0,
         start: () => { controllerRef.current?.start() },
@@ -801,7 +813,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
                 }
             });
         }
-    }, [workerActive, resetSimulation, captureStill, setStopped]);
+    }, [workerActive, resetSimulation, captureStill, setStopped, invalidateAll]);
 
     if (workerActive && block) {
         throw new Error(workerBlockMessage('PingPongShaderEngine', block));

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -19,19 +19,18 @@ import type {
 } from '@/core';
 import { captureFrame } from '@/core/lib/captureFrame';
 import { resolveExportDimensions, validateRenderToBlobOptions } from '@/core/lib/captureOptions';
+import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { InstanceUploader } from '@/core/lib/instanceBuffers';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
-import { useReducedMotion } from '@/react/hooks/useReducedMotion';
-import { useSaveData } from '@/react/hooks/useSaveData';
+import { useMotionGate } from '@/react/hooks/useMotionGate';
 import type { WorkerBridgeInitPayload } from '@/react/hooks/useWorkerBridge';
 import { useWorkerBridge } from '@/react/hooks/useWorkerBridge';
 import { pixelsToBlob, pixelsToDataURL } from '@/react/lib/captureBlob';
 import { instancingContentKey, programConfigContentKey, singleProgramEntry } from '@/react/lib/contentKeys';
 import { createDelegatingInstancingConfig } from '@/react/lib/instancingConfig';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
-import { resolveMotionGate } from '@/react/lib/motionPolicy';
 import { createRecording } from '@/react/lib/record';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import { runRenderSequence } from '@/react/lib/renderSequence';
@@ -83,6 +82,7 @@ interface ShaderEngineBaseProps extends Omit<RenderControlProps, 'worker' | 'cre
     debug?: boolean;
     debugPortRef?: RefObject<UniformDebugPort | null>;
     workerSkipDefaultUniforms?: boolean;
+    invalidation?: FrameInvalidation;
 }
 
 export type ShaderEngineWorkerProps =
@@ -171,6 +171,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     workerUniforms,
     workerSkipDefaultUniforms = false,
     liveUniforms,
+    invalidation,
     worker,
     createWorker,
     useDevicePixelRatio,
@@ -181,13 +182,11 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     dpr = DEFAULT_DPR,
     maxPixelCount = DEFAULT_MAX_PIXEL_COUNT,
     fit = 'window',
-    reducedMotion = 'static-frame',
-    saveData = 'static-frame',
+    reducedMotion,
+    saveData,
     staticFrame = 0
 }, ref) => {
-    const reducedMotionActive = useReducedMotion();
-    const saveDataActive = useSaveData();
-    const motionGate = resolveMotionGate({ reducedMotionActive, saveDataActive, reducedMotion, saveData });
+    const motionGate = useMotionGate(reducedMotion, saveData);
 
     const [keyProgramId, keyProgramConfig] = singleProgramEntry(programConfigs);
     const contentKey = `${programConfigContentKey(keyProgramId, keyProgramConfig)}|${instancingContentKey(instancing)}`;
@@ -437,6 +436,16 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         renderFrame(elapsed);
     }, [postLiveUniforms, renderFrame]);
 
+    const invalidateAll = useCallback(() => {
+        if (workerActiveRef.current) {
+            postLiveUniforms(frameToMs(controllerRef.current?.getFrame() ?? 0));
+            controllerRef.current?.invalidate();
+            bridgeRef.current?.invalidate();
+            return;
+        }
+        controllerRef.current?.invalidate();
+    }, [postLiveUniforms]);
+
     const startSamplerLoop = useCallback(() => {
         if (liveRef.current.names.length === 0) return;
         controllerRef.current?.start();
@@ -513,6 +522,11 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         controller?.start();
         return () => { controller?.stop() };
     }, [workerActive, liveKey, isStopped]);
+
+    useEffect(() => {
+        if (!invalidation) return;
+        return invalidation.connect(invalidateAll);
+    }, [invalidation, invalidateAll]);
 
     useEffect(() => {
         if (workerActive) return;
@@ -779,11 +793,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     }, []);
 
     useImperativeHandle(ref, (): ShaderHandle => workerActive ? {
-        invalidate: () => {
-            postLiveUniforms(frameToMs(controllerRef.current?.getFrame() ?? 0));
-            controllerRef.current?.invalidate();
-            bridgeRef.current?.invalidate();
-        },
+        invalidate: invalidateAll,
         setFrame: (frame: number) => {
             controllerRef.current?.setFrame(frame);
             bridgeRef.current?.renderFrame(frameToMs(frame));
@@ -803,7 +813,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         record: deny('record'),
         renderSequence: deny('renderSequence')
     } : {
-        invalidate: () => { controllerRef.current?.invalidate() },
+        invalidate: invalidateAll,
         setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
         getFrame: () => controllerRef.current?.getFrame() ?? 0,
         start: () => { controllerRef.current?.start() },
@@ -875,7 +885,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         workerActive,
         captureStill,
         renderFrame,
-        postLiveUniforms,
+        invalidateAll,
         startSamplerLoop,
         setStopped
     ]);

--- a/src/react/hooks/useMotionGate.ts
+++ b/src/react/hooks/useMotionGate.ts
@@ -1,0 +1,15 @@
+import { useReducedMotion } from '@/react/hooks/useReducedMotion';
+import { useSaveData } from '@/react/hooks/useSaveData';
+import { DEFAULT_MOTION_POLICY, type MotionGate, resolveMotionGate } from '@/react/lib/motionPolicy';
+import type { MotionPolicy } from '@/types';
+
+export function useMotionGate(reducedMotion?: MotionPolicy, saveData?: MotionPolicy): MotionGate {
+    const reducedMotionActive = useReducedMotion();
+    const saveDataActive = useSaveData();
+    return resolveMotionGate({
+        reducedMotionActive,
+        saveDataActive,
+        reducedMotion: reducedMotion ?? DEFAULT_MOTION_POLICY,
+        saveData: saveData ?? DEFAULT_MOTION_POLICY
+    });
+}

--- a/src/react/hooks/usePingPongPasses.ts
+++ b/src/react/hooks/usePingPongPasses.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { combineFrameInvalidation, type FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
 import { combineUniformDebugPorts, type UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import {
@@ -11,7 +12,7 @@ import {
     serializeFramebufferOptions,
     serializeRenderOptions
 } from '@/react/lib/pingPongPasses';
-import type { FramebufferOptions, RenderPass, UniformParam } from '@/types';
+import type { FramebufferOptions, MotionPolicy, RenderPass, UniformParam } from '@/types';
 
 interface PingPongPassesOptions {
     programId: string;
@@ -23,12 +24,15 @@ interface PingPongPassesOptions {
     renderOptions?: PingPongRenderOptions;
     customPasses?: RenderPass[];
     framebuffers?: Record<string, FramebufferOptions>;
+    reducedMotion?: MotionPolicy;
+    saveData?: MotionPolicy;
 }
 
 const EMPTY_UNIFORMS: Record<string, UniformParam> = {};
 
 export interface PingPongPassesWithPort extends PingPongPassesResult {
     port: UniformDebugPort;
+    invalidation: FrameInvalidation;
 }
 
 export const usePingPongPasses = ({
@@ -40,12 +44,15 @@ export const usePingPongPasses = ({
     framebufferOptions = DEFAULT_FRAMEBUFFER_OPTIONS,
     renderOptions = DEFAULT_RENDER_OPTIONS,
     customPasses,
-    framebuffers
+    framebuffers,
+    reducedMotion,
+    saveData
 }: PingPongPassesOptions): PingPongPassesWithPort => {
-    const primary = useUniformUpdaters(programId, uniforms);
+    const primary = useUniformUpdaters(programId, uniforms, { reducedMotion, saveData });
     const secondary = useUniformUpdaters(
         secondaryProgramId ?? `${programId}-secondary`,
-        secondaryUniforms
+        secondaryUniforms,
+        { reducedMotion, saveData }
     );
 
     const framebufferKey = serializeFramebufferOptions(framebufferOptions);
@@ -86,5 +93,10 @@ export const usePingPongPasses = ({
         [primary.port, secondary.port]
     );
 
-    return { ...passesResult, port };
+    const invalidation = useMemo(
+        () => combineFrameInvalidation([primary.invalidation, secondary.invalidation]),
+        [primary.invalidation, secondary.invalidation]
+    );
+
+    return { ...passesResult, port, invalidation };
 };

--- a/src/react/hooks/useUniformUpdaters.ts
+++ b/src/react/hooks/useUniformUpdaters.ts
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 
+import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+import { useMotionGate } from '@/react/hooks/useMotionGate';
 import {
     buildLiveUpdaters,
     collectLiveValues,
@@ -12,19 +14,29 @@ import {
     uniformDescriptors,
     uniformStructureKey
 } from '@/react/lib/liveUniformUpdaters';
-import type { UniformParam, UniformUpdaterDef } from '@/types';
+import { createTransitionRuntime, type TransitionRuntime } from '@/react/lib/transitionRuntime';
+import type { MotionPolicy, UniformParam, UniformUpdaterDef } from '@/types';
 
 export interface UniformUpdatersResult {
     updaters: Record<string, UniformUpdaterDef[]>;
     port: UniformDebugPort;
+    invalidation: FrameInvalidation;
+}
+
+export interface UniformUpdatersOptions {
+    skipDefaultUniforms?: boolean;
+    reducedMotion?: MotionPolicy;
+    saveData?: MotionPolicy;
 }
 
 export const useUniformUpdaters = (
     programId: string,
     uniforms: Record<string, UniformParam>,
-    options?: { skipDefaultUniforms?: boolean }
+    options?: UniformUpdatersOptions
 ): UniformUpdatersResult => {
     const skipDefaults = options?.skipDefaultUniforms ?? false;
+    const motionGate = useMotionGate(options?.reducedMotion, options?.saveData);
+
     const descriptors = uniformDescriptors(uniforms);
     const structureKey = uniformStructureKey(descriptors, skipDefaults);
 
@@ -34,21 +46,36 @@ export const useUniformUpdaters = (
     const descriptorsRef = useRef<UniformDescriptor[]>(descriptors);
     descriptorsRef.current = descriptors;
 
+    const runtimeRef = useRef<TransitionRuntime | null>(null);
+    runtimeRef.current ??= createTransitionRuntime(
+        name => Object.prototype.hasOwnProperty.call(overridesRef.current, name)
+    );
+    const runtime = runtimeRef.current;
+
     useEffect(() => {
         const base = collectLiveValues(uniforms);
         baseValuesRef.current = base;
         valuesRef.current = mergeOverrides(base, overridesRef.current);
+        runtime.applyTargets(uniforms, motionGate);
     });
 
     const port = useMemo(
-        () => createUniformDebugPort({ descriptorsRef, baseValuesRef, overridesRef, valuesRef }),
-        []
+        () => createUniformDebugPort({
+            descriptorsRef,
+            baseValuesRef,
+            overridesRef,
+            valuesRef,
+            onChange: () => { runtime.invalidation.request() }
+        }),
+        [runtime]
     );
 
     const updaters = useMemo(() => {
         const parsed = parseUniformStructureKey(structureKey);
-        return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef) };
-    }, [programId, structureKey]);
+        return {
+            [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime)
+        };
+    }, [programId, structureKey, runtime]);
 
-    return { updaters, port };
+    return { updaters, port, invalidation: runtime.invalidation };
 };

--- a/src/react/lib/liveUniformUpdaters.test.ts
+++ b/src/react/lib/liveUniformUpdaters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
 import { vec2, vec3 } from '@/core/lib/vectorUtils';
 import {
     buildLiveUpdaters,
@@ -10,13 +11,17 @@ import {
     mergeOverrides,
     normalizeUniformName,
     parseUniformStructureKey,
-    type UniformDebugPortRefs,
+    type UniformDebugPortOptions,
     type UniformDescriptor,
     uniformDescriptors,
     uniformStructureKey,
     validateOverrideValue
 } from '@/react/lib/liveUniformUpdaters';
+import type { TransitionRuntime } from '@/react/lib/transitionRuntime';
+import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
 import type { UniformParam } from '@/types';
+
+const noTransitions = (): TransitionRuntime => createTransitionRuntime(() => false);
 
 describe('normalizeUniformName', () => {
     it('prefixes bare names with u_', () => {
@@ -104,7 +109,12 @@ describe('buildLiveUpdaters', () => {
         const valuesRef: { current: LiveValues } = {
             current: { u_color: vec3([1, 2, 3]) }
         };
-        const updaters = buildLiveUpdaters([{ name: 'u_color', type: 'vec3' }], true, valuesRef);
+        const updaters = buildLiveUpdaters(
+            [{ name: 'u_color', type: 'vec3' }],
+            true,
+            valuesRef,
+            noTransitions()
+        );
         const updater = updaters.find(u => u.name === 'u_color');
 
         expect(updater?.updateFn()).toEqual(vec3([1, 2, 3]));
@@ -117,7 +127,12 @@ describe('buildLiveUpdaters', () => {
         const valuesRef: { current: LiveValues } = {
             current: { u_wave: (time?: number) => vec2([time ?? 0, 0]) }
         };
-        const updaters = buildLiveUpdaters([{ name: 'u_wave', type: 'vec2' }], true, valuesRef);
+        const updaters = buildLiveUpdaters(
+            [{ name: 'u_wave', type: 'vec2' }],
+            true,
+            valuesRef,
+            noTransitions()
+        );
         const updater = updaters.find(u => u.name === 'u_wave');
 
         expect(updater?.updateFn(2)).toEqual(vec2([2, 0]));
@@ -126,19 +141,50 @@ describe('buildLiveUpdaters', () => {
 
     it('injects u_time and u_resolution defaults unless skipped', () => {
         const valuesRef: { current: LiveValues } = { current: {} };
-        const withDefaults = buildLiveUpdaters([], false, valuesRef);
+        const withDefaults = buildLiveUpdaters([], false, valuesRef, noTransitions());
 
         expect(withDefaults.map(u => u.name)).toEqual(['u_time', 'u_resolution']);
 
-        const skipped = buildLiveUpdaters([], true, valuesRef);
+        const skipped = buildLiveUpdaters([], true, valuesRef, noTransitions());
         expect(skipped).toEqual([]);
     });
 
     it('does not inject a default that the caller already declares', () => {
         const valuesRef: { current: LiveValues } = { current: { u_time: 3 } };
-        const updaters = buildLiveUpdaters([{ name: 'u_time', type: 'float' }], false, valuesRef);
+        const updaters = buildLiveUpdaters(
+            [{ name: 'u_time', type: 'float' }],
+            false,
+            valuesRef,
+            noTransitions()
+        );
 
         expect(updaters.map(u => u.name)).toEqual(['u_resolution', 'u_time']);
+    });
+
+    it('a non-null sample wins over the plain ref value', () => {
+        const valuesRef: { current: LiveValues } = { current: { u_swirl: 10 } };
+        const runtime: TransitionRuntime = {
+            applyTargets: () => undefined,
+            sample: (name, timeMs) => name === 'u_swirl' && timeMs < 100 ? 4.5 : null,
+            invalidation: createFrameInvalidation()
+        };
+        const updaters = buildLiveUpdaters([{ name: 'u_swirl', type: 'float' }], true, valuesRef, runtime);
+        const updater = updaters.find(u => u.name === 'u_swirl');
+
+        expect(updater?.updateFn(50)).toBe(4.5);
+    });
+
+    it('a settled (null) sample falls through to the plain ref value', () => {
+        const valuesRef: { current: LiveValues } = { current: { u_swirl: 10 } };
+        const runtime: TransitionRuntime = {
+            applyTargets: () => undefined,
+            sample: () => null,
+            invalidation: createFrameInvalidation()
+        };
+        const updaters = buildLiveUpdaters([{ name: 'u_swirl', type: 'float' }], true, valuesRef, runtime);
+        const updater = updaters.find(u => u.name === 'u_swirl');
+
+        expect(updater?.updateFn(200)).toBe(10);
     });
 });
 
@@ -221,15 +267,36 @@ describe('validateOverrideValue', () => {
     });
 });
 
-function createPortRefs(descriptors: UniformDescriptor[], base: LiveValues): UniformDebugPortRefs {
+function createPortRefs(descriptors: UniformDescriptor[], base: LiveValues): UniformDebugPortOptions {
     const baseValuesRef = { current: base };
     const overridesRef: { current: LiveValues } = { current: {} };
     const valuesRef: { current: LiveValues } = { current: { ...base } };
     const descriptorsRef = { current: descriptors };
-    return { descriptorsRef, baseValuesRef, overridesRef, valuesRef };
+    return { descriptorsRef, baseValuesRef, overridesRef, valuesRef, onChange: () => undefined };
 }
 
 describe('createUniformDebugPort', () => {
+    it('setOverride and clearOverride both notify onChange, so the engine repaints on demand', () => {
+        const refs = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const changes: number[] = [];
+        const port = createUniformDebugPort({ ...refs, onChange: () => { changes.push(1) } });
+
+        port.setOverride('u_a', 5);
+        expect(changes).toHaveLength(1);
+
+        port.clearOverride('u_a');
+        expect(changes).toHaveLength(2);
+    });
+
+    it('does not notify onChange when setOverride throws', () => {
+        const refs = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const changes: number[] = [];
+        const port = createUniformDebugPort({ ...refs, onChange: () => { changes.push(1) } });
+
+        expect(() => { port.setOverride('u_a', NaN) }).toThrow(/finite number/);
+        expect(changes).toHaveLength(0);
+    });
+
     it('lists uniforms with current value and overridden flag', () => {
         const refs = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
         const port = createUniformDebugPort(refs);
@@ -266,7 +333,13 @@ describe('createUniformDebugPort', () => {
         const overridesRef: { current: LiveValues } = { current: {} };
         const valuesRef = { current: mergeOverrides(base, {}) };
         const descriptorsRef = { current: [{ name: 'u_a', type: 'float' } as UniformDescriptor] };
-        const port = createUniformDebugPort({ descriptorsRef, baseValuesRef, overridesRef, valuesRef });
+        const port = createUniformDebugPort({
+            descriptorsRef,
+            baseValuesRef,
+            overridesRef,
+            valuesRef,
+            onChange: () => undefined
+        });
 
         expect(valuesRef.current).toBe(baseValuesRef.current);
 

--- a/src/react/lib/liveUniformUpdaters.ts
+++ b/src/react/lib/liveUniformUpdaters.ts
@@ -1,4 +1,6 @@
+import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
 import { createCommonUpdaters } from '@/react/lib/createUniformUpdater';
+import type { TransitionRuntime } from '@/react/lib/transitionRuntime';
 import type {
     UniformParam,
     UniformType,
@@ -31,21 +33,13 @@ export interface UniformDebugPort {
     clearOverride: (name: string) => void;
 }
 
-export interface UniformDebugPortRefs {
+export interface UniformDebugPortOptions {
     descriptorsRef: { current: UniformDescriptor[] };
     baseValuesRef: { current: LiveValues };
     overridesRef: { current: LiveValues };
     valuesRef: { current: LiveValues };
+    onChange: () => void;
 }
-
-const VEC_LENGTHS: Partial<Record<UniformType, number>> = {
-    vec2: 2,
-    vec3: 3,
-    vec4: 4,
-    mat2: 4,
-    mat3: 9,
-    mat4: 16
-};
 
 function coerceFiniteNumber(type: UniformType, value: unknown): number {
     const parsed = Number(value);
@@ -68,10 +62,7 @@ export function validateOverrideValue(type: UniformType, value: unknown): Unifor
     if (type === 'int' || type === 'sampler2D') {
         return Math.trunc(coerceFiniteNumber(type, value));
     }
-    const length = VEC_LENGTHS[type];
-    if (length === undefined) {
-        throw new Error(`micugl devtools: unsupported uniform type "${type}" for override`);
-    }
+    const length = UNIFORM_COMPONENTS[type];
     if (!isArrayLikeValue(value) || value.length !== length) {
         const gotLength = isArrayLikeValue(value) ? value.length : typeof value;
         throw new Error(
@@ -89,9 +80,9 @@ export function mergeOverrides(base: LiveValues, overrides: LiveValues): LiveVal
     return Object.keys(overrides).length === 0 ? base : { ...base, ...overrides };
 }
 
-export function createUniformDebugPort(refs: UniformDebugPortRefs): UniformDebugPort {
+export function createUniformDebugPort(options: UniformDebugPortOptions): UniformDebugPort {
     const findDescriptor = (name: string): UniformDescriptor => {
-        const found = refs.descriptorsRef.current.find(descriptor => descriptor.name === name);
+        const found = options.descriptorsRef.current.find(descriptor => descriptor.name === name);
         if (!found) {
             throw new Error(`micugl devtools: unknown uniform "${name}"`);
         }
@@ -99,22 +90,27 @@ export function createUniformDebugPort(refs: UniformDebugPortRefs): UniformDebug
     };
 
     return {
-        list: () => refs.descriptorsRef.current.map(descriptor => ({
+        list: () => options.descriptorsRef.current.map(descriptor => ({
             name: descriptor.name,
             type: descriptor.type,
-            value: refs.valuesRef.current[descriptor.name],
-            overridden: Object.prototype.hasOwnProperty.call(refs.overridesRef.current, descriptor.name)
+            value: options.valuesRef.current[descriptor.name],
+            overridden: Object.prototype.hasOwnProperty.call(options.overridesRef.current, descriptor.name)
         })),
         setOverride: (name, value) => {
             const descriptor = findDescriptor(name);
             const validated = validateOverrideValue(descriptor.type, value);
-            refs.overridesRef.current[name] = validated;
-            refs.valuesRef.current = mergeOverrides(refs.baseValuesRef.current, refs.overridesRef.current);
+            options.overridesRef.current[name] = validated;
+            options.valuesRef.current = mergeOverrides(
+                options.baseValuesRef.current,
+                options.overridesRef.current
+            );
+            options.onChange();
         },
         clearOverride: name => {
             findDescriptor(name);
-            Reflect.deleteProperty(refs.overridesRef.current, name);
-            refs.valuesRef.current[name] = refs.baseValuesRef.current[name];
+            Reflect.deleteProperty(options.overridesRef.current, name);
+            options.valuesRef.current[name] = options.baseValuesRef.current[name];
+            options.onChange();
         }
     };
 }
@@ -202,7 +198,8 @@ export function parseUniformStructureKey(
 export function buildLiveUpdaters(
     descriptors: UniformDescriptor[],
     skipDefaults: boolean,
-    valuesRef: { current: LiveValues }
+    valuesRef: { current: LiveValues },
+    runtime: TransitionRuntime
 ): UniformUpdaterDef[] {
     const hasName = (name: string): boolean => descriptors.some(d => d.name === name);
 
@@ -218,6 +215,10 @@ export function buildLiveUpdaters(
             name,
             type,
             updateFn: (time, width, height) => {
+                const sampled = runtime.sample(name, time ?? 0);
+                if (sampled !== null) {
+                    return sampled as UniformTypeMap[UniformType];
+                }
                 const current = valuesRef.current[name];
                 return typeof current === 'function'
                     ? current(time, width, height)

--- a/src/react/lib/motionPolicy.ts
+++ b/src/react/lib/motionPolicy.ts
@@ -2,6 +2,8 @@ import type { MotionPolicy } from '@/types';
 
 export type MotionGate = 'none' | 'pause' | 'static';
 
+export const DEFAULT_MOTION_POLICY: MotionPolicy = 'static-frame';
+
 function gateForPolicy(policy: MotionPolicy): MotionGate {
     if (policy === 'static-frame') {
         return 'static';

--- a/src/react/lib/transitionPipeline.test.ts
+++ b/src/react/lib/transitionPipeline.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { GL_FLOAT, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
+import { vec3 } from '@/core/lib/vectorUtils';
+import { WebGLManager } from '@/core/managers/WebGLManager';
+import { Passes } from '@/core/systems/Passes';
+import {
+    buildLiveUpdaters,
+    collectLiveValues,
+    createUniformDebugPort,
+    type LiveValues,
+    parseUniformStructureKey,
+    uniformDescriptors,
+    uniformStructureKey
+} from '@/react/lib/liveUniformUpdaters';
+import {
+    buildPasses,
+    DEFAULT_FRAMEBUFFER_OPTIONS,
+    DEFAULT_RENDER_OPTIONS
+} from '@/react/lib/pingPongPasses';
+import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
+import type { GLStubConfig, GLStubHandle } from '@/testing';
+import { createCanvasStub } from '@/testing';
+import type { UniformParam } from '@/types';
+
+const PROGRAM_ID = 'transition-demo';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+const GL_STUB_CONFIG: GLStubConfig = {
+    extensions: { OES_texture_float: true, OES_texture_float_linear: true },
+    renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT]
+};
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_swirl: 'float', u_color: 'vec3' }
+});
+
+function uploadsOf(stub: GLStubHandle, name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+function swirlUploads(stub: GLStubHandle): unknown[] {
+    return uploadsOf(stub, 'u_swirl');
+}
+
+describe('a real uniform transition, driven through the production pipeline (no mocks)', () => {
+    it('advances strictly between from and to across intermediate frames, lands exactly on the target, then stops uploading', () => {
+        const runtime = createTransitionRuntime(() => false);
+
+        let uniforms: Record<string, UniformParam> = {
+            swirl: { type: 'float', value: 0, transition: { duration: 100, easing: 'linear' } }
+        };
+        const descriptors = uniformDescriptors(uniforms);
+        const parsed = parseUniformStructureKey(uniformStructureKey(descriptors, true));
+        const valuesRef = { current: collectLiveValues(uniforms) };
+        const updaters = buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime);
+
+        const stub = createCanvasStub();
+        const manager = new WebGLManager(stub.canvas);
+        manager.createProgram(PROGRAM_ID, CONFIG);
+        updaters.forEach(u => { manager.registerUniformUpdater(PROGRAM_ID, u.name, u.type, u.updateFn) });
+        manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+
+        const commit = (nextUniforms: Record<string, UniformParam>): void => {
+            uniforms = nextUniforms;
+            valuesRef.current = collectLiveValues(uniforms);
+            runtime.applyTargets(uniforms, 'none');
+        };
+
+        commit(uniforms);
+        stub.reset();
+
+        manager.updateUniforms(PROGRAM_ID, 0);
+        expect(swirlUploads(stub)).toEqual([0]);
+
+        commit({
+            swirl: { type: 'float', value: 10, transition: { duration: 100, easing: 'linear' } }
+        });
+
+        manager.updateUniforms(PROGRAM_ID, 1000);
+        manager.updateUniforms(PROGRAM_ID, 1025);
+        manager.updateUniforms(PROGRAM_ID, 1050);
+        manager.updateUniforms(PROGRAM_ID, 1075);
+        manager.updateUniforms(PROGRAM_ID, 1100);
+
+        expect(swirlUploads(stub)).toEqual([0, 2.5, 5, 7.5, 10]);
+
+        manager.updateUniforms(PROGRAM_ID, 1200);
+        manager.updateUniforms(PROGRAM_ID, 1300);
+
+        expect(swirlUploads(stub)).toEqual([0, 2.5, 5, 7.5, 10]);
+    });
+
+    it('a vec3 transition uploads advancing buffers every frame and lands exactly on the target', () => {
+        const runtime = createTransitionRuntime(() => false);
+
+        let uniforms: Record<string, UniformParam> = {
+            color: { type: 'vec3', value: vec3([0, 0, 0]), transition: { duration: 100, easing: 'linear' } }
+        };
+        const descriptors = uniformDescriptors(uniforms);
+        const parsed = parseUniformStructureKey(uniformStructureKey(descriptors, true));
+        const valuesRef = { current: collectLiveValues(uniforms) };
+        const updaters = buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime);
+
+        const stub = createCanvasStub();
+        const manager = new WebGLManager(stub.canvas);
+        manager.createProgram(PROGRAM_ID, CONFIG);
+        updaters.forEach(u => { manager.registerUniformUpdater(PROGRAM_ID, u.name, u.type, u.updateFn) });
+        manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+
+        runtime.applyTargets(uniforms, 'none');
+        stub.reset();
+
+        manager.updateUniforms(PROGRAM_ID, 0);
+
+        uniforms = {
+            color: { type: 'vec3', value: vec3([1, 2, 4]), transition: { duration: 100, easing: 'linear' } }
+        };
+        valuesRef.current = collectLiveValues(uniforms);
+        runtime.applyTargets(uniforms, 'none');
+
+        const uploadCount = (): number => uploadsOf(stub, 'u_color').length;
+        const latestUpload = (): number[] => {
+            const calls = uploadsOf(stub, 'u_color');
+            return Array.from(calls[calls.length - 1] as Float32Array);
+        };
+
+        const observed: { count: number; value: number[] }[] = [];
+        for (const time of [1000, 1025, 1050, 1075, 1100]) {
+            manager.updateUniforms(PROGRAM_ID, time);
+            observed.push({ count: uploadCount(), value: latestUpload() });
+        }
+
+        expect(observed.map(entry => entry.count)).toEqual([1, 2, 3, 4, 5]);
+        expect(observed.map(entry => entry.value)).toEqual([
+            [0, 0, 0],
+            [0.25, 0.5, 1],
+            [0.5, 1, 2],
+            [0.75, 1.5, 3],
+            [1, 2, 4]
+        ]);
+
+        manager.updateUniforms(PROGRAM_ID, 1200);
+        expect(uploadCount()).toBe(5);
+    });
+
+    it('a devtools override wins immediately over an in-flight transition', () => {
+        const overridesRef: { current: LiveValues } = { current: {} };
+        const overrideAwareRuntime = createTransitionRuntime(
+            name => Object.prototype.hasOwnProperty.call(overridesRef.current, name)
+        );
+
+        let uniforms: Record<string, UniformParam> = {
+            swirl: { type: 'float', value: 0, transition: { duration: 100, easing: 'linear' } }
+        };
+        const descriptors = uniformDescriptors(uniforms);
+        const parsed = parseUniformStructureKey(uniformStructureKey(descriptors, true));
+        const baseValuesRef = { current: collectLiveValues(uniforms) };
+        const valuesRef = { current: collectLiveValues(uniforms) };
+        const descriptorsRef = { current: descriptors };
+        const repaints: number[] = [];
+        const port = createUniformDebugPort({
+            descriptorsRef,
+            baseValuesRef,
+            overridesRef,
+            valuesRef,
+            onChange: () => { overrideAwareRuntime.invalidation.request() }
+        });
+        overrideAwareRuntime.invalidation.connect(() => { repaints.push(1) });
+        const updaters = buildLiveUpdaters(
+            parsed.descriptors,
+            parsed.skipDefaults,
+            valuesRef,
+            overrideAwareRuntime
+        );
+
+        const stub = createCanvasStub();
+        const manager = new WebGLManager(stub.canvas);
+        manager.createProgram(PROGRAM_ID, CONFIG);
+        updaters.forEach(u => { manager.registerUniformUpdater(PROGRAM_ID, u.name, u.type, u.updateFn) });
+        manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+
+        overrideAwareRuntime.applyTargets(uniforms, 'none');
+        stub.reset();
+
+        manager.updateUniforms(PROGRAM_ID, 0);
+
+        uniforms = { swirl: { type: 'float', value: 10, transition: { duration: 100, easing: 'linear' } } };
+        baseValuesRef.current = collectLiveValues(uniforms);
+        valuesRef.current = baseValuesRef.current;
+        overrideAwareRuntime.applyTargets(uniforms, 'none');
+
+        manager.updateUniforms(PROGRAM_ID, 1000);
+        manager.updateUniforms(PROGRAM_ID, 1025);
+        expect(swirlUploads(stub)).toEqual([0, 2.5]);
+
+        const repaintsBeforeOverride = repaints.length;
+        port.setOverride('u_swirl', 999);
+        expect(repaints.length).toBe(repaintsBeforeOverride + 1);
+
+        manager.updateUniforms(PROGRAM_ID, 1050);
+        expect(swirlUploads(stub)).toEqual([0, 2.5, 999]);
+
+        manager.updateUniforms(PROGRAM_ID, 1075);
+        expect(swirlUploads(stub)).toEqual([0, 2.5, 999]);
+
+        port.clearOverride('u_swirl');
+        expect(repaints.length).toBe(repaintsBeforeOverride + 2);
+
+        manager.updateUniforms(PROGRAM_ID, 1100);
+        expect(swirlUploads(stub)).toEqual([0, 2.5, 999, 10]);
+    });
+
+    it('ping-pong program uniforms transition for free, through the same passUniformsFrom path as any other pass uniform', () => {
+        const runtime = createTransitionRuntime(() => false);
+
+        let uniforms: Record<string, UniformParam> = {
+            swirl: { type: 'float', value: 0, transition: { duration: 100, easing: 'linear' } }
+        };
+
+        const valuesRef = { current: collectLiveValues(uniforms) };
+
+        const commit = (nextUniforms: Record<string, UniformParam>): void => {
+            uniforms = nextUniforms;
+            valuesRef.current = collectLiveValues(uniforms);
+            runtime.applyTargets(uniforms, 'none');
+        };
+
+        commit(uniforms);
+        const descriptors = uniformDescriptors(uniforms);
+        const parsed = parseUniformStructureKey(uniformStructureKey(descriptors, true));
+        const primaryUpdaters = {
+            [PROGRAM_ID]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime)
+        };
+        const { passes, framebuffers } = buildPasses(
+            PROGRAM_ID,
+            undefined,
+            0,
+            primaryUpdaters,
+            {},
+            DEFAULT_FRAMEBUFFER_OPTIONS,
+            DEFAULT_RENDER_OPTIONS,
+            undefined
+        );
+
+        const stub = createCanvasStub(GL_STUB_CONFIG);
+        const manager = new WebGLManager(stub.canvas);
+        manager.createProgram(PROGRAM_ID, CONFIG);
+        for (const [id, options] of Object.entries(framebuffers)) {
+            manager.fbo.createFramebuffer(id, options);
+        }
+
+        const passSystem = new Passes(manager);
+        for (const pass of passes) {
+            passSystem.addPass(pass);
+        }
+        passSystem.initializeResources();
+        manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+        for (const [id, options] of Object.entries(framebuffers)) {
+            manager.fbo.resizeFramebuffer(id, options.width || WIDTH, options.height || HEIGHT);
+        }
+
+        stub.reset();
+        passSystem.execute(0);
+        expect(new Set(swirlUploads(stub))).toEqual(new Set([0]));
+
+        commit({ swirl: { type: 'float', value: 10, transition: { duration: 100, easing: 'linear' } } });
+
+        stub.reset();
+        passSystem.execute(1000);
+        expect(new Set(swirlUploads(stub))).toEqual(new Set([0]));
+
+        stub.reset();
+        passSystem.execute(1050);
+        expect(new Set(swirlUploads(stub))).toEqual(new Set([5]));
+
+        stub.reset();
+        passSystem.execute(1100);
+        expect(new Set(swirlUploads(stub))).toEqual(new Set([10]));
+    });
+});

--- a/src/react/lib/transitionRuntime.test.ts
+++ b/src/react/lib/transitionRuntime.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+
+import { vec3 } from '@/core/lib/vectorUtils';
+import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
+import type { UniformParam, UniformTransitionConfig, Vec3 } from '@/types';
+
+const TWEEN: UniformTransitionConfig = { duration: 100, easing: 'linear' };
+
+function noOverrides(): boolean {
+    return false;
+}
+
+function swirl(value: number): Record<string, UniformParam> {
+    return { u_swirl: { type: 'float', value, transition: TWEEN } };
+}
+
+function color(value: Vec3): Record<string, UniformParam> {
+    return { u_color: { type: 'vec3', value: vec3(value), transition: TWEEN } };
+}
+
+describe('createTransitionRuntime', () => {
+    it('first sight of a name snaps to the value and stays settled (no animation on mount)', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        const requests: number[] = [];
+        runtime.invalidation.connect(() => { requests.push(1) });
+
+        runtime.applyTargets(swirl(5), 'none');
+
+        expect(requests).toHaveLength(0);
+        expect(runtime.sample('u_swirl', 0)).toBeNull();
+    });
+
+    it('a changed target on a later commit retargets and requests a frame', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(swirl(0), 'none');
+
+        const requests: number[] = [];
+        runtime.invalidation.connect(() => { requests.push(1) });
+
+        runtime.applyTargets(swirl(10), 'none');
+
+        expect(requests).toHaveLength(1);
+        expect(runtime.sample('u_swirl', 0)).toBe(0);
+        expect(runtime.sample('u_swirl', 50)).toBe(5);
+    });
+
+    it('an equal-by-value target (fresh Float32Array identity) does not retarget', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(color([1, 2, 3]), 'none');
+
+        const requests: number[] = [];
+        runtime.invalidation.connect(() => { requests.push(1) });
+
+        runtime.applyTargets(color([1, 2, 3]), 'none');
+
+        expect(requests).toHaveLength(0);
+        expect(runtime.sample('u_color', 0)).toBeNull();
+    });
+
+    it('sample returns null once settled, so the caller falls through to the plain ref read', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(swirl(0), 'none');
+        runtime.applyTargets(swirl(10), 'none');
+
+        runtime.sample('u_swirl', 0);
+        expect(runtime.sample('u_swirl', 100)).toBe(10);
+        expect(runtime.sample('u_swirl', 200)).toBeNull();
+    });
+
+    it('an unsettled sample keeps requesting frames until it settles', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(swirl(0), 'none');
+        runtime.applyTargets(swirl(10), 'none');
+
+        const requests: number[] = [];
+        runtime.invalidation.connect(() => { requests.push(1) });
+
+        runtime.sample('u_swirl', 0);
+        expect(requests).toHaveLength(1);
+
+        runtime.sample('u_swirl', 50);
+        expect(requests).toHaveLength(2);
+
+        runtime.sample('u_swirl', 100);
+        expect(requests).toHaveLength(2);
+        expect(runtime.sample('u_swirl', 150)).toBeNull();
+    });
+
+    it('a changed target under a motion gate snaps and requests exactly one frame, then goes idle', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(swirl(0), 'static');
+
+        const requests: number[] = [];
+        runtime.invalidation.connect(() => { requests.push(1) });
+
+        runtime.applyTargets(swirl(10), 'static');
+
+        expect(requests).toHaveLength(1);
+        expect(runtime.sample('u_swirl', 0)).toBeNull();
+        expect(runtime.sample('u_swirl', 50)).toBeNull();
+        expect(requests).toHaveLength(1);
+
+        runtime.applyTargets(swirl(10), 'static');
+        expect(requests).toHaveLength(1);
+    });
+
+    it('a gate that turns on mid-flight settles the in-flight transition on its target', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(swirl(0), 'none');
+        runtime.applyTargets(swirl(10), 'none');
+        runtime.sample('u_swirl', 0);
+
+        runtime.applyTargets(swirl(10), 'static');
+
+        expect(runtime.sample('u_swirl', 50)).toBeNull();
+    });
+
+    it('a commit that lifts the gate and changes the value together animates, it does not snap', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(swirl(0), 'static');
+
+        runtime.applyTargets(swirl(10), 'none');
+
+        expect(runtime.sample('u_swirl', 0)).toBe(0);
+        expect(runtime.sample('u_swirl', 50)).toBe(5);
+    });
+
+    it('an overridden name samples null even mid-flight, so devtools wins over the transition', () => {
+        let overridden = false;
+        const runtime = createTransitionRuntime(name => overridden && name === 'u_swirl');
+        runtime.applyTargets(swirl(0), 'none');
+        runtime.applyTargets(swirl(10), 'none');
+
+        overridden = true;
+        expect(runtime.sample('u_swirl', 50)).toBeNull();
+    });
+
+    it('a uniform that changes type in place restarts as a fresh state instead of sampling a stale shape', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(
+            { u_bands: { type: 'float', value: 0, transition: TWEEN } },
+            'none'
+        );
+
+        runtime.applyTargets(
+            { u_bands: { type: 'vec3', value: vec3([0, 0, 0]), transition: TWEEN } },
+            'none'
+        );
+        expect(runtime.sample('u_bands', 0)).toBeNull();
+
+        runtime.applyTargets(
+            { u_bands: { type: 'vec3', value: vec3([1, 2, 3]), transition: TWEEN } },
+            'none'
+        );
+
+        runtime.sample('u_bands', 0);
+        const midFlight = runtime.sample('u_bands', 50);
+
+        expect(midFlight).toBeInstanceOf(Float32Array);
+        expect(Array.from(midFlight as Float32Array)).toEqual([0.5, 1, 1.5]);
+
+        const landed = runtime.sample('u_bands', 100) as Float32Array;
+        expect(Array.from(landed)).toEqual([1, 2, 3]);
+    });
+
+    it('a uniform that narrows type in place (vec3 -> float) restarts as a fresh state', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(color([1, 2, 3]), 'none');
+
+        runtime.applyTargets(
+            { u_color: { type: 'float', value: 0, transition: TWEEN } },
+            'none'
+        );
+        expect(runtime.sample('u_color', 0)).toBeNull();
+
+        runtime.applyTargets(
+            { u_color: { type: 'float', value: 10, transition: TWEEN } },
+            'none'
+        );
+        runtime.sample('u_color', 0);
+        expect(runtime.sample('u_color', 50)).toBe(5);
+    });
+
+    it('throws for a transition on an unsupported uniform type', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        expect(() => {
+            runtime.applyTargets(
+                { u_tex: { type: 'sampler2D', value: 0, transition: TWEEN } },
+                'none'
+            );
+        }).toThrow(/float\/vec2\/vec3\/vec4/);
+    });
+
+    it('throws for a transition on a function-valued uniform', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        expect(() => {
+            runtime.applyTargets(
+                { u_wave: { type: 'float', value: () => 0, transition: TWEEN } },
+                'none'
+            );
+        }).toThrow(/function/);
+    });
+
+    it('throws for a float whose value has more than one component', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        expect(() => {
+            runtime.applyTargets(
+                { u_swirl: { type: 'float', value: vec3([1, 2, 3]), transition: TWEEN } },
+                'none'
+            );
+        }).toThrow(/expects 1 components, received 3/);
+    });
+
+    it('throws for a non-finite transition target', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        expect(() => {
+            runtime.applyTargets(swirl(Number.NaN), 'none');
+        }).toThrow(/non-finite/);
+    });
+
+    it('normalizes a bare uniform name, so the sampled name matches the registered updater', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets({ swirl: { type: 'float', value: 0, transition: TWEEN } }, 'none');
+        runtime.applyTargets({ swirl: { type: 'float', value: 10, transition: TWEEN } }, 'none');
+
+        runtime.sample('u_swirl', 0);
+        expect(runtime.sample('u_swirl', 50)).toBe(5);
+    });
+
+    it('prunes state for a name whose transition config disappeared', () => {
+        const runtime = createTransitionRuntime(noOverrides);
+        runtime.applyTargets(swirl(0), 'none');
+        runtime.applyTargets(swirl(10), 'none');
+        runtime.sample('u_swirl', 0);
+
+        runtime.applyTargets({ u_swirl: { type: 'float', value: 10 } }, 'none');
+        expect(runtime.sample('u_swirl', 50)).toBeNull();
+
+        runtime.applyTargets(swirl(99), 'none');
+        expect(runtime.sample('u_swirl', 50)).toBeNull();
+    });
+});

--- a/src/react/lib/transitionRuntime.ts
+++ b/src/react/lib/transitionRuntime.ts
@@ -1,0 +1,154 @@
+import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
+import {
+    createMotionState,
+    type MotionState,
+    resolveTransitionConfig,
+    retargetMotion,
+    sampleMotion
+} from '@/core/lib/motionDrivers';
+import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
+import { normalizeUniformName } from '@/react/lib/liveUniformUpdaters';
+import type { MotionGate } from '@/react/lib/motionPolicy';
+import type { UniformParam, UniformType, UniformValue } from '@/types';
+
+export interface TransitionRuntime {
+    applyTargets(uniforms: Record<string, UniformParam>, motionGate: MotionGate): void;
+    sample(name: string, timeMs: number): Float32Array | number | null;
+    invalidation: FrameInvalidation;
+}
+
+const TRANSITIONABLE: ReadonlySet<UniformType> = new Set<UniformType>(['float', 'vec2', 'vec3', 'vec4']);
+
+function componentsForType(type: UniformType, name: string): number {
+    if (!TRANSITIONABLE.has(type)) {
+        throw new Error(
+            `micugl transitions: uniform "${name}" has type "${type}", but "transition" is only supported for `
+            + 'float/vec2/vec3/vec4 uniforms. Remove the transition, or drop this uniform to a supported type.'
+        );
+    }
+    return UNIFORM_COMPONENTS[type];
+}
+
+function targetFromValue(
+    type: UniformType,
+    value: UniformValue<UniformType>,
+    name: string
+): Float32Array {
+    if (typeof value === 'function') {
+        throw new Error(
+            `micugl transitions: uniform "${name}" has a "transition", but its value is a function. A `
+            + 'function-valued uniform already produces a new value every frame, so a transition config has no '
+            + `target to animate toward. Remove "transition" from "${name}", or make its value a plain number/array.`
+        );
+    }
+
+    const components = componentsForType(type, name);
+    const target = new Float32Array(components);
+
+    if (typeof value === 'number') {
+        if (components !== 1) {
+            throw new Error(
+                `micugl transitions: uniform "${name}" is a "${type}" and expects ${String(components)} `
+                + 'components, received a single number'
+            );
+        }
+        target[0] = value;
+    } else {
+        if (value.length !== components) {
+            throw new Error(
+                `micugl transitions: uniform "${name}" is a "${type}" and expects ${String(components)} `
+                + `components, received ${String(value.length)}`
+            );
+        }
+        target.set(value);
+    }
+
+    for (let i = 0; i < target.length; i++) {
+        if (!Number.isFinite(target[i])) {
+            throw new Error(
+                `micugl transitions: uniform "${name}" transition target has a non-finite value at index ${i}`
+            );
+        }
+    }
+
+    return target;
+}
+
+function targetsEqual(a: Float32Array, b: Float32Array): boolean {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
+}
+
+function snapToTarget(state: MotionState, target: Float32Array): void {
+    state.from.set(target);
+    state.to.set(target);
+    state.current.set(target);
+    state.settled = true;
+}
+
+export function createTransitionRuntime(isOverridden: (name: string) => boolean): TransitionRuntime {
+    const states = new Map<string, MotionState>();
+    const invalidation = createFrameInvalidation();
+
+    return {
+        applyTargets(uniforms, motionGate) {
+            const declared = new Set<string>();
+
+            for (const [rawName, param] of Object.entries(uniforms)) {
+                if (!param.transition) {
+                    continue;
+                }
+
+                const name = normalizeUniformName(rawName);
+                declared.add(name);
+
+                const target = targetFromValue(param.type, param.value, name);
+                const config = resolveTransitionConfig(param.transition);
+
+                const state = states.get(name);
+                if (!state || state.to.length !== target.length) {
+                    states.set(name, createMotionState(config, target));
+                    continue;
+                }
+
+                if (motionGate !== 'none') {
+                    state.config = config;
+                    if (!state.settled || !targetsEqual(state.to, target)) {
+                        snapToTarget(state, target);
+                        invalidation.request();
+                    }
+                    continue;
+                }
+
+                if (!targetsEqual(state.to, target)) {
+                    retargetMotion(state, target, config);
+                    invalidation.request();
+                }
+            }
+
+            for (const name of Array.from(states.keys())) {
+                if (!declared.has(name)) {
+                    states.delete(name);
+                }
+            }
+        },
+        sample(name, timeMs) {
+            const state = states.get(name);
+            if (!state || state.settled || isOverridden(name)) {
+                return null;
+            }
+
+            const settledNow = sampleMotion(state, timeMs);
+            if (!settledNow) {
+                invalidation.request();
+            }
+
+            return state.current.length === 1 ? state.current[0] : state.current;
+        },
+        invalidation
+    };
+}

--- a/src/react/lib/workerMode.test.ts
+++ b/src/react/lib/workerMode.test.ts
@@ -14,6 +14,7 @@ import {
     DEFAULT_FRAMEBUFFER_OPTIONS,
     DEFAULT_RENDER_OPTIONS
 } from '@/react/lib/pingPongPasses';
+import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
 import type { WorkerBlockInputs } from '@/react/lib/workerMode';
 import {
     collectWorkerValues,
@@ -44,7 +45,8 @@ function simUniforms(): Record<string, UniformParam> {
 function realUpdaters(programId: string, uniforms: Record<string, UniformParam>): Record<string, UniformUpdaterDef[]> {
     const parsed = parseUniformStructureKey(uniformStructureKey(uniformDescriptors(uniforms), false));
     const valuesRef = { current: collectLiveValues(uniforms) };
-    return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef) };
+    const runtime = createTransitionRuntime(() => false);
+    return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime) };
 }
 
 function realPasses(uniforms = simUniforms()): RenderPass[] {
@@ -199,6 +201,21 @@ describe('findWorkerBlock: one list of the reasons a worker cannot run this comp
 
         expect(block).toEqual({ kind: 'uniform-not-clone-safe', programId: PROGRAM_ID, name: 'u_flag' });
         expect(workerBlockMessage('ShaderEngine', block!)).toMatch(/structured-clone-safe/);
+    });
+
+    it('blocks a uniform with a "transition", which would silently be ignored by the worker', () => {
+        const block = findWorkerBlock(blockInputs({
+            uniforms: {
+                [PROGRAM_ID]: {
+                    u_swirl: { type: 'float', value: 0, transition: { duration: 300 } }
+                }
+            }
+        }));
+
+        expect(block).toEqual({ kind: 'uniform-transition', programId: PROGRAM_ID, name: 'u_swirl' });
+        const message = workerBlockMessage('ShaderEngine', block!);
+        expect(message).toMatch(/u_swirl/);
+        expect(message).toMatch(/transition/);
     });
 
     it('blocks an unknown liveUniforms name in the render body, not from inside the sampler loop', () => {

--- a/src/react/lib/workerMode.ts
+++ b/src/react/lib/workerMode.ts
@@ -27,6 +27,7 @@ export type WorkerBlock =
     | { kind: 'uniform-function'; programId: string; name: string }
     | { kind: 'uniform-builtin-function'; programId: string; name: string }
     | { kind: 'uniform-not-clone-safe'; programId: string; name: string }
+    | { kind: 'uniform-transition'; programId: string; name: string }
     | { kind: 'pass-uniform-function'; programId: string; passIndex: number; name: string }
     | { kind: 'pass-uniform-not-clone-safe'; programId: string; passIndex: number; name: string };
 
@@ -101,6 +102,9 @@ function findLiveUniformBlock(inputs: WorkerBlockInputs): WorkerBlock | null {
 function findProgramUniformBlock(inputs: WorkerBlockInputs): WorkerBlock | null {
     for (const [programId, params] of Object.entries(inputs.uniforms ?? {})) {
         for (const [name, param] of Object.entries(params)) {
+            if (param.transition !== undefined) {
+                return { kind: 'uniform-transition', programId, name };
+            }
             if (typeof param.value === 'function') {
                 if (isWorkerBuiltinUniformName(name)) {
                     return { kind: 'uniform-builtin-function', programId, name };
@@ -162,6 +166,13 @@ function builtinUniformFunctionMessage(programId: string, name: string): string 
         + 'this component so the main thread can call it every frame.';
 }
 
+function uniformTransitionMessage(programId: string, name: string): string {
+    return `micugl worker: uniform "${name}" on program "${programId}" has a "transition", but transitions are `
+        + 'interpolated on the main thread every frame and worker mode posts plain values; the transition would '
+        + `be ignored and "${name}" would jump straight to its new value. Remove the transition, or turn off `
+        + 'worker mode on this component.';
+}
+
 function notCloneSafeMessage(programId: string, name: string): string {
     return `micugl worker: uniform "${name}" on program "${programId}" is not structured-clone-safe, so it `
         + 'cannot be posted to a worker. Worker-mode uniform values must be a number, a number[], or a typed '
@@ -219,6 +230,8 @@ export function workerBlockMessage(component: string, block: WorkerBlock): strin
             return builtinUniformFunctionMessage(block.programId, block.name);
         case 'uniform-not-clone-safe':
             return notCloneSafeMessage(block.programId, block.name);
+        case 'uniform-transition':
+            return uniformTransitionMessage(block.programId, block.name);
         case 'pass-uniform-function':
             return passUniformFunctionMessage(block.programId, block.passIndex, block.name);
         case 'pass-uniform-not-clone-safe':

--- a/src/testing/frameQueue.ts
+++ b/src/testing/frameQueue.ts
@@ -1,0 +1,27 @@
+export interface FrameQueue {
+    schedule: (callback: (now: number) => void) => number;
+    cancel: (handle: number) => void;
+    pending: () => number;
+    tick: (now: number) => void;
+}
+
+export function createFrameQueue(): FrameQueue {
+    const scheduled = new Map<number, (now: number) => void>();
+    let nextHandle = 1;
+
+    return {
+        schedule: callback => {
+            const handle = nextHandle;
+            nextHandle += 1;
+            scheduled.set(handle, callback);
+            return handle;
+        },
+        cancel: handle => { scheduled.delete(handle) },
+        pending: () => scheduled.size,
+        tick: now => {
+            const callbacks = Array.from(scheduled.values());
+            scheduled.clear();
+            callbacks.forEach(callback => { callback(now) });
+        }
+    };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,9 +304,26 @@ export interface UniformUpdaterDef<T extends UniformType = UniformType> {
   updateFn: UniformUpdateFn<T>;
 }
 
+// ===================================================
+// Uniform Transitions
+// ===================================================
+
+export type EasingName = 'linear' | 'easeIn' | 'easeOut' | 'easeInOut';
+export type EasingFn = (t: number) => number;
+
+export interface TweenTransitionConfig {
+  duration: number;
+  easing?: EasingName | EasingFn;
+  delay?: number;
+  interpolate?: (from: ArrayLike<number>, to: ArrayLike<number>, t: number, out: Float32Array) => void;
+}
+
+export type UniformTransitionConfig = TweenTransitionConfig;
+
 export interface UniformParam<T extends UniformType = UniformType> {
   value: UniformValue<T>;
   type: T;
+  transition?: UniformTransitionConfig;
 }
 
 export type UniformParamMap = { [K in UniformType]: UniformParam<K> };

--- a/src/worker/WorkerRuntime.ts
+++ b/src/worker/WorkerRuntime.ts
@@ -1,3 +1,4 @@
+import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import { Passes } from '@/core/systems/Passes';
 import { singleProgramEntry } from '@/react/lib/contentKeys';
@@ -32,18 +33,6 @@ export interface WorkerRuntimeHost {
     now: () => number;
     close?: () => void;
 }
-
-const UNIFORM_COMPONENTS = {
-    float: 1,
-    int: 1,
-    sampler2D: 1,
-    vec2: 2,
-    vec3: 3,
-    vec4: 4,
-    mat2: 4,
-    mat3: 9,
-    mat4: 16
-} as const satisfies Record<UniformType, number>;
 
 const PROBED_EXTENSIONS: WebGLExtensionName[] = [
     'OES_texture_float',

--- a/src/worker/workerPipeline.test.ts
+++ b/src/worker/workerPipeline.test.ts
@@ -17,6 +17,7 @@ import {
     DEFAULT_FRAMEBUFFER_OPTIONS,
     DEFAULT_RENDER_OPTIONS
 } from '@/react/lib/pingPongPasses';
+import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
 import { normalizeWorkerPrograms, stripPassUniforms, workerPingPongUniforms } from '@/react/lib/workerMode';
 import type { GLStubConfig, GLStubHandle } from '@/testing';
 import { createCanvasStub, createGLStub } from '@/testing';
@@ -57,7 +58,8 @@ function realUpdaters(
 ): Record<string, UniformUpdaterDef[]> {
     const parsed = parseUniformStructureKey(uniformStructureKey(uniformDescriptors(uniforms), false));
     const valuesRef = { current: collectLiveValues(uniforms) };
-    return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef) };
+    const runtime = createTransitionRuntime(() => false);
+    return { [programId]: buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime) };
 }
 
 function realPingPong(uniforms: Record<string, UniformParam>): {


### PR DESCRIPTION
First slice of track 4 (uniform transitions + audio). A uniform value prop change now animates to the new value instead of stepping.

```tsx
uniforms={{
    swirl: { type: 'float', value: swirl, transition: { duration: 300, easing: 'easeOut' } },
    colorStart: { type: 'vec3', value: vec3(palette), transition: { duration: 600 } }
}}
```

Interpolation runs at frame time inside the live-value read: zero React work per frame, zero GL re-init, dirty-checked uploads exactly as today. Mid-flight retargeting starts from the current interpolated value. Demo: `?scene=transitions`.

## What's here

- **`FrameInvalidation`** (`src/core/lib/frameInvalidation.ts`) — the channel any per-frame value producer uses to keep the loop alive. `useUniformUpdaters` owns one and returns it; `ShaderEngine`/`PingPongShaderEngine` take it as a single `invalidation` prop and connect the same invalidate-everything closure the imperative handle already used. **Audio (PR C/D) reuses this unchanged.** Per-def `connectInvalidate` was rejected: it is dead in worker mode, where no updaters are registered at all.
- **Tween runtime** — lazy `startTime` capture on the first sample after a retarget, so a transition plays in full from whenever the loop resumes: no time debt, no snap. Self-sustaining under `frameloop="demand"` — a retarget requests frame N, frame N samples and requests N+1, the settling frame requests nothing and the loop goes idle.
- **Ping-pong transitions for free** — `passUniformsFrom` wraps the very updater the runtime hooks, so no second code path was added. A test proves it animates.
- Transitions run on the **engine clock**: `speed` scales them, `setFrame` pins them, so they are deterministic under `renderSequence`/`renderToBlob`.

## Two deliberate fail-louds

**Worker mode rejects a transition.** Worker mode posts plain values; the runtime is a main-thread frame-time sampler. A transition there would be silently ignored and the uniform would jump — the failure that looks like success. It's a `WorkerBlock` with the remedy in the message.

**A motion gate snaps.** Reduced motion reuses the engine's existing gate rather than a second `matchMedia`. Under a gate the clock is frozen, so a tween physically cannot advance — snapping is the only non-broken behavior. Consequence, and it's the right one: `reducedMotion="ignore"` keeps transitions animating.

## Review caught four blocking bugs

1. **Under a gate, the snapped value never reached GL.** `applyTargets` snapped the state but never requested a frame, and a gated engine only renders on `pendingInvalidate`. Every `prefers-reduced-motion` user would have clicked a palette in the demo and seen *nothing*. **The test in the diff masked it** — it called `handle.invalidate()` by hand to produce "the next redraw", and would have passed with the entire runtime deleted. Rewritten to assert production issues the invalidate itself (`frames.pending() === 1`) and that exactly two values upload (snaps, does not tween).
2. **A uniform that changed type in place uploaded NaN.** `MotionState` is keyed by name and sized at first sight; `float` → `vec3` reused the length-1 state and `writeFloatBuffer` read `value[1]`/`value[2]` as `undefined`. Not hypothetical: `u_audioBands` in PR C/D is a same-named uniform whose type moves across float/vec2/vec3/vec4 with the `bands` option.
3. **A dead half-spring seam** — `velocity`, `lastTime`, a `kind` discriminant on a one-member union, and a spring throw *unreachable from TypeScript* (its own test needed `as unknown as` to reach it). Springs land in PR B, in the commit that reads them.
4. **A third divergent copy** of the uniform-type → component-count table, now one exhaustive `satisfies Record<UniformType, number>` table.

Fixing (1) revealed a trap inside the fix: collapsing `setMotionGate` into an `applyTargets` argument (which removes a stale-gate ordering bug) also removed the only thing that settled an **in-flight** tween when a gate turns on mid-flight — it would have frozen at `from` forever on a pinned clock. The gate branch now snaps when the state is unsettled *or* the target changed.

Each of (1), (2), (3) was verified to **fail when the fix is reverted**.

## Also

Devtools overrides now beat an in-flight transition and wake the loop — closing a pre-existing gap from #42 where an override did nothing at all under `frameloop="demand"`.

670 tests (was 610). `bun run test:e2e` — 9/9 worker e2e green (this touched `WorkerRuntime` and `workerMode`).

## Known follow-up (pre-existing, not introduced here)

A **plain, non-transitioned** uniform change still never repaints under a motion gate or under `frameloop="demand"`. That's existing demand-mode semantics (you invalidate when you change something), but under a gate it means a reduced-motion poster can show stale uniform values. Recorded, not fixed here.