### PR TITLE
audio: T3 audio bands core - pure band math + a WebAudio analyser driver that cannot leak the mic

### DIFF
--- a/src/core/lib/audioBands.test.ts
+++ b/src/core/lib/audioBands.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BandRange } from '@/core/lib/audioBands';
+import {
+    applyEnvelope,
+    computeBandRanges,
+    reduceBands,
+    validateAudioOptions
+} from '@/core/lib/audioBands';
+
+function assertPartition(ranges: BandRange[], bands: number): void {
+    expect(ranges).toHaveLength(bands);
+    for (let i = 0; i < ranges.length; i++) {
+        expect(ranges[i].end).toBeGreaterThan(ranges[i].start);
+        if (i > 0) {
+            expect(ranges[i].start).toBe(ranges[i - 1].end);
+        }
+    }
+}
+
+function pairs(ranges: BandRange[]): number[][] {
+    return ranges.map(range => [range.start, range.end]);
+}
+
+describe('computeBandRanges', () => {
+    it('linear layout covers every bin exactly once', () => {
+        const ranges = computeBandRanges(32, 48000, 4, 'linear');
+
+        assertPartition(ranges, 4);
+        expect(pairs(ranges)).toEqual([[0, 8], [8, 16], [16, 24], [24, 32]]);
+
+        const covered: number[] = [];
+        for (const range of ranges) {
+            for (let bin = range.start; bin < range.end; bin++) {
+                covered.push(bin);
+            }
+        }
+        expect(covered).toEqual(Array.from({ length: 32 }, (_, i) => i));
+    });
+
+    it('log layout is monotone, non-overlapping, geometric, and skips the DC bin', () => {
+        const ranges = computeBandRanges(1024, 48000, 4, 'log');
+
+        assertPartition(ranges, 4);
+        expect(pairs(ranges)).toEqual([[1, 5], [5, 27], [27, 152], [152, 854]]);
+        expect(ranges[0].start).toBe(1);
+        expect(ranges[3].end).toBeLessThanOrEqual(1024);
+
+        const widths = ranges.map(range => range.end - range.start);
+        for (let i = 1; i < widths.length; i++) {
+            expect(widths[i]).toBeGreaterThan(widths[i - 1]);
+        }
+    });
+
+    it('log layout stops at nyquist when nyquist is below 20 kHz', () => {
+        const ranges = computeBandRanges(1024, 22050, 4, 'log');
+
+        assertPartition(ranges, 4);
+        expect(ranges[3].end).toBe(1024);
+        expect(pairs(ranges)).toEqual([[1, 9], [9, 44], [44, 211], [211, 1024]]);
+    });
+
+    it('every band is non-empty in the degenerate cases where the raw log edges collapse onto one bin', () => {
+        const tinyFft = computeBandRanges(16, 48000, 4, 'log');
+        assertPartition(tinyFft, 4);
+        expect(pairs(tinyFft)).toEqual([[1, 2], [2, 3], [3, 4], [4, 14]]);
+
+        const lowSampleRate = computeBandRanges(16, 8000, 4, 'log');
+        assertPartition(lowSampleRate, 4);
+        expect(pairs(lowSampleRate)).toEqual([[1, 2], [2, 3], [3, 4], [4, 16]]);
+
+        const lowestSampleRate = computeBandRanges(16, 3000, 4, 'log');
+        assertPartition(lowestSampleRate, 4);
+
+        const crushedAgainstTheTop = computeBandRanges(16, 50, 4, 'log');
+        assertPartition(crushedAgainstTheTop, 4);
+        expect(pairs(crushedAgainstTheTop)).toEqual([[12, 13], [13, 14], [14, 15], [15, 16]]);
+        expect(crushedAgainstTheTop[3].end).toBeLessThanOrEqual(16);
+
+        const fewBins = computeBandRanges(5, 48000, 4, 'linear');
+        assertPartition(fewBins, 4);
+        expect(pairs(fewBins)).toEqual([[0, 1], [1, 3], [3, 4], [4, 5]]);
+    });
+
+    it('a single band spans the whole audible range', () => {
+        const ranges = computeBandRanges(1024, 48000, 1, 'log');
+
+        assertPartition(ranges, 1);
+        expect(pairs(ranges)).toEqual([[1, 854]]);
+    });
+
+    it('throws when the audible span has fewer bins than bands, instead of returning duplicate bands', () => {
+        expect(() => computeBandRanges(16, 384000, 4, 'log')).toThrow(/cannot be\s+split into 4 non-empty/);
+        expect(() => computeBandRanges(16, 384000, 4, 'log')).toThrow(/Raise "fftSize"/);
+    });
+
+    it('throws when there are fewer bins than bands in linear layout', () => {
+        expect(() => computeBandRanges(3, 48000, 4, 'linear')).toThrow(/cannot split 3 frequency bins into 4/);
+    });
+
+    it('throws on nonsense inputs', () => {
+        expect(() => computeBandRanges(0, 48000, 4, 'log')).toThrow(/binCount must be a positive integer/);
+        expect(() => computeBandRanges(1024, 0, 4, 'log')).toThrow(/sampleRate must be a finite positive number/);
+        expect(() => computeBandRanges(1024, 48000, 0, 'log')).toThrow(/bands must be a positive integer/);
+    });
+});
+
+describe('reduceBands', () => {
+    it('reduces byte bins to the 0..1 mean of each band', () => {
+        const freqData = new Uint8Array([0, 255, 51, 204, 255, 255, 0, 0]);
+        const ranges: BandRange[] = [{ start: 0, end: 4 }, { start: 4, end: 8 }];
+        const out = new Float32Array(2);
+
+        reduceBands(freqData, ranges, out);
+
+        expect(out[0]).toBeCloseTo(0.5, 10);
+        expect(out[1]).toBeCloseTo(0.5, 10);
+    });
+
+    it('a full-scale band reads 1 and a silent band reads 0', () => {
+        const freqData = new Uint8Array([255, 255, 0, 0]);
+        const ranges: BandRange[] = [{ start: 0, end: 2 }, { start: 2, end: 4 }];
+        const out = new Float32Array(2);
+
+        reduceBands(freqData, ranges, out);
+
+        expect(Array.from(out)).toEqual([1, 0]);
+    });
+
+    it('reduces bands of unequal width by their own means, not the global mean', () => {
+        const freqData = new Uint8Array([255, 0, 0, 0, 0]);
+        const ranges: BandRange[] = [{ start: 0, end: 1 }, { start: 1, end: 5 }];
+        const out = new Float32Array(2);
+
+        reduceBands(freqData, ranges, out);
+
+        expect(Array.from(out)).toEqual([1, 0]);
+    });
+
+    it('throws when the output buffer does not match the band count', () => {
+        const ranges: BandRange[] = [{ start: 0, end: 2 }];
+        expect(() => { reduceBands(new Uint8Array(4), ranges, new Float32Array(2)) })
+            .toThrow(/received 1 band range\(s\) but an output buffer of length 2/);
+    });
+
+    it('throws when a range reaches past the frequency buffer, instead of averaging in undefined', () => {
+        const ranges: BandRange[] = [{ start: 0, end: 8 }];
+        expect(() => { reduceBands(new Uint8Array(4), ranges, new Float32Array(1)) })
+            .toThrow(/not a non-empty range inside the 4-bin frequency buffer/);
+    });
+});
+
+describe('applyEnvelope', () => {
+    it('is the exact one-pole coefficient at a fixed dt', () => {
+        const env = applyEnvelope(0, 1, 0.1, 0.25, 0.5);
+
+        expect(env).toBeCloseTo(0.32967995396436073, 12);
+        expect(env).toBeCloseTo(1 - Math.exp(-0.4), 12);
+    });
+
+    it('uses release, not attack, when the target is below the envelope', () => {
+        const env = applyEnvelope(1, 0, 0.1, 0.25, 0.5);
+
+        expect(env).toBeCloseTo(Math.exp(-0.2), 12);
+        expect(env).toBeCloseTo(0.8187307530779818, 12);
+    });
+
+    it('rises faster than it falls for symmetric inputs', () => {
+        const attack = 0.05;
+        const release = 0.4;
+        const dt = 1 / 60;
+
+        const rise = applyEnvelope(0, 1, dt, attack, release) - 0;
+        const fall = 1 - applyEnvelope(1, 0, dt, attack, release);
+
+        expect(rise).toBeGreaterThan(fall);
+        expect(rise).toBeCloseTo(1 - Math.exp(-dt / attack), 12);
+        expect(fall).toBeCloseTo(1 - Math.exp(-dt / release), 12);
+    });
+
+    it('converges to the target over repeated steps', () => {
+        let env = 0;
+        for (let i = 0; i < 200; i++) {
+            env = applyEnvelope(env, 0.75, 1 / 60, 0.05, 0.4);
+        }
+
+        expect(env).toBeCloseTo(0.75, 6);
+    });
+
+    it('dt = 0 is the identity, and never poisons the envelope with NaN even when the time constant is 0', () => {
+        expect(applyEnvelope(0.42, 1, 0, 0.05, 0.4)).toBe(0.42);
+        expect(applyEnvelope(0.42, 1, 0, 0, 0)).toBe(0.42);
+        expect(applyEnvelope(0.42, 1, -0.5, 0, 0)).toBe(0.42);
+    });
+
+    it('a time constant of 0 snaps straight to the target at any positive dt', () => {
+        expect(applyEnvelope(0, 1, 1 / 60, 0, 0.4)).toBe(1);
+        expect(applyEnvelope(1, 0, 1 / 60, 0.05, 0)).toBe(0);
+    });
+});
+
+describe('validateAudioOptions', () => {
+    it('fills in the documented defaults', () => {
+        const resolved = validateAudioOptions();
+
+        expect(resolved).toEqual({
+            bands: 4,
+            fftSize: 2048,
+            smoothingTimeConstant: 0.8,
+            attack: 0,
+            release: 0,
+            minDecibels: -90,
+            maxDecibels: -10,
+            bandLayout: 'log',
+            names: { bands: 'u_audioBands', level: 'u_audioLevel' }
+        });
+    });
+
+    it('forces smoothingTimeConstant to 0 when an envelope is supplied', () => {
+        const withAttack = validateAudioOptions({ attack: 0.01 });
+        expect(withAttack.smoothingTimeConstant).toBe(0);
+        expect(withAttack.attack).toBe(0.01);
+        expect(withAttack.release).toBe(0);
+
+        const withRelease = validateAudioOptions({ release: 0.18 });
+        expect(withRelease.smoothingTimeConstant).toBe(0);
+
+        const noSmoothingRequested = validateAudioOptions({});
+        expect(noSmoothingRequested.smoothingTimeConstant).toBe(0.8);
+    });
+
+    it('throws rather than silently zeroing an explicit smoothingTimeConstant that an envelope would override', () => {
+        expect(() => validateAudioOptions({ smoothingTimeConstant: 0.6, attack: 0.01 }))
+            .toThrow(/cannot be combined with "attack"\/"release"/);
+        expect(() => validateAudioOptions({ smoothingTimeConstant: 0.6, release: 0.2 }))
+            .toThrow(/silently ignored/);
+
+        expect(() => validateAudioOptions({ smoothingTimeConstant: 0, attack: 0.01 })).not.toThrow();
+    });
+
+    it('throws for bands outside 1..4, naming the spectrum-texture path as the reason for the cap', () => {
+        expect(() => validateAudioOptions({ bands: 5 })).toThrow(/sampler2D/);
+        expect(() => validateAudioOptions({ bands: 5 })).toThrow(/must be an integer between 1 and 4/);
+        expect(() => validateAudioOptions({ bands: 0 })).toThrow(/must be an integer between 1 and 4/);
+        expect(() => validateAudioOptions({ bands: 2.5 })).toThrow(/must be an integer between 1 and 4/);
+
+        expect(validateAudioOptions({ bands: 1 }).bands).toBe(1);
+        expect(validateAudioOptions({ bands: 4 }).bands).toBe(4);
+    });
+
+    it('throws for an fftSize that is not a power of two in 32..32768', () => {
+        expect(() => validateAudioOptions({ fftSize: 1000 })).toThrow(/power of two between 32 and 32768/);
+        expect(() => validateAudioOptions({ fftSize: 16 })).toThrow(/power of two between 32 and 32768/);
+        expect(() => validateAudioOptions({ fftSize: 65536 })).toThrow(/power of two between 32 and 32768/);
+
+        expect(validateAudioOptions({ fftSize: 32 }).fftSize).toBe(32);
+        expect(validateAudioOptions({ fftSize: 32768 }).fftSize).toBe(32768);
+    });
+
+    it('throws for an inverted or empty decibel window', () => {
+        expect(() => validateAudioOptions({ minDecibels: -10, maxDecibels: -90 })).toThrow(/strictly below/);
+        expect(() => validateAudioOptions({ minDecibels: -30, maxDecibels: -30 })).toThrow(/strictly below/);
+        expect(() => validateAudioOptions({ minDecibels: Number.NaN })).toThrow(/strictly below/);
+    });
+
+    it('throws for negative or non-finite attack/release', () => {
+        expect(() => validateAudioOptions({ attack: -0.01 })).toThrow(/"attack" must be a finite number of seconds/);
+        expect(() => validateAudioOptions({ release: -1 })).toThrow(/"release" must be a finite number of seconds/);
+        expect(() => validateAudioOptions({ attack: Number.POSITIVE_INFINITY }))
+            .toThrow(/"attack" must be a finite number of seconds/);
+    });
+
+    it('throws for a smoothingTimeConstant outside 0..1', () => {
+        expect(() => validateAudioOptions({ smoothingTimeConstant: 1.5 })).toThrow(/between 0 and 1/);
+        expect(() => validateAudioOptions({ smoothingTimeConstant: -0.1 })).toThrow(/between 0 and 1/);
+    });
+
+    it('throws for an unknown bandLayout', () => {
+        expect(() => validateAudioOptions({ bandLayout: 'mel' as 'log' })).toThrow(/must be "log" or "linear"/);
+    });
+
+    it('throws for empty or colliding uniform names', () => {
+        expect(() => validateAudioOptions({ names: { bands: '   ' } })).toThrow(/"names.bands" must be a non-empty/);
+        expect(() => validateAudioOptions({ names: { level: '' } })).toThrow(/"names.level" must be a non-empty/);
+        expect(() => validateAudioOptions({ names: { bands: 'u_x', level: 'u_x' } }))
+            .toThrow(/must be different uniform names/);
+
+        expect(validateAudioOptions({ names: { bands: 'u_fft' } }).names)
+            .toEqual({ bands: 'u_fft', level: 'u_audioLevel' });
+    });
+});

--- a/src/core/lib/audioBands.ts
+++ b/src/core/lib/audioBands.ts
@@ -1,0 +1,274 @@
+import type { AudioUniformsOptions, BandLayout } from '@/types';
+
+export interface BandRange {
+    start: number;
+    end: number;
+}
+
+export interface ResolvedAudioNames {
+    bands: string;
+    level: string;
+}
+
+export interface ResolvedAnalyserOptions {
+    bands: number;
+    fftSize: number;
+    smoothingTimeConstant: number;
+    attack: number;
+    release: number;
+    minDecibels: number;
+    maxDecibels: number;
+    bandLayout: BandLayout;
+}
+
+export interface ResolvedAudioOptions extends ResolvedAnalyserOptions {
+    names: ResolvedAudioNames;
+}
+
+const MAX_BANDS = 4;
+const AUDIBLE_LOW_HZ = 20;
+const AUDIBLE_HIGH_HZ = 20000;
+
+const MIN_FFT_SIZE = 32;
+const MAX_FFT_SIZE = 32768;
+
+const DEFAULT_BANDS = 4;
+const DEFAULT_FFT_SIZE = 2048;
+const DEFAULT_SMOOTHING = 0.8;
+const DEFAULT_MIN_DECIBELS = -90;
+const DEFAULT_MAX_DECIBELS = -10;
+const DEFAULT_BANDS_NAME = 'u_audioBands';
+const DEFAULT_LEVEL_NAME = 'u_audioLevel';
+
+const BAND_LAYOUTS: Record<BandLayout, true> = { log: true, linear: true };
+
+function isPowerOfTwo(value: number): boolean {
+    return Number.isInteger(value) && value > 0 && (value & (value - 1)) === 0;
+}
+
+function partitionBins(rawEdges: number[], lo: number, hi: number, bands: number): BandRange[] {
+    const bins: number[] = new Array<number>(bands + 1);
+    bins[0] = lo;
+    for (let k = 1; k < bands; k++) {
+        bins[k] = Math.min(hi, Math.max(lo, Math.round(rawEdges[k])));
+    }
+    bins[bands] = hi;
+
+    for (let k = 1; k <= bands; k++) {
+        bins[k] = Math.max(bins[k], bins[k - 1] + 1);
+    }
+
+    bins[bands] = hi;
+    for (let k = bands - 1; k >= 1; k--) {
+        bins[k] = Math.min(bins[k], bins[k + 1] - 1);
+    }
+
+    const ranges: BandRange[] = [];
+    for (let k = 0; k < bands; k++) {
+        ranges.push({ start: bins[k], end: bins[k + 1] });
+    }
+    return ranges;
+}
+
+export function computeBandRanges(
+    binCount: number,
+    sampleRate: number,
+    bands: number,
+    layout: BandLayout
+): BandRange[] {
+    if (!Number.isInteger(binCount) || binCount < 1) {
+        throw new Error(
+            `micugl audio: binCount must be a positive integer, received ${JSON.stringify(binCount)}`
+        );
+    }
+    if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+        throw new Error(
+            `micugl audio: sampleRate must be a finite positive number, received ${JSON.stringify(sampleRate)}`
+        );
+    }
+    if (!Number.isInteger(bands) || bands < 1) {
+        throw new Error(
+            `micugl audio: bands must be a positive integer, received ${JSON.stringify(bands)}`
+        );
+    }
+
+    if (layout === 'linear') {
+        if (binCount < bands) {
+            throw new Error(
+                `micugl audio: cannot split ${binCount} frequency bins into ${bands} non-empty bands. `
+                + `An fftSize of ${binCount * 2} gives only ${binCount} bins; raise "fftSize".`
+            );
+        }
+        const rawEdges: number[] = [];
+        for (let k = 0; k <= bands; k++) {
+            rawEdges.push((k * binCount) / bands);
+        }
+        return partitionBins(rawEdges, 0, binCount, bands);
+    }
+
+    const nyquist = sampleRate / 2;
+    const hzPerBin = nyquist / binCount;
+    const highHz = Math.min(nyquist, AUDIBLE_HIGH_HZ);
+    const lo = Math.max(1, Math.floor(AUDIBLE_LOW_HZ / hzPerBin));
+    const hi = Math.min(binCount, Math.ceil(highHz / hzPerBin));
+
+    if (hi - lo < bands) {
+        throw new Error(
+            `micugl audio: an fftSize of ${binCount * 2} at a ${sampleRate} Hz sample rate leaves only `
+            + `${Math.max(0, hi - lo)} frequency bin(s) between ${AUDIBLE_LOW_HZ} Hz and ${highHz} Hz, which cannot be `
+            + `split into ${bands} non-empty log-spaced bands. Raise "fftSize", or use bandLayout "linear" to split `
+            + 'the whole spectrum evenly instead.'
+        );
+    }
+
+    const ratio = highHz / AUDIBLE_LOW_HZ;
+    const rawEdges: number[] = [];
+    for (let k = 0; k <= bands; k++) {
+        rawEdges.push((AUDIBLE_LOW_HZ * ratio ** (k / bands)) / hzPerBin);
+    }
+    return partitionBins(rawEdges, lo, hi, bands);
+}
+
+export function reduceBands(freqData: Uint8Array, ranges: BandRange[], out: Float32Array): void {
+    if (out.length !== ranges.length) {
+        throw new Error(
+            `micugl audio: reduceBands received ${ranges.length} band range(s) but an output buffer of length `
+            + `${out.length}; they must match`
+        );
+    }
+
+    for (let i = 0; i < ranges.length; i++) {
+        const { start, end } = ranges[i];
+        if (start < 0 || end <= start || end > freqData.length) {
+            throw new Error(
+                `micugl audio: band ${i} covers bins [${start}, ${end}), which is not a non-empty range inside the `
+                + `${freqData.length}-bin frequency buffer`
+            );
+        }
+
+        let sum = 0;
+        for (let bin = start; bin < end; bin++) {
+            sum += freqData[bin];
+        }
+        out[i] = sum / (end - start) / 255;
+    }
+}
+
+export function applyEnvelope(
+    env: number,
+    target: number,
+    dtSeconds: number,
+    attack: number,
+    release: number
+): number {
+    if (!(dtSeconds > 0)) {
+        return env;
+    }
+    const tau = target > env ? attack : release;
+    const coef = Math.exp(-dtSeconds / tau);
+    return target + (env - target) * coef;
+}
+
+function validateSeconds(value: number, raw: number | undefined, name: string): void {
+    if (!Number.isFinite(value) || value < 0) {
+        throw new Error(
+            `micugl audio: "${name}" must be a finite number of seconds >= 0, received ${JSON.stringify(raw)}. `
+            + 'A value of 0 means "instant" (that edge of the envelope snaps straight to the new level).'
+        );
+    }
+}
+
+function validateName(value: string, key: string): void {
+    if (value.trim() === '') {
+        throw new Error(
+            `micugl audio: "names.${key}" must be a non-empty uniform name, received ${JSON.stringify(value)}`
+        );
+    }
+}
+
+export function validateAudioOptions(options: AudioUniformsOptions = {}): ResolvedAudioOptions {
+    const bands = options.bands ?? DEFAULT_BANDS;
+    if (!Number.isInteger(bands) || bands < 1 || bands > MAX_BANDS) {
+        throw new Error(
+            `micugl audio: "bands" must be an integer between 1 and ${MAX_BANDS}, received ${JSON.stringify(options.bands)}. `
+            + `The bands are packed into one float/vec2/vec3/vec4 uniform, which holds at most ${MAX_BANDS} components. `
+            + 'More bands than that needs the full-spectrum texture path (the frequency data uploaded as a sampler2D), '
+            + 'which micugl does not have yet.'
+        );
+    }
+
+    const fftSize = options.fftSize ?? DEFAULT_FFT_SIZE;
+    if (!isPowerOfTwo(fftSize) || fftSize < MIN_FFT_SIZE || fftSize > MAX_FFT_SIZE) {
+        throw new Error(
+            `micugl audio: "fftSize" must be a power of two between ${MIN_FFT_SIZE} and ${MAX_FFT_SIZE}, `
+            + `received ${JSON.stringify(options.fftSize)}`
+        );
+    }
+
+    const attack = options.attack ?? 0;
+    validateSeconds(attack, options.attack, 'attack');
+    const release = options.release ?? 0;
+    validateSeconds(release, options.release, 'release');
+    const envelopeEnabled = options.attack !== undefined || options.release !== undefined;
+
+    const requestedSmoothing = options.smoothingTimeConstant;
+    if (requestedSmoothing !== undefined && (!Number.isFinite(requestedSmoothing)
+        || requestedSmoothing < 0 || requestedSmoothing > 1)) {
+        throw new Error(
+            `micugl audio: "smoothingTimeConstant" must be a number between 0 and 1, `
+            + `received ${JSON.stringify(requestedSmoothing)}`
+        );
+    }
+    if (envelopeEnabled && requestedSmoothing !== undefined && requestedSmoothing !== 0) {
+        throw new Error(
+            `micugl audio: "smoothingTimeConstant" (${requestedSmoothing}) cannot be combined with "attack"/"release". `
+            + 'The envelope replaces the analyser\'s built-in smoothing, which is symmetric and cannot express a fast '
+            + 'attack with a slow release, so micugl forces smoothingTimeConstant to 0 whenever attack or release is '
+            + 'set, and your value would be silently ignored. Pass attack/release for an asymmetric envelope, or '
+            + 'smoothingTimeConstant on its own for symmetric smoothing, but not both.'
+        );
+    }
+    const smoothingTimeConstant = envelopeEnabled ? 0 : (requestedSmoothing ?? DEFAULT_SMOOTHING);
+
+    const minDecibels = options.minDecibels ?? DEFAULT_MIN_DECIBELS;
+    const maxDecibels = options.maxDecibels ?? DEFAULT_MAX_DECIBELS;
+    if (!Number.isFinite(minDecibels) || !Number.isFinite(maxDecibels) || minDecibels >= maxDecibels) {
+        throw new Error(
+            `micugl audio: "minDecibels" (${JSON.stringify(minDecibels)}) must be a finite number strictly below `
+            + `"maxDecibels" (${JSON.stringify(maxDecibels)}); the analyser maps that dB window onto the 0..255 byte `
+            + 'range, so an inverted or empty window has no meaning.'
+        );
+    }
+
+    const bandLayout = options.bandLayout ?? 'log';
+    if (!Object.prototype.hasOwnProperty.call(BAND_LAYOUTS, bandLayout)) {
+        throw new Error(
+            `micugl audio: "bandLayout" must be "log" or "linear", received ${JSON.stringify(bandLayout)}`
+        );
+    }
+
+    const names: ResolvedAudioNames = {
+        bands: options.names?.bands ?? DEFAULT_BANDS_NAME,
+        level: options.names?.level ?? DEFAULT_LEVEL_NAME
+    };
+    validateName(names.bands, 'bands');
+    validateName(names.level, 'level');
+    if (names.bands === names.level) {
+        throw new Error(
+            `micugl audio: "names.bands" and "names.level" are both "${names.bands}"; they must be different uniform `
+            + 'names, or one would overwrite the other.'
+        );
+    }
+
+    return {
+        bands,
+        fftSize,
+        smoothingTimeConstant,
+        attack,
+        release,
+        minDecibels,
+        maxDecibels,
+        bandLayout,
+        names
+    };
+}

--- a/src/react/lib/audioAnalyserDriver.test.ts
+++ b/src/react/lib/audioAnalyserDriver.test.ts
@@ -1,0 +1,824 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateAudioOptions } from '@/core/lib/audioBands';
+import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
+import { createAudioAnalyserDriver } from '@/react/lib/audioAnalyserDriver';
+import type { AudioSourceSpec, AudioUniformsOptions } from '@/types';
+
+type Spectrum = (bin: number, binCount: number) => number;
+
+class FakeAnalyser {
+    fftSize = 2048;
+    smoothingTimeConstant = 0.8;
+    reads = 0;
+    spectrum: Spectrum = () => 0;
+    private minValue = -100;
+    private maxValue = -30;
+
+    get minDecibels(): number { return this.minValue }
+    set minDecibels(value: number) {
+        if (value >= this.maxValue) {
+            throw new Error(`IndexSizeError: minDecibels ${value} is not below maxDecibels ${this.maxValue}`);
+        }
+        this.minValue = value;
+    }
+
+    get maxDecibels(): number { return this.maxValue }
+    set maxDecibels(value: number) {
+        if (value <= this.minValue) {
+            throw new Error(`IndexSizeError: maxDecibels ${value} is not above minDecibels ${this.minValue}`);
+        }
+        this.maxValue = value;
+    }
+
+    get frequencyBinCount(): number { return this.fftSize / 2 }
+
+    getByteFrequencyData(target: Uint8Array): void {
+        this.reads += 1;
+        for (let i = 0; i < target.length; i++) {
+            target[i] = this.spectrum(i, target.length);
+        }
+    }
+}
+
+class FakeSourceNode {
+    connections: unknown[] = [];
+    constructor(public context: FakeContext) {}
+    connect(target: unknown): void { this.connections.push(target) }
+    disconnect(target: unknown): void { this.connections = this.connections.filter(entry => entry !== target) }
+}
+
+class FakeContext {
+    state: AudioContextState = 'suspended';
+    sampleRate = 48000;
+    destination = { id: 'destination' };
+    analysers: FakeAnalyser[] = [];
+    streamSources: FakeSourceNode[] = [];
+    elementSources: FakeSourceNode[] = [];
+    resumeCalls = 0;
+    closeCalls = 0;
+    bindThrows = false;
+    deferResume = false;
+    releaseResume: (() => void) | null = null;
+
+    createAnalyser(): FakeAnalyser {
+        const analyser = new FakeAnalyser();
+        this.analysers.push(analyser);
+        return analyser;
+    }
+
+    createMediaStreamSource(_stream: MediaStream): FakeSourceNode {
+        const node = new FakeSourceNode(this);
+        this.streamSources.push(node);
+        return node;
+    }
+
+    createMediaElementSource(_element: HTMLMediaElement): FakeSourceNode {
+        if (this.bindThrows) {
+            throw new Error('InvalidStateError: HTMLMediaElement already connected to a different MediaElementSourceNode');
+        }
+        const node = new FakeSourceNode(this);
+        this.elementSources.push(node);
+        return node;
+    }
+
+    resume(): Promise<void> {
+        this.resumeCalls += 1;
+        if (this.deferResume) {
+            return new Promise<void>(resolve => {
+                this.releaseResume = () => {
+                    this.state = 'running';
+                    resolve();
+                };
+            });
+        }
+        this.state = 'running';
+        return Promise.resolve();
+    }
+
+    close(): Promise<void> {
+        this.closeCalls += 1;
+        this.state = 'closed';
+        return Promise.resolve();
+    }
+}
+
+function createFakeStream(): { stream: MediaStream; tracks: { stopped: boolean }[] } {
+    const tracks = [
+        { stopped: false, stop() { this.stopped = true } },
+        { stopped: false, stop() { this.stopped = true } }
+    ];
+    return { stream: { getTracks: () => tracks } as unknown as MediaStream, tracks };
+}
+
+function asContext(context: FakeContext): AudioContext {
+    return context as unknown as AudioContext;
+}
+
+function asElement(id: string): HTMLMediaElement {
+    return { id } as unknown as HTMLMediaElement;
+}
+
+interface Harness {
+    driver: ReturnType<typeof createAudioAnalyserDriver>;
+    context: FakeContext;
+    tracks: { stopped: boolean }[];
+    requests: number[];
+    analyser: () => FakeAnalyser;
+}
+
+function createHarness(
+    options: AudioUniformsOptions = {},
+    source: AudioSourceSpec = { type: 'mic' },
+    overrides: { context?: FakeContext; deps?: Partial<AudioAnalyserDriverDeps> } = {}
+): Harness {
+    const context = overrides.context ?? new FakeContext();
+    const { stream, tracks } = createFakeStream();
+    const requests: number[] = [];
+
+    const driver = createAudioAnalyserDriver(source, validateAudioOptions(options), {
+        createContext: () => asContext(context),
+        getUserMedia: () => Promise.resolve(stream),
+        ...overrides.deps
+    });
+    driver.invalidation.connect(() => { requests.push(1) });
+
+    return {
+        driver,
+        context,
+        tracks,
+        requests,
+        analyser: () => context.analysers[context.analysers.length - 1]
+    };
+}
+
+const LOW_HALF: Spectrum = (bin, binCount) => (bin < binCount / 2 ? 255 : 0);
+const HIGH_HALF: Spectrum = (bin, binCount) => (bin < binCount / 2 ? 0 : 255);
+
+const TWO_BAND_LINEAR: AudioUniformsOptions = {
+    bands: 2,
+    fftSize: 64,
+    bandLayout: 'linear',
+    attack: 0.05,
+    release: 0.4
+};
+
+describe('the audio analyser driver, reading a fake analyser whose spectrum the test controls', () => {
+    it('bandsScratch changes across successive frames and tracks the signal that was fed in', async () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+        await harness.driver.start();
+        const analyser = harness.analyser();
+
+        analyser.spectrum = LOW_HALF;
+
+        harness.driver.analyseIfNeeded(0);
+        expect(Array.from(harness.driver.bandsScratch)).toEqual([0, 0]);
+
+        const lowBand: number[] = [];
+        const highBand: number[] = [];
+        for (let time = 16; time <= 160; time += 16) {
+            harness.driver.analyseIfNeeded(time);
+            lowBand.push(harness.driver.bandsScratch[0]);
+            highBand.push(harness.driver.bandsScratch[1]);
+        }
+
+        expect(analyser.reads).toBe(11);
+        expect(lowBand[0]).toBeGreaterThan(0);
+        for (let i = 1; i < lowBand.length; i++) {
+            expect(lowBand[i]).toBeGreaterThan(lowBand[i - 1]);
+        }
+        expect(lowBand[lowBand.length - 1]).toBeGreaterThan(0.8);
+        expect(lowBand[lowBand.length - 1]).toBeLessThanOrEqual(1);
+        expect(highBand.every(value => value === 0)).toBe(true);
+
+        analyser.spectrum = HIGH_HALF;
+
+        const afterSwap: { low: number; high: number }[] = [];
+        for (let time = 176; time <= 320; time += 16) {
+            harness.driver.analyseIfNeeded(time);
+            afterSwap.push({ low: harness.driver.bandsScratch[0], high: harness.driver.bandsScratch[1] });
+        }
+
+        for (let i = 1; i < afterSwap.length; i++) {
+            expect(afterSwap[i].low).toBeLessThan(afterSwap[i - 1].low);
+            expect(afterSwap[i].high).toBeGreaterThan(afterSwap[i - 1].high);
+        }
+        expect(afterSwap[afterSwap.length - 1].high).toBeGreaterThan(0.8);
+
+        expect(harness.driver.level).toBeCloseTo(
+            (harness.driver.bandsScratch[0] + harness.driver.bandsScratch[1]) / 2,
+            10
+        );
+    });
+
+    it('the envelope rises faster than it falls across frames', async () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+        await harness.driver.start();
+        const analyser = harness.analyser();
+
+        analyser.spectrum = LOW_HALF;
+        harness.driver.analyseIfNeeded(0);
+        harness.driver.analyseIfNeeded(16);
+        const rise = harness.driver.bandsScratch[0];
+
+        for (let time = 32; time <= 480; time += 16) {
+            harness.driver.analyseIfNeeded(time);
+        }
+        const settled = harness.driver.bandsScratch[0];
+
+        analyser.spectrum = () => 0;
+        harness.driver.analyseIfNeeded(496);
+        const fall = settled - harness.driver.bandsScratch[0];
+
+        expect(rise).toBeGreaterThan(0);
+        expect(fall).toBeGreaterThan(0);
+        expect(rise).toBeGreaterThan(fall * 4);
+    });
+
+    it('a long gap between frames eases back over 100ms of envelope instead of snapping to the new spectrum', async () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+        await harness.driver.start();
+        harness.analyser().spectrum = LOW_HALF;
+
+        harness.driver.analyseIfNeeded(0);
+        harness.driver.analyseIfNeeded(10000);
+
+        expect(harness.driver.bandsScratch[0]).toBeCloseTo(1 - Math.exp(-0.1 / 0.05), 6);
+        expect(harness.driver.bandsScratch[0]).toBeLessThan(0.9);
+    });
+
+    it('a clock that steps backwards freezes the envelope rather than poisoning it', async () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+        await harness.driver.start();
+        const analyser = harness.analyser();
+        analyser.spectrum = LOW_HALF;
+
+        harness.driver.analyseIfNeeded(0);
+        harness.driver.analyseIfNeeded(32);
+        const settled = harness.driver.bandsScratch[0];
+        expect(settled).toBeGreaterThan(0);
+
+        harness.driver.analyseIfNeeded(16);
+
+        expect(harness.driver.bandsScratch[0]).toBe(settled);
+        expect(harness.driver.level).toBe(settled / 2);
+
+        harness.driver.analyseIfNeeded(32);
+
+        expect(harness.driver.bandsScratch[0]).toBeGreaterThan(settled);
+        expect(Number.isFinite(harness.driver.level)).toBe(true);
+    });
+
+    it('memoizes on frame time: two reads at the same timeMs analyse exactly once', async () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+        await harness.driver.start();
+        const analyser = harness.analyser();
+        analyser.spectrum = LOW_HALF;
+
+        harness.driver.analyseIfNeeded(100);
+        harness.driver.analyseIfNeeded(100);
+        harness.driver.analyseIfNeeded(100);
+
+        expect(analyser.reads).toBe(1);
+
+        harness.driver.analyseIfNeeded(116);
+        expect(analyser.reads).toBe(2);
+    });
+
+    it('a pinned clock does not spin the analyser, and a running frame re-arms the invalidation chain', async () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+        await harness.driver.start();
+
+        expect(harness.requests).toHaveLength(1);
+
+        harness.driver.analyseIfNeeded(50);
+        expect(harness.requests).toHaveLength(2);
+
+        harness.driver.analyseIfNeeded(50);
+        harness.driver.analyseIfNeeded(50);
+        expect(harness.requests).toHaveLength(2);
+        expect(harness.analyser().reads).toBe(1);
+    });
+
+    it('start() resolves to a running driver and requests exactly one frame to kick the chain', async () => {
+        const harness = createHarness();
+
+        expect(harness.driver.status).toBe('idle');
+        expect(Array.from(harness.driver.bandsScratch)).toEqual([0, 0, 0, 0]);
+
+        await harness.driver.start();
+
+        expect(harness.driver.status).toBe('running');
+        expect(harness.driver.error).toBeNull();
+        expect(harness.requests).toHaveLength(1);
+        expect(harness.context.resumeCalls).toBe(1);
+    });
+
+    it('is inert before start(): the uniforms read a documented zero, and nothing is analysed', () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+
+        harness.driver.analyseIfNeeded(16);
+        harness.driver.analyseIfNeeded(32);
+
+        expect(harness.driver.status).toBe('idle');
+        expect(Array.from(harness.driver.bandsScratch)).toEqual([0, 0]);
+        expect(harness.driver.level).toBe(0);
+        expect(harness.context.analysers).toHaveLength(0);
+        expect(harness.requests).toHaveLength(0);
+    });
+});
+
+describe('audio driver lifecycle', () => {
+    it('stop() stops every microphone track and closes the context it created', async () => {
+        const harness = createHarness();
+        await harness.driver.start();
+
+        const analyser = harness.analyser();
+        const sourceNode = harness.context.streamSources[0];
+        expect(sourceNode.connections).toEqual([analyser]);
+
+        harness.driver.stop();
+
+        expect(harness.tracks.every(track => track.stopped)).toBe(true);
+        expect(harness.context.closeCalls).toBe(1);
+        expect(harness.driver.status).toBe('stopped');
+        expect(sourceNode.connections).toEqual([]);
+    });
+
+    it('never routes the microphone to the speakers', async () => {
+        const harness = createHarness();
+        await harness.driver.start();
+
+        expect(harness.context.streamSources[0].connections)
+            .not.toContain(harness.context.destination);
+    });
+
+    it('stop() zeroes the bands and repaints, so a stopped visual cannot freeze on the last spectrum', async () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+        await harness.driver.start();
+        harness.analyser().spectrum = LOW_HALF;
+
+        harness.driver.analyseIfNeeded(0);
+        harness.driver.analyseIfNeeded(200);
+        expect(harness.driver.bandsScratch[0]).toBeGreaterThan(0);
+
+        const before = harness.requests.length;
+        harness.driver.stop();
+
+        expect(Array.from(harness.driver.bandsScratch)).toEqual([0, 0]);
+        expect(harness.driver.level).toBe(0);
+        expect(harness.requests.length).toBe(before + 1);
+    });
+
+    it('does NOT close a caller-owned context, and does not touch the caller node beyond its own analyser', async () => {
+        const context = new FakeContext();
+        const node = new FakeSourceNode(context);
+        const harness = createHarness(
+            {},
+            { type: 'node', node: node as unknown as AudioNode, context: asContext(context) },
+            { context }
+        );
+
+        await harness.driver.start();
+        const analyser = harness.analyser();
+        expect(node.connections).toEqual([analyser]);
+
+        harness.driver.stop();
+
+        expect(context.closeCalls).toBe(0);
+        expect(node.connections).toEqual([]);
+        expect(harness.driver.status).toBe('stopped');
+    });
+
+    it('throws when the caller-owned context passed with a node source has already been closed', async () => {
+        const context = new FakeContext();
+        const node = new FakeSourceNode(context);
+        await context.close();
+
+        const harness = createHarness(
+            {},
+            { type: 'node', node: node as unknown as AudioNode, context: asContext(context) },
+            { context }
+        );
+
+        await expect(harness.driver.start()).rejects.toThrow(/is closed, so no analyser can be built/);
+
+        expect(harness.driver.status).toBe('error');
+        expect(context.analysers).toHaveLength(0);
+        expect(node.connections).toEqual([]);
+    });
+
+    it('throws when a node source is given a context the node does not belong to', async () => {
+        const nodeContext = new FakeContext();
+        const otherContext = new FakeContext();
+        const node = new FakeSourceNode(nodeContext);
+        const harness = createHarness(
+            {},
+            { type: 'node', node: node as unknown as AudioNode, context: asContext(otherContext) }
+        );
+
+        await expect(harness.driver.start()).rejects.toThrow(/do not match/);
+        expect(harness.driver.status).toBe('error');
+    });
+
+    it('a rejected getUserMedia rejects start(), sets status to error, and populates error', async () => {
+        const denied = new Error('NotAllowedError: Permission denied');
+        const harness = createHarness({}, { type: 'mic' }, {
+            deps: { getUserMedia: () => Promise.reject(denied) }
+        });
+
+        await expect(harness.driver.start()).rejects.toThrow('NotAllowedError: Permission denied');
+
+        expect(harness.driver.status).toBe('error');
+        expect(harness.driver.error).toBe(denied);
+        expect(harness.context.analysers).toHaveLength(0);
+    });
+
+    it('a failure AFTER the microphone is granted still stops the tracks and closes the context', async () => {
+        const context = new FakeContext();
+        context.sampleRate = 384000;
+        const harness = createHarness({ bands: 4, fftSize: 32 }, { type: 'mic' }, { context });
+
+        await expect(harness.driver.start()).rejects.toThrow(/cannot be\s+split into 4 non-empty/);
+
+        expect(harness.driver.status).toBe('error');
+        expect(harness.tracks.every(track => track.stopped)).toBe(true);
+        expect(context.closeCalls).toBe(1);
+    });
+
+    it('a microphone granted to an attempt that then fails is released before the next attempt grants another', async () => {
+        const context = new FakeContext();
+        context.sampleRate = 384000;
+        const grants: { stream: MediaStream; tracks: { stopped: boolean }[] }[] = [];
+
+        const driver = createAudioAnalyserDriver({ type: 'mic' }, validateAudioOptions({ bands: 4, fftSize: 32 }), {
+            createContext: () => asContext(context),
+            getUserMedia: () => {
+                const grant = createFakeStream();
+                grants.push(grant);
+                return Promise.resolve(grant.stream);
+            }
+        });
+
+        await expect(driver.start()).rejects.toThrow(/cannot be\s+split into 4 non-empty/);
+        await expect(driver.start()).rejects.toThrow(/cannot be\s+split into 4 non-empty/);
+
+        expect(grants).toHaveLength(2);
+        expect(grants.every(grant => grant.tracks.every(track => track.stopped))).toBe(true);
+    });
+
+    it('start() after an error retries and can succeed', async () => {
+        const { stream, tracks } = createFakeStream();
+        const context = new FakeContext();
+        let attempt = 0;
+
+        const driver = createAudioAnalyserDriver({ type: 'mic' }, validateAudioOptions(), {
+            createContext: () => asContext(context),
+            getUserMedia: () => {
+                attempt += 1;
+                return attempt === 1 ? Promise.reject(new Error('denied')) : Promise.resolve(stream);
+            }
+        });
+
+        await expect(driver.start()).rejects.toThrow('denied');
+        expect(driver.status).toBe('error');
+
+        await driver.start();
+
+        expect(driver.status).toBe('running');
+        expect(driver.error).toBeNull();
+        expect(tracks.every(track => !track.stopped)).toBe(true);
+    });
+
+    it('start() while starting joins the in-flight attempt instead of prompting twice', async () => {
+        let calls = 0;
+        const harness = createHarness({}, { type: 'mic' }, {
+            deps: {
+                getUserMedia: () => {
+                    calls += 1;
+                    return Promise.resolve(createFakeStream().stream);
+                }
+            }
+        });
+
+        const first = harness.driver.start();
+        const second = harness.driver.start();
+        expect(harness.driver.status).toBe('starting');
+
+        await Promise.all([first, second]);
+
+        expect(calls).toBe(1);
+        expect(harness.context.analysers).toHaveLength(1);
+        expect(harness.driver.status).toBe('running');
+    });
+
+    it('a subscriber that calls start() from inside the starting notification cannot open a second microphone', async () => {
+        let calls = 0;
+        const harness = createHarness({}, { type: 'mic' }, {
+            deps: {
+                getUserMedia: () => {
+                    calls += 1;
+                    return Promise.resolve(createFakeStream().stream);
+                }
+            }
+        });
+
+        const rejoined: Promise<void>[] = [];
+        let reentered = false;
+        harness.driver.subscribe(() => {
+            if (!reentered && harness.driver.status === 'starting') {
+                reentered = true;
+                rejoined.push(harness.driver.start());
+            }
+        });
+
+        await harness.driver.start();
+        await Promise.all(rejoined);
+
+        expect(reentered).toBe(true);
+        expect(calls).toBe(1);
+        expect(harness.context.streamSources).toHaveLength(1);
+        expect(harness.context.analysers).toHaveLength(1);
+        expect(harness.driver.status).toBe('running');
+    });
+
+    it('a denied start() the caller does not await reports through status and error without an unhandled rejection', async () => {
+        const denied = new Error('NotAllowedError: Permission denied');
+        const harness = createHarness({}, { type: 'mic' }, {
+            deps: { getUserMedia: () => Promise.reject(denied) }
+        });
+
+        void harness.driver.start();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(harness.driver.status).toBe('error');
+        expect(harness.driver.error).toBe(denied);
+    });
+
+    it('start() while running is a no-op that does not rebuild the graph', async () => {
+        const harness = createHarness();
+        await harness.driver.start();
+        await harness.driver.start();
+
+        expect(harness.context.analysers).toHaveLength(1);
+        expect(harness.context.streamSources).toHaveLength(1);
+        expect(harness.requests).toHaveLength(1);
+    });
+
+    it('stop() during starting cancels the attempt and releases the microphone it was granted', async () => {
+        const { stream, tracks } = createFakeStream();
+        const context = new FakeContext();
+        let grant: (value: MediaStream) => void = () => undefined;
+
+        const driver = createAudioAnalyserDriver({ type: 'mic' }, validateAudioOptions(), {
+            createContext: () => asContext(context),
+            getUserMedia: () => new Promise<MediaStream>(resolve => { grant = resolve })
+        });
+
+        const starting = driver.start();
+        expect(driver.status).toBe('starting');
+
+        driver.stop();
+        expect(driver.status).toBe('stopped');
+
+        grant(stream);
+        await expect(starting).resolves.toBeUndefined();
+
+        expect(tracks.every(track => track.stopped)).toBe(true);
+        expect(context.closeCalls).toBe(1);
+        expect(context.analysers).toHaveLength(0);
+        expect(driver.status).toBe('stopped');
+    });
+
+    it('a stop() during starting never resumes the caller-owned context it was about to use', async () => {
+        const context = new FakeContext();
+        const node = new FakeSourceNode(context);
+        let release: () => void = () => undefined;
+
+        const driver = createAudioAnalyserDriver(
+            { type: 'node', node: node as unknown as AudioNode, context: asContext(context) },
+            validateAudioOptions(),
+            { getUserMedia: () => new Promise<MediaStream>(() => undefined) }
+        );
+
+        const gate = new Promise<void>(resolve => { release = resolve });
+        const starting = driver.start();
+        driver.stop();
+        release();
+        await gate;
+        await expect(starting).resolves.toBeUndefined();
+
+        expect(context.resumeCalls).toBe(0);
+        expect(context.closeCalls).toBe(0);
+        expect(context.analysers).toHaveLength(0);
+        expect(node.connections).toEqual([]);
+        expect(driver.status).toBe('stopped');
+    });
+
+    it('a stop() while the context is still resuming builds no graph and leaves no zombie microphone', async () => {
+        const context = new FakeContext();
+        context.deferResume = true;
+        const harness = createHarness({}, { type: 'mic' }, { context });
+
+        const starting = harness.driver.start();
+        for (let turn = 0; turn < 20 && context.resumeCalls === 0; turn++) {
+            await Promise.resolve();
+        }
+        expect(context.resumeCalls).toBe(1);
+        expect(harness.driver.status).toBe('starting');
+
+        harness.driver.stop();
+        context.releaseResume?.();
+        await expect(starting).resolves.toBeUndefined();
+
+        expect(context.analysers).toHaveLength(0);
+        expect(harness.context.streamSources[0].connections).toEqual([]);
+        expect(harness.tracks.every(track => track.stopped)).toBe(true);
+        expect(context.closeCalls).toBe(1);
+        expect(harness.driver.status).toBe('stopped');
+    });
+
+    it('stop() is idempotent and inert from idle', async () => {
+        const harness = createHarness();
+
+        harness.driver.stop();
+        expect(harness.driver.status).toBe('idle');
+        expect(harness.requests).toHaveLength(0);
+
+        await harness.driver.start();
+        harness.driver.stop();
+        harness.driver.stop();
+
+        expect(harness.context.closeCalls).toBe(1);
+        expect(harness.driver.status).toBe('stopped');
+    });
+
+    it('notifies subscribers on every status change', async () => {
+        const harness = createHarness();
+        const seen: string[] = [];
+        const dispose = harness.driver.subscribe(() => { seen.push(harness.driver.status) });
+
+        await harness.driver.start();
+        harness.driver.stop();
+        dispose();
+        await harness.driver.start();
+
+        expect(seen).toEqual(['starting', 'running', 'stopped']);
+    });
+});
+
+describe('audio driver element sources', () => {
+    it('keeps the media element audible by connecting the source to the destination', async () => {
+        const element = asElement('audible');
+        const harness = createHarness({}, { type: 'element', element });
+
+        await harness.driver.start();
+
+        const sourceNode = harness.context.elementSources[0];
+        expect(sourceNode.connections).toContain(harness.context.destination);
+        expect(sourceNode.connections).toContain(harness.analyser());
+
+        harness.driver.stop();
+
+        expect(sourceNode.connections).toEqual([harness.context.destination]);
+        expect(harness.context.closeCalls).toBe(0);
+    });
+
+    it('binds createMediaElementSource once per element and reuses it across restarts and drivers', async () => {
+        const element = asElement('reused');
+        const context = new FakeContext();
+
+        const first = createHarness({}, { type: 'element', element }, { context });
+        await first.driver.start();
+        first.driver.stop();
+        await first.driver.start();
+
+        expect(context.elementSources).toHaveLength(1);
+
+        const otherContext = new FakeContext();
+        const second = createHarness({}, { type: 'element', element }, { context: otherContext });
+        await second.driver.start();
+
+        expect(context.elementSources).toHaveLength(1);
+        expect(otherContext.elementSources).toHaveLength(0);
+        expect(otherContext.analysers).toHaveLength(0);
+        expect(context.analysers.length).toBeGreaterThan(1);
+        expect(second.driver.status).toBe('running');
+    });
+
+    it('translates the platform InvalidStateError for an element bound outside micugl', async () => {
+        const element = asElement('foreign');
+        const context = new FakeContext();
+        context.bindThrows = true;
+
+        const harness = createHarness({}, { type: 'element', element }, { context });
+
+        await expect(harness.driver.start())
+            .rejects.toThrow(/already bound to an AudioContext that micugl did not create/);
+        await expect(harness.driver.start()).rejects.toThrow(/only ever be connected to one AudioContext/);
+        expect(harness.driver.status).toBe('error');
+        expect(context.closeCalls).toBeGreaterThan(0);
+    });
+
+    it('a failure to build the analyser leaves the element bound, audible, and its context open', async () => {
+        const element = asElement('survives-a-failed-start');
+        const context = new FakeContext();
+        context.sampleRate = 384000;
+
+        const harness = createHarness({ bands: 4, fftSize: 32 }, { type: 'element', element }, { context });
+
+        await expect(harness.driver.start()).rejects.toThrow(/cannot be\s+split into 4 non-empty/);
+
+        expect(harness.driver.status).toBe('error');
+        expect(context.closeCalls).toBe(0);
+        expect(context.elementSources[0].connections).toEqual([context.destination]);
+    });
+});
+
+describe('audio driver reconfigure', () => {
+    it('rebuilds the analyser against the surviving source node, and keeps analysing', async () => {
+        const element = asElement('reconfigure');
+        const harness = createHarness({ bands: 4, fftSize: 2048 }, { type: 'element', element });
+        await harness.driver.start();
+
+        const sourceNode = harness.context.elementSources[0];
+        const original = harness.analyser();
+
+        harness.driver.reconfigure(validateAudioOptions({
+            bands: 2,
+            fftSize: 64,
+            bandLayout: 'linear',
+            attack: 0.05,
+            release: 0.4
+        }));
+
+        const rebuilt = harness.analyser();
+        expect(harness.context.analysers).toHaveLength(2);
+        expect(rebuilt).not.toBe(original);
+        expect(harness.context.elementSources).toHaveLength(1);
+        expect(sourceNode.connections).toContain(rebuilt);
+        expect(sourceNode.connections).not.toContain(original);
+        expect(sourceNode.connections).toContain(harness.context.destination);
+
+        expect(harness.driver.bandsScratch).toHaveLength(2);
+        expect(rebuilt.fftSize).toBe(64);
+
+        rebuilt.spectrum = LOW_HALF;
+        harness.driver.analyseIfNeeded(0);
+        harness.driver.analyseIfNeeded(200);
+
+        expect(harness.driver.bandsScratch[0]).toBeGreaterThan(0);
+        expect(original.reads).toBe(0);
+        expect(rebuilt.reads).toBe(2);
+    });
+
+    it('applies the decibel window in an order the platform accepts, even when it inverts the defaults', async () => {
+        const harness = createHarness({ minDecibels: -20, maxDecibels: -5 });
+
+        await harness.driver.start();
+
+        const analyser = harness.analyser();
+        expect(analyser.minDecibels).toBe(-20);
+        expect(analyser.maxDecibels).toBe(-5);
+        expect(harness.driver.status).toBe('running');
+    });
+
+    it('a reconfigure that cannot build an analyser throws, and the running driver keeps analysing every frame after', async () => {
+        const harness = createHarness(TWO_BAND_LINEAR);
+        await harness.driver.start();
+        const original = harness.analyser();
+        original.spectrum = LOW_HALF;
+
+        harness.driver.analyseIfNeeded(0);
+        harness.driver.analyseIfNeeded(16);
+        const beforeReconfigure = harness.driver.bandsScratch[0];
+        expect(beforeReconfigure).toBeGreaterThan(0);
+
+        harness.context.sampleRate = 384000;
+        const impossible = validateAudioOptions({ bands: 4, fftSize: 32 });
+
+        expect(() => { harness.driver.reconfigure(impossible) }).toThrow(/cannot be\s+split into 4 non-empty/);
+
+        expect(harness.driver.status).toBe('running');
+        expect(harness.driver.bandsScratch).toHaveLength(2);
+        expect(harness.context.streamSources[0].connections).toEqual([original]);
+
+        harness.driver.analyseIfNeeded(32);
+        harness.driver.analyseIfNeeded(48);
+
+        expect(original.reads).toBe(4);
+        expect(harness.driver.bandsScratch).toHaveLength(2);
+        expect(harness.driver.bandsScratch[0]).toBeGreaterThan(beforeReconfigure);
+        expect(harness.driver.level).toBeGreaterThan(0);
+    });
+
+    it('a reconfigure while idle still resizes the bands the next start() will fill', () => {
+        const harness = createHarness({ bands: 4, fftSize: 2048 });
+
+        harness.driver.reconfigure(validateAudioOptions(TWO_BAND_LINEAR));
+
+        expect(harness.driver.bandsScratch).toHaveLength(2);
+        expect(harness.driver.status).toBe('idle');
+        expect(harness.context.analysers).toHaveLength(0);
+    });
+});

--- a/src/react/lib/audioAnalyserDriver.ts
+++ b/src/react/lib/audioAnalyserDriver.ts
@@ -1,0 +1,375 @@
+import type { BandRange, ResolvedAnalyserOptions } from '@/core/lib/audioBands';
+import { applyEnvelope, computeBandRanges, reduceBands } from '@/core/lib/audioBands';
+import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
+import type { AudioSourceSpec, AudioStatus } from '@/types';
+
+export interface AudioAnalyserDriverDeps {
+    createContext?: () => AudioContext;
+    getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+}
+
+export interface AudioAnalyserDriver {
+    start(): Promise<void>;
+    stop(): void;
+    analyseIfNeeded(timeMs: number): void;
+    reconfigure(options: ResolvedAnalyserOptions): void;
+    subscribe(onChange: () => void): () => void;
+    readonly bandsScratch: Float32Array;
+    readonly level: number;
+    readonly status: AudioStatus;
+    readonly error: Error | null;
+    readonly invalidation: FrameInvalidation;
+}
+
+interface Analysis {
+    analyser: AnalyserNode;
+    freqData: Uint8Array;
+    ranges: BandRange[];
+}
+
+interface SourceGraph {
+    context: AudioContext;
+    mayCloseContext: boolean;
+    sourceNode: AudioNode;
+    stream: MediaStream | null;
+}
+
+interface AudioGraph extends SourceGraph {
+    analysis: Analysis;
+}
+
+type DriverState =
+    | { kind: 'idle' }
+    | { kind: 'starting'; pending: Promise<void> }
+    | { kind: 'running'; graph: AudioGraph }
+    | { kind: 'stopped' }
+    | { kind: 'error'; error: Error };
+
+interface ElementBinding {
+    context: AudioContext;
+    sourceNode: MediaElementAudioSourceNode;
+}
+
+const ELEMENT_BINDINGS = new WeakMap<HTMLMediaElement, ElementBinding>();
+
+const MAX_DT_SECONDS = 0.1;
+
+function defaultCreateContext(): AudioContext {
+    if (typeof AudioContext !== 'function') {
+        throw new Error(
+            'micugl audio: this environment has no AudioContext, so micugl cannot analyse audio. WebAudio is '
+            + 'browser-only; start() must run in a browser, never during server rendering.'
+        );
+    }
+    return new AudioContext();
+}
+
+function defaultGetUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream> {
+    if (typeof navigator !== 'object' || typeof navigator.mediaDevices !== 'object') {
+        throw new Error(
+            'micugl audio: navigator.mediaDevices.getUserMedia is unavailable, so the microphone cannot be opened. '
+            + 'getUserMedia only exists in a secure context: serve the page over https, or from localhost.'
+        );
+    }
+    return navigator.mediaDevices.getUserMedia(constraints);
+}
+
+function toError(cause: unknown): Error {
+    return cause instanceof Error ? cause : new Error(String(cause));
+}
+
+function keepRejectionHandled(promise: Promise<void>): void {
+    void promise.catch(() => undefined);
+}
+
+function stopTracks(stream: MediaStream): void {
+    for (const track of stream.getTracks()) {
+        track.stop();
+    }
+}
+
+function assertUsableContext(context: AudioContext, what: string): void {
+    if (context.state === 'closed') {
+        throw new Error(
+            `micugl audio: the AudioContext ${what} is closed, so no analyser can be built on it. A closed `
+            + 'AudioContext cannot be reopened.'
+        );
+    }
+}
+
+function buildAnalysis(context: AudioContext, options: ResolvedAnalyserOptions): Analysis {
+    const analyser = context.createAnalyser();
+    analyser.fftSize = options.fftSize;
+    analyser.smoothingTimeConstant = options.smoothingTimeConstant;
+
+    if (options.minDecibels >= analyser.maxDecibels) {
+        analyser.maxDecibels = options.maxDecibels;
+        analyser.minDecibels = options.minDecibels;
+    } else {
+        analyser.minDecibels = options.minDecibels;
+        analyser.maxDecibels = options.maxDecibels;
+    }
+
+    const freqData = new Uint8Array(analyser.frequencyBinCount);
+    const ranges = computeBandRanges(
+        analyser.frequencyBinCount,
+        context.sampleRate,
+        options.bands,
+        options.bandLayout
+    );
+
+    return { analyser, freqData, ranges };
+}
+
+function bindElement(element: HTMLMediaElement, createContext: () => AudioContext): SourceGraph {
+    const bound = ELEMENT_BINDINGS.get(element);
+    if (bound) {
+        return { context: bound.context, mayCloseContext: false, sourceNode: bound.sourceNode, stream: null };
+    }
+
+    const context = createContext();
+    let sourceNode: MediaElementAudioSourceNode;
+    try {
+        sourceNode = context.createMediaElementSource(element);
+    } catch (cause) {
+        void context.close();
+        throw new Error(
+            'micugl audio: this media element is already bound to an AudioContext that micugl did not create, and a '
+            + 'media element can only ever be connected to one AudioContext for the lifetime of the page. Either let '
+            + 'micugl own the element, or pass the source node you already made as { type: "node", node, context }. '
+            + `(the browser said: ${toError(cause).message})`
+        );
+    }
+
+    sourceNode.connect(context.destination);
+    ELEMENT_BINDINGS.set(element, { context, sourceNode });
+
+    return { context, mayCloseContext: false, sourceNode, stream: null };
+}
+
+export function createAudioAnalyserDriver(
+    source: AudioSourceSpec,
+    options: ResolvedAnalyserOptions,
+    deps: AudioAnalyserDriverDeps = {}
+): AudioAnalyserDriver {
+    const invalidation = createFrameInvalidation();
+    const listeners = new Set<() => void>();
+    const createContext = deps.createContext ?? defaultCreateContext;
+    const getUserMedia = deps.getUserMedia ?? defaultGetUserMedia;
+
+    let currentOptions = options;
+    let state: DriverState = { kind: 'idle' };
+    let bands = new Float32Array(currentOptions.bands);
+    let raw = new Float32Array(currentOptions.bands);
+    let level = 0;
+    let lastAnalysedTime: number | null = null;
+    let generation = 0;
+
+    function setState(next: DriverState): void {
+        state = next;
+        listeners.forEach(listener => { listener() });
+    }
+
+    function resetBands(): void {
+        bands.fill(0);
+        raw.fill(0);
+        level = 0;
+        lastAnalysedTime = null;
+    }
+
+    function releaseSource(graph: SourceGraph): void {
+        if (graph.stream) {
+            stopTracks(graph.stream);
+        }
+        if (graph.mayCloseContext) {
+            void graph.context.close();
+        }
+    }
+
+    function releaseGraph(graph: AudioGraph): void {
+        graph.sourceNode.disconnect(graph.analysis.analyser);
+        releaseSource(graph);
+    }
+
+    async function acquireSource(): Promise<SourceGraph> {
+        if (source.type === 'mic') {
+            const stream = await getUserMedia({ audio: true });
+            try {
+                const context = createContext();
+                return {
+                    context,
+                    mayCloseContext: true,
+                    sourceNode: context.createMediaStreamSource(stream),
+                    stream
+                };
+            } catch (cause) {
+                stopTracks(stream);
+                throw cause;
+            }
+        }
+
+        if (source.type === 'element') {
+            return bindElement(source.element, createContext);
+        }
+
+        if (source.node.context !== source.context) {
+            throw new Error(
+                'micugl audio: the "node" source was given a node and a context that do not match (node.context is a '
+                + 'different AudioContext). WebAudio cannot connect nodes across contexts. Pass the context the node '
+                + 'was actually created on.'
+            );
+        }
+        assertUsableContext(source.context, 'passed with the "node" source');
+
+        return { context: source.context, mayCloseContext: false, sourceNode: source.node, stream: null };
+    }
+
+    async function beginStart(myGeneration: number): Promise<void> {
+        let acquired: SourceGraph | null = null;
+        try {
+            acquired = await acquireSource();
+
+            if (myGeneration !== generation) {
+                releaseSource(acquired);
+                return;
+            }
+
+            if (acquired.context.state === 'suspended') {
+                await acquired.context.resume();
+            }
+
+            if (myGeneration !== generation) {
+                releaseSource(acquired);
+                return;
+            }
+
+            const analysis = buildAnalysis(acquired.context, currentOptions);
+            acquired.sourceNode.connect(analysis.analyser);
+
+            resetBands();
+            const graph: AudioGraph = { ...acquired, analysis };
+            acquired = null;
+            setState({ kind: 'running', graph });
+            invalidation.request();
+        } catch (cause) {
+            if (acquired !== null) {
+                releaseSource(acquired);
+            }
+
+            const error = toError(cause);
+            if (myGeneration === generation) {
+                resetBands();
+                setState({ kind: 'error', error });
+                invalidation.request();
+            }
+            throw error;
+        }
+    }
+
+    function start(): Promise<void> {
+        if (state.kind === 'running') {
+            return Promise.resolve();
+        }
+        if (state.kind === 'starting') {
+            return state.pending;
+        }
+
+        generation += 1;
+        const run = beginStart(generation);
+        keepRejectionHandled(run);
+        setState({ kind: 'starting', pending: run });
+
+        return run;
+    }
+
+    function stop(): void {
+        if (state.kind !== 'running' && state.kind !== 'starting') {
+            return;
+        }
+
+        generation += 1;
+
+        if (state.kind === 'running') {
+            releaseGraph(state.graph);
+        }
+
+        resetBands();
+        setState({ kind: 'stopped' });
+        invalidation.request();
+    }
+
+    function analyseIfNeeded(timeMs: number): void {
+        if (state.kind !== 'running' || timeMs === lastAnalysedTime) {
+            return;
+        }
+
+        const { analyser, freqData, ranges } = state.graph.analysis;
+        analyser.getByteFrequencyData(freqData);
+        reduceBands(freqData, ranges, raw);
+
+        const dtSeconds = lastAnalysedTime === null
+            ? 0
+            : Math.min(MAX_DT_SECONDS, (timeMs - lastAnalysedTime) / 1000);
+
+        let sum = 0;
+        for (let i = 0; i < bands.length; i++) {
+            bands[i] = applyEnvelope(
+                bands[i],
+                raw[i],
+                dtSeconds,
+                currentOptions.attack,
+                currentOptions.release
+            );
+            sum += bands[i];
+        }
+        level = sum / bands.length;
+
+        lastAnalysedTime = timeMs;
+        invalidation.request();
+    }
+
+    function adoptOptions(next: ResolvedAnalyserOptions): void {
+        if (next.bands !== currentOptions.bands) {
+            bands = new Float32Array(next.bands);
+            raw = new Float32Array(next.bands);
+            level = 0;
+            lastAnalysedTime = null;
+        }
+        currentOptions = next;
+    }
+
+    function reconfigure(next: ResolvedAnalyserOptions): void {
+        if (state.kind !== 'running') {
+            adoptOptions(next);
+            return;
+        }
+
+        const graph = state.graph;
+        const analysis = buildAnalysis(graph.context, next);
+
+        adoptOptions(next);
+
+        graph.sourceNode.disconnect(graph.analysis.analyser);
+        graph.sourceNode.connect(analysis.analyser);
+        graph.analysis = analysis;
+
+        invalidation.request();
+    }
+
+    return {
+        start,
+        stop,
+        analyseIfNeeded,
+        reconfigure,
+        subscribe(onChange) {
+            listeners.add(onChange);
+            return () => { listeners.delete(onChange) };
+        },
+        get bandsScratch() { return bands },
+        get level() { return level },
+        get status() { return state.kind },
+        get error() { return state.kind === 'error' ? state.error : null },
+        invalidation
+    };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -328,6 +328,32 @@ export interface UniformParam<T extends UniformType = UniformType> {
 
 export type UniformParamMap = { [K in UniformType]: UniformParam<K> };
 
+export type BandLayout = 'log' | 'linear';
+
+export type AudioStatus = 'idle' | 'starting' | 'running' | 'stopped' | 'error';
+
+export type AudioSourceSpec =
+  | { type: 'mic' }
+  | { type: 'element'; element: HTMLMediaElement }
+  | { type: 'node'; node: AudioNode; context: AudioContext };
+
+export interface AudioUniformNames {
+  bands?: string;
+  level?: string;
+}
+
+export interface AudioUniformsOptions {
+  bands?: number;
+  fftSize?: number;
+  smoothingTimeConstant?: number;
+  attack?: number;
+  release?: number;
+  minDecibels?: number;
+  maxDecibels?: number;
+  bandLayout?: BandLayout;
+  names?: AudioUniformNames;
+}
+
 // ===================================================
 // JS -> Vector and Matrix
 // ===================================================


### PR DESCRIPTION
Core half of audio-reactive uniforms (track 4). **No React, no hook, no demo, no barrel exports** — T4 owns the public surface and is a thin wrapper over this driver.

- **`src/core/lib/audioBands.ts`** — `computeBandRanges` / `reduceBands` / `applyEnvelope` / `validateAudioOptions`. Pure; no WebAudio types anywhere. The envelope is an asymmetric one-pole (fast attack, slow release) — what music visuals actually want, and what a symmetric `smoothingTimeConstant` structurally cannot express.
- **`src/react/lib/audioAnalyserDriver.ts`** — the WebAudio graph and its lifecycle, with the status modelled as a discriminated union rather than a string assigned in five places (`status` and `error` are derived getters off the single state value, so they cannot disagree).

Analysis is **frame-driven**: it runs lazily inside the uniform read, memoized on frame time. Several uniforms in one frame trigger exactly one `getByteFrequencyData`; pausing the engine pauses analysis for free; and a pinned clock (`setFrame`) repeats the same time, so a deterministic snapshot doesn't spin the analyser.

**Every test injects a fake AudioContext through `deps`. No microphone or camera was ever touched.**

## Three things the plan asked for are wrong, and this doesn't do them

1. **"Close the context only if the driver created it" bricks the element.** `createMediaElementSource` may only ever be called **once per element, for the page's lifetime**. Close the context we made for an `<audio>` and it is permanently bound to a dead context — never visualizable again, possibly never playable. So element contexts are cached in a `WeakMap` and **never closed**; only mic contexts are. The cost is one bounded leaked `AudioContext` per media element per page, which is unavoidable given the one-binding rule.
2. **The "element bound to a foreign context" throw is unreachable** once the design is right — you must *adopt* the cached context, or every remount with a persistent `<audio>` element throws. The three genuinely reachable cases are translated instead (element bound outside micugl, closed cached context, a `node` spec whose `node.context` mismatches), so no opaque `InvalidStateError` ever surfaces — and no dead guard ships.
3. **`stop()` must not disconnect the element's `source → destination` edge**, or stopping the *visualizer* silences the *music*. (Conversely, the mic is never connected to `destination` — feedback howl.) Both tested.

## Review caught two blocking bugs, both invisible

**A throw after the mic is granted leaked the microphone.** `acquireSource()` was `await`ed *inside* the `try`, so the `catch` couldn't see it: tracks were never stopped, **the OS mic indicator stayed lit**, `stop()` early-returned from `'error'` and could not clean up, and a retry granted a **second live stream**. This is reachable in the wild, not theoretical — `computeBandRanges` throws for `{bands: 4, fftSize: 32}` on a 192 kHz interface but not on a 48 kHz one, and `validateAudioOptions` structurally *cannot* catch it because the sample rate isn't known until the context exists.

**A failed `reconfigure()` left a `'running'` driver that threw on every frame**, forever — the options were committed before the analyser was built, so `raw` had the new length while `ranges` had the old. **Its test was hollow**: it chose `bands: 4 → 4`, the one parameterization where nothing is reallocated, so the property it claimed to check could not be violated.

Also: a nullable `pending` promise shadowed the `starting` state variant and could raise a **second permission prompt** — subscribers are notified synchronously, *before* `pending` is assigned, so a re-entrant `start()` slipped the guard and launched a second `getUserMedia`. It lives inside the variant now, and the guard is gone with it. Both reviewers found this independently.

Each fix was verified to **fail when reverted**.

## Evidence the driver actually analyses

The failure mode here is that a driver which never analyses returns a `bandsScratch` full of zeros: nothing throws, nothing logs, and the shader renders a still picture that looks exactly like *"the room is quiet"*. So the tests assert **values over time** — bands tracking a time-varying signal fed through the fake analyser, envelopes rising faster than they fall — not names or key sets. A review sweep of **800k `computeBandRanges` cases** (binCount × sample rate × bands) found zero invariant violations: every band non-empty, monotone, contiguous, in-bounds.

## Known limitation, documented rather than guessed at

A **CORS-tainted media element** makes the browser feed the analyser silent zeros. It is undetectable without a heuristic, so `status` reads `'running'` and the uniforms read 0. Not papered over.

## Manual hardware checklist (for @mcullan — nothing below is machine-verified)

Needs T4's demo scene to exercise. The privacy-critical ones are 6 and 7.

1. **Element playback stays audible.** Play a track, hit start: bars move *and you still hear the music*. Hit stop: bars drop to zero, **music keeps playing**.
2. **Restart / remount** on the same `<audio>` element must work (WeakMap reuse), including navigating away and back.
3. **Autoplay policy.** `start()` on mount with no click → context stays suspended, and if it fails, `status: 'error'` with a real message — never a silent still picture.
4. **Mic grant** → OS indicator lights, bars respond to your voice, **no feedback howl**.
5. **Mic denial** → the `start()` promise rejects, `status: 'error'`, `error.name === 'NotAllowedError'`. Then allow and retry — **the retry must work**.
6. **The privacy one: the OS mic indicator must clear** on `stop()` and on unmount/tab-close.
7. **Stop during the permission prompt** — click mic, click stop while the prompt is open, then allow. The mic must be released immediately; the indicator must not stay lit.
8. **Insecure context** (plain `http://`, not localhost) → a clear "requires a secure context" error, not `undefined is not a function`.
9. **Sanity:** at 48 kHz / fftSize 2048 the bands are `[1,5) [5,27) [27,152) [152,854)`. Kick drums should hit band 0, hi-hats band 3.

734 tests (was 670 at T1).