### PR TITLE
transitions: T2 spring transitions - and a capture guard, because a spring is an accumulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,59 @@ instead of stepping to it:
 - Mounting snaps: the first value a uniform is given is its starting value, never animated
   from zero. Retargeting mid-flight starts the new leg from the current interpolated value.
 
+**Springs** are the other driver: swap `{ duration, easing?, delay?, interpolate? }` for
+`{ type: 'spring', stiffness?, damping?, mass?, restDelta?, restSpeed? }`.
+
+```tsx
+color: {
+    type: 'vec3',
+    value: isDarkMode ? colorStartDark : colorStart,
+    transition: { type: 'spring', stiffness: 170, damping: 26 }
+}
+```
+
+- Defaults: `stiffness: 170`, `damping: 26`, `mass: 1`, `restDelta: 0.001`, `restSpeed: 0.01` -
+  a semi-implicit-Euler damped spring that is just this side of critically damped, so it settles
+  without a visible bounce. Lower the damping (or raise the stiffness) for an overshoot-and-settle
+  feel instead.
+- The spring integrates on a fixed substep - 1/120s, and finer when a stiff or heavily damped
+  config needs it to stay stable - regardless of the actual frame rate, so a janky tab and a smooth
+  one follow the same trajectory instead of the integrator diverging under a large per-frame `dt`.
+  A gap longer than 100ms (a tab waking from being backgrounded) is clamped, so a spring that has
+  been idle for minutes does not lurch through a decade of simulated time on the next frame.
+- Retargeting a spring mid-flight **preserves velocity** instead of resetting it to zero - that is
+  the defining difference from a tween's retarget. A fast double-click chases the new target from
+  wherever the spring already was moving, instead of visibly stopping dead and restarting.
+- `stiffness`, `damping` and `mass` must be finite and strictly positive; `restDelta` and
+  `restSpeed` must be finite and non-negative; and a spring so stiff, or so light, that no
+  affordable substep could integrate it stably throws at config resolution rather than uploading
+  the garbage a diverging integrator produces. `damping: 0` throws too: an undamped spring never
+  comes to rest, so it would oscillate around its target forever, animating and holding the render
+  loop awake for as long as it is mounted instead of letting it go idle.
+- **A spring is an accumulator, not a function of time.** A tween's value at frame `n` depends only
+  on `n`; a spring's depends on the whole sequence of frames it has been sampled at. So an
+  in-flight spring cannot be reconstructed from a pinned frame the way a tween can: capture a
+  spring by replaying the sequence from its start, or let it settle before capturing. Springs are
+  still deterministic - the same sequence of sample times always produces the same output.
+- **So the deterministic-capture calls throw while a spring is in flight**, rather than handing you
+  a frame that will not reproduce: `renderSequence()`, and `renderToBlob({ frame })` /
+  `renderToDataURL({ frame })` (plus the seeded `steps` export on `PingPongShaderEngine`) all pin a
+  time the spring has not actually been integrated to. Wait for the spring to settle, or use a
+  tween. The calls that do not synthesize a time are untouched, because they are honest about what
+  they capture: `renderToBlob()` with no `frame` grabs the live clock - whatever is on screen right
+  now - and `record()`/`captureStream()` record in real time, where a spring animating through the
+  take is the whole point. An in-flight *tween* never blocks a capture: it is a pure function of
+  the frame number, so `setFrame(n)` reproduces it exactly.
+- The `?scene=transitions` demo has a tween/spring toggle next to the palette buttons - click a
+  palette, then a different one before the first animation finishes, to see mid-flight
+  retargeting on both drivers.
+
 **Transitions run on the engine clock, not on wall time.** `speed` scales them (`speed={0.5}`
-halves their pace, `speed={0}` freezes them), and `setFrame(n)` pins them, which is what makes
-them deterministic: the same frame number always produces the same interpolated value, so
-`renderSequence()` and `renderToBlob({ frame })` capture transitions exactly.
+halves their pace, `speed={0}` freezes them), and `setFrame(n)` pins them. For a tween that is what
+makes it deterministic: the same frame number always produces the same interpolated value, so
+`renderSequence()` and `renderToBlob({ frame })` capture tweens exactly. A spring is integrated
+across frames rather than indexed by them, so those same calls throw while one is in flight - see
+the spring caveat above.
 
 **A motion gate snaps them.** Under `reducedMotion="static-frame"`/`"pause"` (the default, when
 the user has `prefers-reduced-motion: reduce` or Save-Data on) the render clock is frozen, so a

--- a/demo/scenes/Transitions.tsx
+++ b/demo/scenes/Transitions.tsx
@@ -4,8 +4,10 @@ import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
 import { vec3 } from '../../src/core/lib/vectorUtils';
 import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
 import { useReducedMotion } from '../../src/react/hooks/useReducedMotion';
-import type { UniformParam } from '../../src/types';
+import type { UniformParam, UniformTransitionConfig } from '../../src/types';
 import { QUAD_VERTEX, TRANSITION_FRAGMENT } from './shaders';
+
+type TransitionMode = 'tween' | 'spring';
 
 interface Palette {
     name: string;
@@ -31,22 +33,29 @@ const config = createShaderConfig({
     }
 });
 
+const transitionForMode = (mode: TransitionMode): UniformTransitionConfig =>
+    mode === 'spring'
+        ? { type: 'spring', stiffness: 180, damping: 12 }
+        : { duration: 600, easing: 'easeInOut' };
+
 export const Transitions = () => {
     const [paletteIndex, setPaletteIndex] = useState(0);
+    const [mode, setMode] = useState<TransitionMode>('tween');
     const reducedMotionActive = useReducedMotion();
     const palette = PALETTES[paletteIndex];
+    const transition = transitionForMode(mode);
 
     const uniforms: Record<string, UniformParam> = {
-        swirl: { type: 'float', value: palette.swirl, transition: { duration: 600, easing: 'easeInOut' } },
+        swirl: { type: 'float', value: palette.swirl, transition },
         colorStart: {
             type: 'vec3',
             value: vec3(palette.colorStart),
-            transition: { duration: 600, easing: 'easeInOut' }
+            transition
         },
         colorEnd: {
             type: 'vec3',
             value: vec3(palette.colorEnd),
-            transition: { duration: 600, easing: 'easeInOut' }
+            transition
         }
     };
 
@@ -94,14 +103,35 @@ export const Transitions = () => {
                         </button>
                     ))}
                 </div>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                    {(['tween', 'spring'] as const).map(entry => (
+                        <button
+                            key={entry}
+                            type='button'
+                            onClick={() => { setMode(entry) }}
+                            style={{
+                                padding: '6px 10px',
+                                background: mode === entry ? '#16a34a' : '#0f3460',
+                                border: 'none',
+                                borderRadius: '4px',
+                                color: '#fff',
+                                cursor: 'pointer'
+                            }}
+                        >
+                            {entry}
+                        </button>
+                    ))}
+                </div>
                 <div>
-                    Click palettes fast to see mid-flight retargeting: each click starts a new 600ms
-                    tween from wherever the current colors and swirl amount already are, not from the start.
+                    Click palettes fast to see mid-flight retargeting: each click starts a new leg from
+                    wherever the current colors and swirl amount already are, not from the start. The
+                    tween restarts its timing; the spring keeps its velocity, so a fast click chases the
+                    new target instead of stuttering.
                 </div>
                 <div>
                     useReducedMotion(): {String(reducedMotionActive)}
                     {reducedMotionActive
-                        ? ' (OS reduced-motion is on, so transitions snap instantly instead of tweening.)'
+                        ? ' (OS reduced-motion is on, so transitions snap instantly instead of animating.)'
                         : ''}
                 </div>
             </div>

--- a/src/core/lib/motionDrivers.test.ts
+++ b/src/core/lib/motionDrivers.test.ts
@@ -6,10 +6,14 @@ import {
     retargetMotion,
     sampleMotion
 } from '@/core/lib/motionDrivers';
-import type { UniformTransitionConfig } from '@/types';
+import type { SpringTransitionConfig, UniformTransitionConfig } from '@/types';
 
 function tween(config: UniformTransitionConfig) {
-    return resolveTransitionConfig(config);
+    const resolved = resolveTransitionConfig(config);
+    if (resolved.kind !== 'tween') {
+        throw new Error('expected a tween config');
+    }
+    return resolved;
 }
 
 describe('resolveTransitionConfig', () => {
@@ -178,5 +182,244 @@ describe('retargetMotion + sampleMotion (tween)', () => {
 
         expect(settled).toBe(true);
         expect(state.current[0]).toBe(5);
+    });
+});
+
+function spring(config: SpringTransitionConfig) {
+    const resolved = resolveTransitionConfig(config);
+    if (resolved.kind !== 'spring') {
+        throw new Error('expected a spring config');
+    }
+    return resolved;
+}
+
+describe('resolveTransitionConfig (spring)', () => {
+    it('applies the documented defaults', () => {
+        const resolved = spring({ type: 'spring' });
+        expect(resolved.stiffness).toBe(170);
+        expect(resolved.damping).toBe(26);
+        expect(resolved.mass).toBe(1);
+        expect(resolved.restDelta).toBe(0.001);
+        expect(resolved.restSpeed).toBe(0.01);
+        expect(resolved.substepSeconds).toBe(1 / 120);
+    });
+
+    it('shrinks the substep below 1/120s for a spring that semi-implicit Euler cannot integrate stably at 1/120s', () => {
+        expect(spring({ type: 'spring', stiffness: 1200, damping: 20 }).substepSeconds).toBe(1 / 120);
+        expect(spring({ type: 'spring', stiffness: 100, damping: 300 }).substepSeconds).toBeLessThan(1 / 120);
+        expect(spring({ type: 'spring', stiffness: 170, damping: 30, mass: 0.1 }).substepSeconds).toBeLessThan(1 / 120);
+        expect(spring({ type: 'spring', stiffness: 200_000 }).substepSeconds).toBeLessThan(1 / 120);
+    });
+
+    it('throws on a spring so stiff that a stable substep costs more than a frame can afford', () => {
+        expect(() => spring({ type: 'spring', stiffness: 1e12 })).toThrow(/substep/);
+        expect(() => spring({ type: 'spring', stiffness: 170, mass: 1e-9 })).toThrow(/substep/);
+    });
+
+    it('throws on stiffness <= 0', () => {
+        expect(() => spring({ type: 'spring', stiffness: 0 })).toThrow(/stiffness/);
+        expect(() => spring({ type: 'spring', stiffness: -5 })).toThrow(/stiffness/);
+    });
+
+    it('throws on damping <= 0', () => {
+        expect(() => spring({ type: 'spring', damping: -1 })).toThrow(/damping/);
+        expect(() => spring({ type: 'spring', damping: 0 })).toThrow(/damping/);
+    });
+
+    it('says why an undamped spring is rejected: it never comes to rest, so the loop never idles', () => {
+        expect(() => spring({ type: 'spring', damping: 0 })).toThrow(/never comes to rest/);
+        expect(() => spring({ type: 'spring', damping: 0 })).toThrow(/render loop awake/);
+    });
+
+    it('throws on mass <= 0', () => {
+        expect(() => spring({ type: 'spring', mass: 0 })).toThrow(/mass/);
+        expect(() => spring({ type: 'spring', mass: -1 })).toThrow(/mass/);
+    });
+
+    it('throws on a negative restDelta', () => {
+        expect(() => spring({ type: 'spring', restDelta: -0.1 })).toThrow(/restDelta/);
+    });
+
+    it('throws on a negative restSpeed', () => {
+        expect(() => spring({ type: 'spring', restSpeed: -0.1 })).toThrow(/restSpeed/);
+    });
+
+    it('throws on every non-finite field', () => {
+        expect(() => spring({ type: 'spring', stiffness: Number.NaN })).toThrow(/stiffness/);
+        expect(() => spring({ type: 'spring', stiffness: Number.POSITIVE_INFINITY })).toThrow(/stiffness/);
+        expect(() => spring({ type: 'spring', damping: Number.NaN })).toThrow(/damping/);
+        expect(() => spring({ type: 'spring', mass: Number.NaN })).toThrow(/mass/);
+        expect(() => spring({ type: 'spring', restDelta: Number.NaN })).toThrow(/restDelta/);
+        expect(() => spring({ type: 'spring', restSpeed: Number.NaN })).toThrow(/restSpeed/);
+    });
+});
+
+describe('retargetMotion + sampleMotion (spring)', () => {
+    it('converges to the target and settles once every element is under restDelta/restSpeed, snapping to the exact target', () => {
+        const config = spring({ type: 'spring' });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        let settled = false;
+        let t = 0;
+        for (let i = 0; i < 5000 && !settled; i++) {
+            t += 16;
+            settled = sampleMotion(state, t);
+        }
+
+        expect(settled).toBe(true);
+        expect(state.settled).toBe(true);
+        expect(state.current[0]).toBe(10);
+        expect(state.velocity[0]).toBe(0);
+    });
+
+    it('overshoots and returns for an underdamped spring, proving the integrator actually ran (a snap cannot do this)', () => {
+        const config = spring({ type: 'spring', stiffness: 1200, damping: 20 });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        let t = 0;
+        let peak = -Infinity;
+        for (const step of [25, 25, 25, 25]) {
+            t += step;
+            sampleMotion(state, t);
+            peak = Math.max(peak, state.current[0]);
+        }
+        expect(peak).toBeGreaterThan(10);
+
+        let trough = Infinity;
+        for (const step of [50, 50, 100, 100]) {
+            t += step;
+            sampleMotion(state, t);
+            trough = Math.min(trough, state.current[0]);
+        }
+        expect(trough).toBeLessThan(10);
+    });
+
+    it('a retarget preserves velocity for a spring, unlike a tween (the defining spring property)', () => {
+        const config = spring({ type: 'spring', stiffness: 170, damping: 10 });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+
+        sampleMotion(state, 0);
+        sampleMotion(state, 50);
+        sampleMotion(state, 100);
+
+        const velocityBeforeRetarget = state.velocity[0];
+        expect(velocityBeforeRetarget).not.toBe(0);
+        const currentBeforeRetarget = state.current[0];
+
+        retargetMotion(state, [20], config);
+
+        expect(state.velocity[0]).toBe(velocityBeforeRetarget);
+        expect(state.current[0]).toBe(currentBeforeRetarget);
+        expect(state.lastTime).toBeNull();
+    });
+
+    it('a tween retarget resets velocity to zero, unlike a spring retarget', () => {
+        const config = tween({ duration: 100 });
+        const state = createMotionState(config, new Float32Array([0]));
+        state.velocity[0] = 5;
+
+        retargetMotion(state, [10], config);
+
+        expect(state.velocity[0]).toBe(0);
+    });
+
+    it('clamps the dt of a 10-second idle gap to 100ms, so a post-idle wake does not explode', () => {
+        const config = spring({ type: 'spring' });
+
+        const wokeAfterTenSeconds = createMotionState(config, new Float32Array([0]));
+        retargetMotion(wokeAfterTenSeconds, [10], config);
+        sampleMotion(wokeAfterTenSeconds, 0);
+        sampleMotion(wokeAfterTenSeconds, 10_000);
+
+        const sampledAtOneHundredMs = createMotionState(config, new Float32Array([0]));
+        retargetMotion(sampledAtOneHundredMs, [10], config);
+        sampleMotion(sampledAtOneHundredMs, 0);
+        sampleMotion(sampledAtOneHundredMs, 100);
+
+        expect(Number.isFinite(wokeAfterTenSeconds.current[0])).toBe(true);
+        expect(wokeAfterTenSeconds.current[0]).toBe(sampledAtOneHundredMs.current[0]);
+    });
+
+    it('fixed 1/120s substeps keep a coarse 66ms sampling cadence close to a fine 1ms reference, instead of diverging into instability', () => {
+        const config = spring({ type: 'spring', stiffness: 1200, damping: 20 });
+
+        const coarse = createMotionState(config, new Float32Array([0]));
+        retargetMotion(coarse, [10], config);
+        let tCoarse = 0;
+        for (let i = 0; i < 6; i++) {
+            tCoarse += 66;
+            sampleMotion(coarse, tCoarse);
+        }
+
+        const fine = createMotionState(config, new Float32Array([0]));
+        retargetMotion(fine, [10], config);
+        for (let tFine = 1; tFine <= tCoarse; tFine++) {
+            sampleMotion(fine, tFine);
+        }
+
+        expect(Number.isFinite(coarse.current[0])).toBe(true);
+        expect(Math.abs(coarse.current[0] - fine.current[0])).toBeLessThan(1);
+    });
+
+    it('is deterministic: replaying the same time sequence produces bit-identical output', () => {
+        const config = spring({ type: 'spring' });
+        const timeSequence = [0, 16, 33, 50, 90, 140, 260, 500];
+
+        const run = (): number[] => {
+            const state = createMotionState(config, new Float32Array([0]));
+            retargetMotion(state, [10], config);
+            return timeSequence.map(t => {
+                sampleMotion(state, t);
+                return state.current[0];
+            });
+        };
+
+        expect(run()).toEqual(run());
+    });
+
+    it.each([
+        ['heavily damped', { type: 'spring', stiffness: 100, damping: 300 }],
+        ['light mass, ordinary damping', { type: 'spring', stiffness: 170, damping: 30, mass: 0.1 }],
+        ['very stiff', { type: 'spring', stiffness: 200_000, damping: 26 }],
+        ['very stiff and heavily damped', { type: 'spring', stiffness: 200_000, damping: 4000 }]
+    ] satisfies [string, SpringTransitionConfig][])(
+        'a %s spring stays inside a sane envelope on every frame instead of diverging into garbage uploads',
+        (_label, config) => {
+            const resolved = spring(config);
+            const state = createMotionState(resolved, new Float32Array([0]));
+            retargetMotion(state, [10], resolved);
+
+            const trajectory: number[] = [];
+            let settled = false;
+            let t = 0;
+            for (let i = 0; i < 3000 && !settled; i++) {
+                t += 16;
+                settled = sampleMotion(state, t);
+                trajectory.push(state.current[0]);
+            }
+
+            expect(trajectory.every(value => Number.isFinite(value))).toBe(true);
+            expect(Math.min(...trajectory)).toBeGreaterThan(-5);
+            expect(Math.max(...trajectory)).toBeLessThan(25);
+            expect(settled).toBe(true);
+            expect(state.current[0]).toBe(10);
+        }
+    );
+
+    it('a non-finite velocity can never masquerade as a settled spring (NaN fails every rest comparison)', () => {
+        const config = spring({ type: 'spring' });
+        const state = createMotionState(config, new Float32Array([0]));
+        retargetMotion(state, [10], config);
+        sampleMotion(state, 0);
+
+        state.velocity[0] = Number.NaN;
+        state.current[0] = Number.NaN;
+
+        expect(sampleMotion(state, 16)).toBe(false);
+        expect(state.settled).toBe(false);
+        expect(state.current[0]).not.toBe(10);
     });
 });

--- a/src/core/lib/motionDrivers.ts
+++ b/src/core/lib/motionDrivers.ts
@@ -1,23 +1,46 @@
 import { resolveEasing } from '@/core/lib/easing';
-import type { EasingFn, UniformTransitionConfig } from '@/types';
+import type {
+    EasingFn,
+    SpringTransitionConfig,
+    TweenTransitionConfig,
+    UniformTransitionConfig
+} from '@/types';
 
 export interface ResolvedTweenConfig {
+    kind: 'tween';
     duration: number;
     delay: number;
     easing: EasingFn;
     interpolate?: (from: ArrayLike<number>, to: ArrayLike<number>, t: number, out: Float32Array) => void;
 }
 
-export type ResolvedTransitionConfig = ResolvedTweenConfig;
+export interface ResolvedSpringConfig {
+    kind: 'spring';
+    stiffness: number;
+    damping: number;
+    mass: number;
+    restDelta: number;
+    restSpeed: number;
+    substepSeconds: number;
+}
+
+export type ResolvedTransitionConfig = ResolvedTweenConfig | ResolvedSpringConfig;
 
 export interface MotionState {
     from: Float32Array;
     to: Float32Array;
     current: Float32Array;
+    velocity: Float32Array;
     startTime: number | null;
+    lastTime: number | null;
     settled: boolean;
     config: ResolvedTransitionConfig;
 }
+
+const SPRING_SUBSTEP_SECONDS = 1 / 120;
+const SPRING_MAX_DT_SECONDS = 0.1;
+const SPRING_STABILITY_MARGIN = 0.5;
+const SPRING_MAX_SUBSTEPS_PER_FRAME = 1000;
 
 function clamp01(value: number): number {
     if (value < 0) return 0;
@@ -31,7 +54,66 @@ function lerpInto(from: Float32Array, to: Float32Array, t: number, out: Float32A
     }
 }
 
-export function resolveTransitionConfig(config: UniformTransitionConfig): ResolvedTransitionConfig {
+function springSubstepSeconds(stiffness: number, damping: number, mass: number): number {
+    const omegaSquared = stiffness / mass;
+    const dampingRate = damping / mass;
+    const stabilityLimit =
+        (Math.sqrt(dampingRate * dampingRate + 4 * omegaSquared) - dampingRate) / omegaSquared;
+
+    return Math.min(SPRING_SUBSTEP_SECONDS, stabilityLimit * SPRING_STABILITY_MARGIN);
+}
+
+function resolveSpringConfig(config: SpringTransitionConfig): ResolvedSpringConfig {
+    const stiffness = config.stiffness ?? 170;
+    if (!Number.isFinite(stiffness) || stiffness <= 0) {
+        throw new Error(
+            `micugl transitions: "stiffness" must be a finite number > 0, received ${JSON.stringify(stiffness)}`
+        );
+    }
+
+    const damping = config.damping ?? 26;
+    if (!Number.isFinite(damping) || damping <= 0) {
+        throw new Error(
+            `micugl transitions: "damping" must be a finite number > 0, received ${JSON.stringify(damping)}. An `
+            + 'undamped spring never comes to rest: it would oscillate around its target forever, animating and '
+            + 'keeping the render loop awake for as long as it is mounted instead of letting it go idle.'
+        );
+    }
+
+    const mass = config.mass ?? 1;
+    if (!Number.isFinite(mass) || mass <= 0) {
+        throw new Error(
+            `micugl transitions: "mass" must be a finite number > 0, received ${JSON.stringify(mass)}`
+        );
+    }
+
+    const restDelta = config.restDelta ?? 0.001;
+    if (!Number.isFinite(restDelta) || restDelta < 0) {
+        throw new Error(
+            `micugl transitions: "restDelta" must be a finite number >= 0, received ${JSON.stringify(restDelta)}`
+        );
+    }
+
+    const restSpeed = config.restSpeed ?? 0.01;
+    if (!Number.isFinite(restSpeed) || restSpeed < 0) {
+        throw new Error(
+            `micugl transitions: "restSpeed" must be a finite number >= 0, received ${JSON.stringify(restSpeed)}`
+        );
+    }
+
+    const substepSeconds = springSubstepSeconds(stiffness, damping, mass);
+    if (SPRING_MAX_DT_SECONDS / substepSeconds > SPRING_MAX_SUBSTEPS_PER_FRAME) {
+        throw new Error(
+            `micugl transitions: a spring with stiffness ${String(stiffness)}, damping ${String(damping)} and mass `
+            + `${String(mass)} needs a ${substepSeconds.toExponential(2)}s integration substep to stay stable, which `
+            + 'is far finer than one frame can afford. Lower "stiffness" or "damping", or raise "mass".'
+        );
+    }
+
+    return { kind: 'spring', stiffness, damping, mass, restDelta, restSpeed, substepSeconds };
+}
+
+function resolveTweenConfig(config: TweenTransitionConfig): ResolvedTweenConfig {
     const duration = config.duration;
     if (!Number.isFinite(duration) || duration < 0) {
         throw new Error(
@@ -47,6 +129,7 @@ export function resolveTransitionConfig(config: UniformTransitionConfig): Resolv
     }
 
     return {
+        kind: 'tween',
         duration,
         delay,
         easing: resolveEasing(config.easing),
@@ -54,12 +137,21 @@ export function resolveTransitionConfig(config: UniformTransitionConfig): Resolv
     };
 }
 
+export function resolveTransitionConfig(config: UniformTransitionConfig): ResolvedTransitionConfig {
+    if (config.type === 'spring') {
+        return resolveSpringConfig(config);
+    }
+    return resolveTweenConfig(config);
+}
+
 export function createMotionState(config: ResolvedTransitionConfig, initial: Float32Array): MotionState {
     return {
         from: initial.slice(),
         to: initial.slice(),
         current: initial.slice(),
+        velocity: new Float32Array(initial.length),
         startTime: null,
+        lastTime: null,
         settled: true,
         config
     };
@@ -73,16 +165,16 @@ export function retargetMotion(
     state.from.set(state.current);
     state.to.set(target);
     state.startTime = null;
+    state.lastTime = null;
     state.settled = false;
     state.config = config;
+    if (config.kind === 'tween') {
+        state.velocity.fill(0);
+    }
 }
 
-export function sampleMotion(state: MotionState, timeMs: number): boolean {
-    if (state.settled) {
-        return true;
-    }
-
-    const { duration, delay, easing, interpolate } = state.config;
+function sampleTween(state: MotionState, timeMs: number, config: ResolvedTweenConfig): boolean {
+    const { duration, delay, easing, interpolate } = config;
 
     state.startTime ??= timeMs;
 
@@ -103,4 +195,57 @@ export function sampleMotion(state: MotionState, timeMs: number): boolean {
     }
 
     return false;
+}
+
+function integrateSpringStep(state: MotionState, config: ResolvedSpringConfig, dtSeconds: number): void {
+    const { stiffness, damping, mass } = config;
+    for (let i = 0; i < state.current.length; i++) {
+        const displacement = state.current[i] - state.to[i];
+        const springForce = -stiffness * displacement;
+        const dampingForce = -damping * state.velocity[i];
+        const acceleration = (springForce + dampingForce) / mass;
+        state.velocity[i] += acceleration * dtSeconds;
+        state.current[i] += state.velocity[i] * dtSeconds;
+    }
+}
+
+function sampleSpring(state: MotionState, timeMs: number, config: ResolvedSpringConfig): boolean {
+    state.lastTime ??= timeMs;
+
+    let dtSeconds = (timeMs - state.lastTime) / 1000;
+    if (dtSeconds < 0) dtSeconds = 0;
+    dtSeconds = Math.min(dtSeconds, SPRING_MAX_DT_SECONDS);
+    state.lastTime = timeMs;
+
+    let remaining = dtSeconds;
+    while (remaining > 0) {
+        const step = Math.min(config.substepSeconds, remaining);
+        integrateSpringStep(state, config, step);
+        remaining -= step;
+    }
+
+    for (let i = 0; i < state.current.length; i++) {
+        const atRest =
+            Math.abs(state.velocity[i]) < config.restSpeed
+            && Math.abs(state.current[i] - state.to[i]) < config.restDelta;
+        if (!atRest) {
+            return false;
+        }
+    }
+
+    state.current.set(state.to);
+    state.velocity.fill(0);
+    state.settled = true;
+
+    return true;
+}
+
+export function sampleMotion(state: MotionState, timeMs: number): boolean {
+    if (state.settled) {
+        return true;
+    }
+
+    return state.config.kind === 'tween'
+        ? sampleTween(state, timeMs, state.config)
+        : sampleSpring(state, timeMs, state.config);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export type {
     ShaderRenderCallback,
     ShaderResources,
     ShaderUniformLocations,
+    SpringTransitionConfig,
     TextureBinding,
     TextureOptions,
     TweenTransitionConfig,

--- a/src/react/components/base/BaseInstancedShaderComponent.tsx
+++ b/src/react/components/base/BaseInstancedShaderComponent.tsx
@@ -64,7 +64,7 @@ const BaseInstancedShaderComponentImpl = forwardRef<ShaderHandle, BaseInstancedS
     renderOptions = RENDER_OPTIONS
 }, ref) => {
     const programConfigs = { [programId]: shaderConfig };
-    const { updaters, port, invalidation } = useUniformUpdaters(
+    const { updaters, port, invalidation, springsInFlight } = useUniformUpdaters(
         programId,
         uniforms,
         { skipDefaultUniforms, reducedMotion, saveData }
@@ -82,6 +82,7 @@ const BaseInstancedShaderComponentImpl = forwardRef<ShaderHandle, BaseInstancedS
             uniformUpdaters={updaters}
             debugPortRef={debugPortRef}
             invalidation={invalidation}
+            springsInFlight={springsInFlight}
             width={width}
             height={height}
             pixelRatio={pixelRatio}

--- a/src/react/components/base/BasePingPongShaderComponent.tsx
+++ b/src/react/components/base/BasePingPongShaderComponent.tsx
@@ -79,7 +79,7 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
         programConfigs[actualSecondaryProgramId] = secondaryShaderConfig;
     }
 
-    const { passes, framebuffers, port, invalidation } = usePingPongPasses({
+    const { passes, framebuffers, port, invalidation, springsInFlight } = usePingPongPasses({
         programId,
         secondaryProgramId: secondaryShaderConfig ? actualSecondaryProgramId : undefined,
         iterations,
@@ -118,6 +118,7 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
             framebuffers={framebuffers}
             debugPortRef={debugPortRef}
             invalidation={invalidation}
+            springsInFlight={springsInFlight}
             {...workerProps}
             className={className}
             style={style}

--- a/src/react/components/base/BaseShaderComponent.transition.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.transition.test.tsx
@@ -95,6 +95,31 @@ const Scene = ({
     />
 );
 
+interface SpringSceneProps {
+    value: number;
+    frameloop?: Frameloop;
+}
+
+const SpringScene = ({ value, frameloop = 'demand' }: SpringSceneProps) => (
+    <BaseShaderComponent
+        programId={PROGRAM_ID}
+        shaderConfig={CONFIG}
+        uniforms={{
+            swirl: {
+                type: 'float',
+                value,
+                transition: { type: 'spring', stiffness: 1200, damping: 20 }
+            }
+        }}
+        width={WIDTH}
+        height={HEIGHT}
+        useDevicePixelRatio={false}
+        frameloop={frameloop}
+        reducedMotion='ignore'
+        saveData='ignore'
+    />
+);
+
 function mockReducedMotionActive(): void {
     window.matchMedia = ((query: string) => ({
         matches: query === '(prefers-reduced-motion: reduce)',
@@ -172,5 +197,41 @@ describe('a real uniform transition, driven through a mounted BaseShaderComponen
 
         frames.tick(2_000_000);
         expect(uploads('u_swirl')).toEqual([0, 10]);
+    });
+
+    it('a spring prop change under frameloop="demand" self-sustains the rAF chain, overshoots and returns, lands exactly on the target, then drains', async () => {
+        await mount(<SpringScene value={0} />);
+        frames.tick(0);
+        expect(uploads('u_swirl')).toEqual([0]);
+        expect(frames.pending()).toBe(0);
+
+        await mount(<SpringScene value={10} />);
+        expect(frames.pending()).toBe(1);
+
+        const sampleTimes = [
+            1000, 1025, 1050, 1075, 1100, 1150, 1200, 1300, 1400, 1500, 1700, 1900, 1950, 2000, 2100
+        ];
+        for (const time of sampleTimes.slice(0, -1)) {
+            frames.tick(time);
+            expect(frames.pending()).toBe(1);
+        }
+        frames.tick(sampleTimes[sampleTimes.length - 1]);
+        expect(frames.pending()).toBe(0);
+
+        const values = uploads('u_swirl') as number[];
+        expect(values[0]).toBe(0);
+
+        const peakIndex = values.indexOf(Math.max(...values));
+        expect(values[peakIndex]).toBeGreaterThan(10);
+
+        const troughAfterPeak = Math.min(...values.slice(peakIndex + 1));
+        expect(troughAfterPeak).toBeLessThan(10);
+
+        expect(values[values.length - 1]).toBe(10);
+
+        const uploadCountAtSettle = values.length;
+        frames.tick(2200);
+        expect(frames.pending()).toBe(0);
+        expect(uploads('u_swirl').length).toBe(uploadCountAtSettle);
     });
 });

--- a/src/react/components/base/BaseShaderComponent.tsx
+++ b/src/react/components/base/BaseShaderComponent.tsx
@@ -59,7 +59,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     renderOptions = RENDER_OPTIONS
 }, ref) => {
     const programConfigs = { [programId]: shaderConfig };
-    const { updaters, port, invalidation } = useUniformUpdaters(
+    const { updaters, port, invalidation, springsInFlight } = useUniformUpdaters(
         programId,
         uniforms,
         { skipDefaultUniforms, reducedMotion, saveData }
@@ -79,6 +79,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
             uniformUpdaters={updaters}
             debugPortRef={debugPortRef}
             invalidation={invalidation}
+            springsInFlight={springsInFlight}
             {...workerProps}
             workerSkipDefaultUniforms={skipDefaultUniforms}
             width={width}

--- a/src/react/components/base/springCapture.test.tsx
+++ b/src/react/components/base/springCapture.test.tsx
@@ -1,0 +1,298 @@
+import { act, type ReactElement, type RefObject } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { GL_NEAREST, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
+import { BasePingPongShaderComponent } from '@/react/components/base/BasePingPongShaderComponent';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type {
+    FramebufferOptions,
+    PingPongShaderHandle,
+    SequenceOptions,
+    ShaderHandle,
+    UniformTransitionConfig
+} from '@/types';
+
+const PROGRAM_ID = 'spring-capture';
+const SECONDARY_PROGRAM_ID = 'spring-capture-secondary';
+const WIDTH = 64;
+const HEIGHT = 32;
+
+const SPRING: UniformTransitionConfig = { type: 'spring', stiffness: 1200, damping: 20 };
+const TWEEN: UniformTransitionConfig = { duration: 100, easing: 'linear' };
+
+const SETTLE_TIMES = [
+    1000, 1025, 1050, 1075, 1100, 1150, 1200, 1300, 1400, 1500, 1700, 1900, 1950, 2000, 2100
+];
+
+const SEQUENCE: SequenceOptions = { frames: 2, fps: 30 };
+
+const BYTE_FRAMEBUFFERS: FramebufferOptions = {
+    width: 0,
+    height: 0,
+    textureCount: 1,
+    textureOptions: { type: GL_UNSIGNED_BYTE, minFilter: GL_NEAREST, magFilter: GL_NEAREST }
+};
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_swirl: 'float' }
+});
+
+class MediaRecorderStub {
+    static isTypeSupported = (type: string): boolean => type === 'video/webm;codecs=vp9';
+    state = 'inactive';
+    addEventListener = (): void => undefined;
+    start = (): void => { recorderStarts += 1 };
+    stop = (): void => undefined;
+}
+
+class ImageDataStub {
+    constructor(
+        public data: Uint8ClampedArray,
+        public width: number,
+        public height: number
+    ) {}
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let recorderStarts = 0;
+let originalGetContext: unknown;
+let originalToBlob: unknown;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stub = createGLStub();
+    recorderStarts = 0;
+
+    const canvasProto = HTMLCanvasElement.prototype as unknown as {
+        getContext: unknown;
+        toBlob: unknown;
+    };
+    originalGetContext = canvasProto.getContext;
+    originalToBlob = canvasProto.toBlob;
+
+    canvasProto.getContext = function stubGetContext(type: string): unknown {
+        return type === '2d' ? { putImageData: () => undefined } : stub.gl;
+    };
+    canvasProto.toBlob = function stubToBlob(callback: (blob: Blob) => void, type?: string): void {
+        callback(new Blob([], { type: type ?? 'image/png' }));
+    };
+
+    (stub.gl.canvas as unknown as { captureStream: () => unknown }).captureStream =
+        () => ({ getTracks: () => [] });
+
+    (globalThis as { ImageData?: unknown }).ImageData = ImageDataStub;
+    (globalThis as { MediaRecorder?: unknown }).MediaRecorder = MediaRecorderStub;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+
+    const canvasProto = HTMLCanvasElement.prototype as unknown as {
+        getContext: unknown;
+        toBlob: unknown;
+    };
+    canvasProto.getContext = originalGetContext;
+    canvasProto.toBlob = originalToBlob;
+
+    delete (globalThis as { ImageData?: unknown }).ImageData;
+    delete (globalThis as { MediaRecorder?: unknown }).MediaRecorder;
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+interface SceneProps {
+    handleRef: RefObject<ShaderHandle | null>;
+    value: number;
+    transition: UniformTransitionConfig;
+}
+
+const Scene = ({ handleRef, value, transition }: SceneProps) => (
+    <BaseShaderComponent
+        ref={handleRef}
+        programId={PROGRAM_ID}
+        shaderConfig={CONFIG}
+        uniforms={{ swirl: { type: 'float', value, transition } }}
+        width={WIDTH}
+        height={HEIGHT}
+        useDevicePixelRatio={false}
+        frameloop='demand'
+        reducedMotion='ignore'
+        saveData='ignore'
+    />
+);
+
+interface PingPongSceneProps {
+    handleRef: RefObject<PingPongShaderHandle | null>;
+    value: number;
+}
+
+const PingPongScene = ({ handleRef, value }: PingPongSceneProps) => (
+    <BasePingPongShaderComponent
+        ref={handleRef}
+        programId={PROGRAM_ID}
+        shaderConfig={CONFIG}
+        secondaryProgramId={SECONDARY_PROGRAM_ID}
+        secondaryShaderConfig={CONFIG}
+        uniforms={{ swirl: { type: 'float', value: 1 } }}
+        secondaryUniforms={{ swirl: { type: 'float', value, transition: SPRING } }}
+        framebufferOptions={BYTE_FRAMEBUFFERS}
+        width={WIDTH}
+        height={HEIGHT}
+        useDevicePixelRatio={false}
+        frameloop='demand'
+        reducedMotion='ignore'
+        saveData='ignore'
+    />
+);
+
+function settle(): void {
+    for (const time of SETTLE_TIMES) {
+        frames.tick(time);
+    }
+}
+
+describe('deterministic capture with a spring transition in flight, through mounted components', () => {
+    it('renderSequence throws while a spring is in flight, and the message says why', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        await mount(<Scene handleRef={handleRef} value={0} transition={SPRING} />);
+        frames.tick(0);
+
+        await mount(<Scene handleRef={handleRef} value={10} transition={SPRING} />);
+        frames.tick(1000);
+        expect(frames.pending()).toBe(1);
+
+        expect(() => handleRef.current?.renderSequence(SEQUENCE))
+            .toThrow(/ShaderEngine\.renderSequence: a spring transition is still in flight/);
+        expect(() => handleRef.current?.renderSequence(SEQUENCE)).toThrow(/would not reproduce/);
+    });
+
+    it('renderToBlob({ frame }) rejects while a spring is in flight, and never reaches the pixel read', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        await mount(<Scene handleRef={handleRef} value={0} transition={SPRING} />);
+        frames.tick(0);
+
+        await mount(<Scene handleRef={handleRef} value={10} transition={SPRING} />);
+        frames.tick(1000);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob({ frame: 30 }))
+            .rejects.toThrow(/ShaderEngine\.renderToBlob: a spring transition is still in flight/);
+        expect(stub.readPixelsCalls.length).toBe(0);
+
+        expect(() => handleRef.current?.renderToDataURL({ frame: 30 }))
+            .toThrow(/a spring transition is still in flight/);
+    });
+
+    it('the same spring, once settled, exports an explicit frame: the capture reads pixels and resolves to a Blob', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        await mount(<Scene handleRef={handleRef} value={0} transition={SPRING} />);
+        frames.tick(0);
+
+        await mount(<Scene handleRef={handleRef} value={10} transition={SPRING} />);
+        settle();
+        expect(frames.pending()).toBe(0);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
+        expect(stub.readPixelsCalls.length).toBe(1);
+
+        await expect(handleRef.current?.renderSequence(SEQUENCE)).rejects.toThrow(/WebCodecs|VideoEncoder/);
+    });
+
+    it('an in-flight tween is deterministic under setFrame, so it does not block a capture', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        await mount(<Scene handleRef={handleRef} value={0} transition={TWEEN} />);
+        frames.tick(0);
+
+        await mount(<Scene handleRef={handleRef} value={10} transition={TWEEN} />);
+        frames.tick(1000);
+        expect(frames.pending()).toBe(1);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
+        expect(stub.readPixelsCalls.length).toBe(1);
+
+        await expect(handleRef.current?.renderSequence(SEQUENCE)).rejects.toThrow(/WebCodecs|VideoEncoder/);
+    });
+
+    it('a live capture of a spring in flight is honest, so renderToBlob() with no frame and record() both run', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        await mount(<Scene handleRef={handleRef} value={0} transition={SPRING} />);
+        frames.tick(0);
+
+        await mount(<Scene handleRef={handleRef} value={10} transition={SPRING} />);
+        frames.tick(1000);
+
+        await expect(handleRef.current?.renderToBlob({ frame: 30 }))
+            .rejects.toThrow(/still in flight/);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob()).resolves.toBeInstanceOf(Blob);
+        expect(stub.readPixelsCalls.length).toBe(1);
+
+        const recording = handleRef.current?.record();
+        expect(recording?.stream).toBeDefined();
+        expect(recorderStarts).toBe(1);
+    });
+
+    it('a spring on the secondary program of a ping-pong chain trips the guard too', async () => {
+        const handleRef: RefObject<PingPongShaderHandle | null> = { current: null };
+        await mount(<PingPongScene handleRef={handleRef} value={0} />);
+        frames.tick(0);
+
+        await mount(<PingPongScene handleRef={handleRef} value={10} />);
+        frames.tick(1000);
+        expect(frames.pending()).toBe(1);
+
+        expect(() => handleRef.current?.renderSequence(SEQUENCE))
+            .toThrow(/PingPongShaderEngine\.renderSequence: a spring transition is still in flight/);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob({ frame: 30 }))
+            .rejects.toThrow(/PingPongShaderEngine\.renderToBlob: a spring transition is still in flight/);
+        expect(stub.readPixelsCalls.length).toBe(0);
+
+        await expect(handleRef.current?.renderToBlob({ seed: { kind: 'clear', color: [0, 0, 0, 1] }, steps: 4 }))
+            .rejects.toThrow(/a spring transition is still in flight/);
+    });
+
+    it('the same ping-pong secondary spring, once settled, exports an explicit frame', async () => {
+        const handleRef: RefObject<PingPongShaderHandle | null> = { current: null };
+        await mount(<PingPongScene handleRef={handleRef} value={0} />);
+        frames.tick(0);
+
+        await mount(<PingPongScene handleRef={handleRef} value={10} />);
+        settle();
+        expect(frames.pending()).toBe(0);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
+        expect(stub.readPixelsCalls.length).toBe(1);
+    });
+});

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -38,6 +38,8 @@ import {
     resolveDeviceResolution,
     resolveResolution
 } from '@/react/lib/resolution';
+import type { SpringsInFlight } from '@/react/lib/springCapture';
+import { springInFlightMessage } from '@/react/lib/springCapture';
 import { frameToMs } from '@/react/lib/timeKeeper';
 import type { WorkerBlock, WorkerProgramUniforms } from '@/react/lib/workerMode';
 import {
@@ -72,6 +74,7 @@ interface PingPongShaderEngineBaseProps extends Omit<RenderControlProps, 'worker
     debug?: boolean;
     debugPortRef?: RefObject<UniformDebugPort | null>;
     invalidation?: FrameInvalidation;
+    springsInFlight?: SpringsInFlight;
 }
 
 export type PingPongShaderEngineWorkerProps =
@@ -154,6 +157,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     workerUniforms,
     workerCustomPasses = false,
     invalidation,
+    springsInFlight,
     worker,
     createWorker,
     useDevicePixelRatio,
@@ -250,6 +254,11 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             throw new Error('PingPongShaderEngine.renderToBlob: WebGL context is lost');
         }
 
+        const stepsTheClock = opts.frame !== undefined || opts.steps !== undefined;
+        if (stepsTheClock && springsInFlight?.()) {
+            throw new Error(springInFlightMessage('PingPongShaderEngine', 'renderToBlob'));
+        }
+
         const timePure = passSystem.isTimePure();
         if (opts.frame !== undefined && !timePure && opts.steps === undefined) {
             throw new Error(
@@ -307,7 +316,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         );
 
         return { ...result, type: opts.type, quality: opts.quality };
-    }, []);
+    }, [springsInFlight]);
 
     const applySize = useCallback(() => {
         const canvas = canvasRef.current;
@@ -790,6 +799,9 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             if (manager.context.isContextLost()) {
                 throw new Error('PingPongShaderEngine.renderSequence: WebGL context is lost');
             }
+            if (springsInFlight?.()) {
+                throw new Error(springInFlightMessage('PingPongShaderEngine', 'renderSequence'));
+            }
             const canvas = manager.context.canvas as HTMLCanvasElement;
             const controller = controllerRef.current;
             const wasRunning = controller !== null && !controller.isPaused();
@@ -813,7 +825,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
                 }
             });
         }
-    }, [workerActive, resetSimulation, captureStill, setStopped, invalidateAll]);
+    }, [workerActive, resetSimulation, captureStill, setStopped, invalidateAll, springsInFlight]);
 
     if (workerActive && block) {
         throw new Error(workerBlockMessage('PingPongShaderEngine', block));

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -40,6 +40,8 @@ import {
     resolveDeviceResolution,
     resolveResolution
 } from '@/react/lib/resolution';
+import type { SpringsInFlight } from '@/react/lib/springCapture';
+import { springInFlightMessage } from '@/react/lib/springCapture';
 import { frameToMs } from '@/react/lib/timeKeeper';
 import type { WorkerBlock, WorkerProgramUniforms } from '@/react/lib/workerMode';
 import {
@@ -83,6 +85,7 @@ interface ShaderEngineBaseProps extends Omit<RenderControlProps, 'worker' | 'cre
     debugPortRef?: RefObject<UniformDebugPort | null>;
     workerSkipDefaultUniforms?: boolean;
     invalidation?: FrameInvalidation;
+    springsInFlight?: SpringsInFlight;
 }
 
 export type ShaderEngineWorkerProps =
@@ -172,6 +175,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     workerSkipDefaultUniforms = false,
     liveUniforms,
     invalidation,
+    springsInFlight,
     worker,
     createWorker,
     useDevicePixelRatio,
@@ -285,13 +289,17 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             throw new Error('ShaderEngine.renderToBlob: WebGL context is lost');
         }
 
+        const explicitFrame = opts.frame !== undefined;
+        if (explicitFrame && springsInFlight?.()) {
+            throw new Error(springInFlightMessage('ShaderEngine', 'renderToBlob'));
+        }
+
         const canvas = manager.context.canvas as HTMLCanvasElement;
         const backingWidth = canvas.width;
         const backingHeight = canvas.height;
 
         const { width, height } = resolveExportDimensions(opts, backingWidth, backingHeight);
         const isDefaultDims = width === backingWidth && height === backingHeight;
-        const explicitFrame = opts.frame !== undefined;
         const timeMs = frameToMs(opts.frame ?? controllerRef.current?.getFrame() ?? 0);
 
         const result = captureFrame(
@@ -321,7 +329,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         );
 
         return { ...result, type: opts.type, quality: opts.quality };
-    }, [renderFrame, drawFastPathGeometry]);
+    }, [renderFrame, drawFastPathGeometry, springsInFlight]);
 
     const commitSize = useCallback((
         resolution: { renderWidth: number; renderHeight: number },
@@ -868,6 +876,9 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             if (options.seed !== undefined) {
                 throw new Error('ShaderEngine.renderSequence: no simulation to seed');
             }
+            if (springsInFlight?.()) {
+                throw new Error(springInFlightMessage('ShaderEngine', 'renderSequence'));
+            }
             const canvas = manager.context.canvas as HTMLCanvasElement;
             const controller = controllerRef.current;
             const wasRunning = controller !== null && !controller.isPaused();
@@ -887,7 +898,8 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         renderFrame,
         invalidateAll,
         startSamplerLoop,
-        setStopped
+        setStopped,
+        springsInFlight
     ]);
 
     if (workerActive && block) {

--- a/src/react/hooks/usePingPongPasses.ts
+++ b/src/react/hooks/usePingPongPasses.ts
@@ -12,6 +12,7 @@ import {
     serializeFramebufferOptions,
     serializeRenderOptions
 } from '@/react/lib/pingPongPasses';
+import type { SpringsInFlight } from '@/react/lib/springCapture';
 import type { FramebufferOptions, MotionPolicy, RenderPass, UniformParam } from '@/types';
 
 interface PingPongPassesOptions {
@@ -33,6 +34,7 @@ const EMPTY_UNIFORMS: Record<string, UniformParam> = {};
 export interface PingPongPassesWithPort extends PingPongPassesResult {
     port: UniformDebugPort;
     invalidation: FrameInvalidation;
+    springsInFlight: SpringsInFlight;
 }
 
 export const usePingPongPasses = ({
@@ -98,5 +100,12 @@ export const usePingPongPasses = ({
         [primary.invalidation, secondary.invalidation]
     );
 
-    return { ...passesResult, port, invalidation };
+    const primarySprings = primary.springsInFlight;
+    const secondarySprings = secondary.springsInFlight;
+    const springsInFlight = useMemo<SpringsInFlight>(
+        () => () => primarySprings() || secondarySprings(),
+        [primarySprings, secondarySprings]
+    );
+
+    return { ...passesResult, port, invalidation, springsInFlight };
 };

--- a/src/react/hooks/useUniformUpdaters.ts
+++ b/src/react/hooks/useUniformUpdaters.ts
@@ -14,6 +14,7 @@ import {
     uniformDescriptors,
     uniformStructureKey
 } from '@/react/lib/liveUniformUpdaters';
+import type { SpringsInFlight } from '@/react/lib/springCapture';
 import { createTransitionRuntime, type TransitionRuntime } from '@/react/lib/transitionRuntime';
 import type { MotionPolicy, UniformParam, UniformUpdaterDef } from '@/types';
 
@@ -21,6 +22,7 @@ export interface UniformUpdatersResult {
     updaters: Record<string, UniformUpdaterDef[]>;
     port: UniformDebugPort;
     invalidation: FrameInvalidation;
+    springsInFlight: SpringsInFlight;
 }
 
 export interface UniformUpdatersOptions {
@@ -77,5 +79,10 @@ export const useUniformUpdaters = (
         };
     }, [programId, structureKey, runtime]);
 
-    return { updaters, port, invalidation: runtime.invalidation };
+    return {
+        updaters,
+        port,
+        invalidation: runtime.invalidation,
+        springsInFlight: runtime.springsInFlight
+    };
 };

--- a/src/react/lib/liveUniformUpdaters.test.ts
+++ b/src/react/lib/liveUniformUpdaters.test.ts
@@ -166,6 +166,7 @@ describe('buildLiveUpdaters', () => {
         const runtime: TransitionRuntime = {
             applyTargets: () => undefined,
             sample: (name, timeMs) => name === 'u_swirl' && timeMs < 100 ? 4.5 : null,
+            springsInFlight: () => false,
             invalidation: createFrameInvalidation()
         };
         const updaters = buildLiveUpdaters([{ name: 'u_swirl', type: 'float' }], true, valuesRef, runtime);
@@ -179,6 +180,7 @@ describe('buildLiveUpdaters', () => {
         const runtime: TransitionRuntime = {
             applyTargets: () => undefined,
             sample: () => null,
+            springsInFlight: () => false,
             invalidation: createFrameInvalidation()
         };
         const updaters = buildLiveUpdaters([{ name: 'u_swirl', type: 'float' }], true, valuesRef, runtime);

--- a/src/react/lib/springCapture.ts
+++ b/src/react/lib/springCapture.ts
@@ -1,0 +1,9 @@
+export type SpringsInFlight = () => boolean;
+
+export function springInFlightMessage(engine: string, method: string): string {
+    return (
+        `${engine}.${method}: a spring transition is still in flight. Springs integrate frame to frame, so a `
+        + 'captured frame depends on the frames rendered before it, and this export would not reproduce. Wait for '
+        + 'the spring to settle, or use a tween transition, which is deterministic under setFrame.'
+    );
+}

--- a/src/react/lib/transitionPipeline.test.ts
+++ b/src/react/lib/transitionPipeline.test.ts
@@ -96,6 +96,116 @@ describe('a real uniform transition, driven through the production pipeline (no 
         expect(swirlUploads(stub)).toEqual([0, 2.5, 5, 7.5, 10]);
     });
 
+    it('a spring transition overshoots the target and returns before landing exactly on it, then stops uploading', () => {
+        const runtime = createTransitionRuntime(() => false);
+        const springConfig = { type: 'spring' as const, stiffness: 1200, damping: 20 };
+
+        let uniforms: Record<string, UniformParam> = {
+            swirl: { type: 'float', value: 0, transition: springConfig }
+        };
+        const descriptors = uniformDescriptors(uniforms);
+        const parsed = parseUniformStructureKey(uniformStructureKey(descriptors, true));
+        const valuesRef = { current: collectLiveValues(uniforms) };
+        const updaters = buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime);
+
+        const stub = createCanvasStub();
+        const manager = new WebGLManager(stub.canvas);
+        manager.createProgram(PROGRAM_ID, CONFIG);
+        updaters.forEach(u => { manager.registerUniformUpdater(PROGRAM_ID, u.name, u.type, u.updateFn) });
+        manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+
+        const commit = (nextUniforms: Record<string, UniformParam>): void => {
+            uniforms = nextUniforms;
+            valuesRef.current = collectLiveValues(uniforms);
+            runtime.applyTargets(uniforms, 'none');
+        };
+
+        commit(uniforms);
+        stub.reset();
+
+        manager.updateUniforms(PROGRAM_ID, 0);
+        expect(swirlUploads(stub)).toEqual([0]);
+
+        commit({ swirl: { type: 'float', value: 10, transition: springConfig } });
+
+        const sampleTimes = [
+            1000, 1025, 1050, 1075, 1100, 1150, 1200, 1300, 1400, 1500, 1700, 1900, 1950, 2000, 2100
+        ];
+        for (const time of sampleTimes) {
+            manager.updateUniforms(PROGRAM_ID, time);
+        }
+
+        const values = swirlUploads(stub) as number[];
+        expect(values[0]).toBe(0);
+
+        const peakIndex = values.indexOf(Math.max(...values));
+        expect(values[peakIndex]).toBeGreaterThan(10);
+        expect(values[peakIndex]).toBeCloseTo(13.413144, 3);
+
+        const troughAfterPeak = Math.min(...values.slice(peakIndex + 1));
+        expect(troughAfterPeak).toBeLessThan(10);
+
+        expect(values[values.length - 1]).toBe(10);
+
+        const uploadCountAtSettle = values.length;
+        manager.updateUniforms(PROGRAM_ID, 2200);
+        manager.updateUniforms(PROGRAM_ID, 2300);
+        expect(swirlUploads(stub).length).toBe(uploadCountAtSettle);
+    });
+
+    it('a spring retarget mid-flight preserves velocity, so a mid-flight color chase never resets speed to zero', () => {
+        const runtime = createTransitionRuntime(() => false);
+        const springConfig = { type: 'spring' as const, stiffness: 170, damping: 10 };
+
+        let uniforms: Record<string, UniformParam> = {
+            swirl: { type: 'float', value: 0, transition: springConfig }
+        };
+        const descriptors = uniformDescriptors(uniforms);
+        const parsed = parseUniformStructureKey(uniformStructureKey(descriptors, true));
+        const valuesRef = { current: collectLiveValues(uniforms) };
+        const updaters = buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime);
+
+        const stub = createCanvasStub();
+        const manager = new WebGLManager(stub.canvas);
+        manager.createProgram(PROGRAM_ID, CONFIG);
+        updaters.forEach(u => { manager.registerUniformUpdater(PROGRAM_ID, u.name, u.type, u.updateFn) });
+        manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+
+        const commit = (nextUniforms: Record<string, UniformParam>): void => {
+            uniforms = nextUniforms;
+            valuesRef.current = collectLiveValues(uniforms);
+            runtime.applyTargets(uniforms, 'none');
+        };
+
+        commit(uniforms);
+        stub.reset();
+        manager.updateUniforms(PROGRAM_ID, 0);
+
+        const latest = (): number => {
+            const values = swirlUploads(stub) as number[];
+            return values[values.length - 1];
+        };
+
+        commit({ swirl: { type: 'float', value: 10, transition: springConfig } });
+        manager.updateUniforms(PROGRAM_ID, 1000);
+        manager.updateUniforms(PROGRAM_ID, 1050);
+        const valueAt1050 = latest();
+        manager.updateUniforms(PROGRAM_ID, 1100);
+        const valueAt1100 = latest();
+
+        const speedBeforeRetarget = (valueAt1100 - valueAt1050) / 50;
+        expect(speedBeforeRetarget).toBeGreaterThan(0);
+
+        commit({ swirl: { type: 'float', value: 20, transition: springConfig } });
+        manager.updateUniforms(PROGRAM_ID, 1100);
+        expect(latest()).toBe(valueAt1100);
+
+        manager.updateUniforms(PROGRAM_ID, 1116);
+        const speedAfterRetarget = (latest() - valueAt1100) / 16;
+
+        expect(speedAfterRetarget).toBeGreaterThan(speedBeforeRetarget);
+    });
+
     it('a vec3 transition uploads advancing buffers every frame and lands exactly on the target', () => {
         const runtime = createTransitionRuntime(() => false);
 

--- a/src/react/lib/transitionRuntime.test.ts
+++ b/src/react/lib/transitionRuntime.test.ts
@@ -5,6 +5,7 @@ import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
 import type { UniformParam, UniformTransitionConfig, Vec3 } from '@/types';
 
 const TWEEN: UniformTransitionConfig = { duration: 100, easing: 'linear' };
+const SPRING: UniformTransitionConfig = { type: 'spring', stiffness: 170, damping: 10 };
 
 function noOverrides(): boolean {
     return false;
@@ -12,6 +13,10 @@ function noOverrides(): boolean {
 
 function swirl(value: number): Record<string, UniformParam> {
     return { u_swirl: { type: 'float', value, transition: TWEEN } };
+}
+
+function springSwirl(value: number): Record<string, UniformParam> {
+    return { u_swirl: { type: 'float', value, transition: SPRING } };
 }
 
 function color(value: Vec3): Record<string, UniformParam> {
@@ -113,6 +118,26 @@ describe('createTransitionRuntime', () => {
         runtime.applyTargets(swirl(10), 'static');
 
         expect(runtime.sample('u_swirl', 50)).toBeNull();
+    });
+
+    it('a gate that snaps an in-flight spring clears its velocity, so lifting the gate later does not carry a phantom speed', () => {
+        const gated = createTransitionRuntime(noOverrides);
+        gated.applyTargets(springSwirl(0), 'none');
+        gated.applyTargets(springSwirl(10), 'none');
+        gated.sample('u_swirl', 0);
+        gated.sample('u_swirl', 100);
+        gated.applyTargets(springSwirl(10), 'static');
+        expect(gated.sample('u_swirl', 200)).toBeNull();
+
+        const fromRest = createTransitionRuntime(noOverrides);
+        fromRest.applyTargets(springSwirl(10), 'none');
+
+        gated.applyTargets(springSwirl(20), 'none');
+        fromRest.applyTargets(springSwirl(20), 'none');
+
+        for (const time of [300, 316, 332]) {
+            expect(gated.sample('u_swirl', time)).toBe(fromRest.sample('u_swirl', time));
+        }
     });
 
     it('a commit that lifts the gate and changes the value together animates, it does not snap', () => {

--- a/src/react/lib/transitionRuntime.ts
+++ b/src/react/lib/transitionRuntime.ts
@@ -10,11 +10,13 @@ import {
 import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
 import { normalizeUniformName } from '@/react/lib/liveUniformUpdaters';
 import type { MotionGate } from '@/react/lib/motionPolicy';
+import type { SpringsInFlight } from '@/react/lib/springCapture';
 import type { UniformParam, UniformType, UniformValue } from '@/types';
 
 export interface TransitionRuntime {
     applyTargets(uniforms: Record<string, UniformParam>, motionGate: MotionGate): void;
     sample(name: string, timeMs: number): Float32Array | number | null;
+    springsInFlight: SpringsInFlight;
     invalidation: FrameInvalidation;
 }
 
@@ -87,6 +89,7 @@ function snapToTarget(state: MotionState, target: Float32Array): void {
     state.from.set(target);
     state.to.set(target);
     state.current.set(target);
+    state.velocity.fill(0);
     state.settled = true;
 }
 
@@ -148,6 +151,14 @@ export function createTransitionRuntime(isOverridden: (name: string) => boolean)
             }
 
             return state.current.length === 1 ? state.current[0] : state.current;
+        },
+        springsInFlight: () => {
+            for (const [name, state] of states) {
+                if (state.config.kind === 'spring' && !state.settled && !isOverridden(name)) {
+                    return true;
+                }
+            }
+            return false;
         },
         invalidation
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,13 +312,23 @@ export type EasingName = 'linear' | 'easeIn' | 'easeOut' | 'easeInOut';
 export type EasingFn = (t: number) => number;
 
 export interface TweenTransitionConfig {
+  type?: 'tween';
   duration: number;
   easing?: EasingName | EasingFn;
   delay?: number;
   interpolate?: (from: ArrayLike<number>, to: ArrayLike<number>, t: number, out: Float32Array) => void;
 }
 
-export type UniformTransitionConfig = TweenTransitionConfig;
+export interface SpringTransitionConfig {
+  type: 'spring';
+  stiffness?: number;
+  damping?: number;
+  mass?: number;
+  restDelta?: number;
+  restSpeed?: number;
+}
+
+export type UniformTransitionConfig = TweenTransitionConfig | SpringTransitionConfig;
 
 export interface UniformParam<T extends UniformType = UniformType> {
   value: UniformValue<T>;


### PR DESCRIPTION
Springs land alongside T1's tweens. `transitionRuntime.ts` needed **no changes** — the driver seam absorbed this exactly as T1 designed it.

```tsx
uniforms={{
    colorStart: { type: 'vec3', value: vec3(palette), transition: { type: 'spring', stiffness: 180, damping: 12 } }
}}
```

Semi-implicit Euler, fixed substeps, and velocity **carried across a mid-flight retarget** — a spring redirected in motion keeps its momentum instead of restarting. Demo: `?scene=transitions`, tween/spring toggle.

## The integrator diverged, and a diverged spring reported itself settled on target

Semi-implicit Euler at a hard 1/120s substep is only stable when `h²(k/m) + 2h(c/m) < 4`. Ordinary configs violate it — `{stiffness: 100, damping: 300}` traces `0.004 → -0.06 → -41 → -1e5 → ±Infinity`.

Then the kill shot. The settle check was written *negatively*:

```ts
if (speed >= restSpeed || displacement >= restDelta) settled = false;
```

Once a value reaches Infinity, `Infinity - Infinity = NaN` — and **`NaN >= x` is `false`**. So the check fell through, declared the spring at rest, snapped `current` to the exact target and zeroed the velocity. The probe printed `{ final: 1, velocity: 0, settled: true }`. Nothing throws, nothing logs, and it lands *perfectly on target*. A failure that looks exactly like success — the ninth in this codebase.

Fixed three ways:
- **the substep is derived from the stability bound** at config resolution — it is exactly 1/120 for every sane config, so determinism and all existing numeric expectations are untouched (the substep is a pure function of the config, not of the frame times);
- **the settle predicate is written positively** (`|v| < restSpeed && |x - to| < restDelta`) — De Morgan-identical for finite values, but **NaN can never be mistaken for rest**;
- a config too stiff or too light for any affordable substep now **throws** instead of hanging the frame loop.

## Deterministic capture now fails loud on an in-flight spring

A spring is an **accumulator**: its value at time T depends on the frames before it, not on T. So `renderToBlob({frame: 2000})` sampled once gives 0, while stepping the loop to t=2000 gives 1. Track 2's existing guard (`chainIsTimePure`) only knows about feedback passes, so a spring sailed straight through it and **silently produced a frame that would never reproduce**.

The guard covers only the paths that *synthesize* a time:

| throws | left alone |
|---|---|
| `renderSequence(...)` | `renderToBlob()` / `renderToDataURL()` with no `frame` |
| `renderToBlob`/`renderToDataURL` with an explicit `frame` | `record()`, `captureStream()` |
| ping-pong `renderToBlob({seed, steps})` (re-runs the sim at synthesized times) | |

Those left alone render the **live clock** — exactly what is on screen — which is honest. And an in-flight **tween** never blocks a capture: it is a pure function of time and genuinely reproducible under `setFrame`. Both directions are tested, through real mounted components with a real GL stub — including that a blocked capture never reaches `readPixels`, and that a *settled* spring exports fine.

The engine asks the runtime via one `springsInFlight?: () => boolean` prop (same size as `invalidation`, no `TransitionRuntime` leak). This is the production caller that earns back the `isAnimating()` T1's review deleted for having none. Devtools-overridden uniforms are excluded from the check — an overridden spring is never sampled, so it never settles, and would otherwise block every capture forever.

## `damping: 0` now throws

Honest physics (an undamped spring), but it **provably never settles** — 100k frames later it is still oscillating at |v| = 12. Under `frameloop="demand"` the invalidation chain then keeps the rAF loop permanently hot: a pinned core and a drained battery, with no error and no log.

## Also caught in review

- `snapToTarget` did not zero the `velocity` array T2 introduces, so a spring gated away by reduced-motion mid-flight would **relaunch with a phantom speed** when the gate lifted.
- **A hollow test**: the one claiming to prove velocity carry asserted only that the next sample was *greater* than the retarget value — but a zero-velocity spring also accelerates toward a target above it, so **it passed with the carry deleted**. Rewritten to assert speed continuity across the retarget (carry gives ratio 1.277, no-carry 0.359).
- The spring **defaults are deliberately non-bouncy** (170/26/1 is ζ ≈ 0.997, measured zero overshoot — matching react-spring's default preset). Verified, kept, and the README says so rather than promising bounce the defaults don't deliver.

767 tests (was 734 at T3).