### PR TITLE
audio: T4 audio uniforms hook - the param invalidation relay that did not exist, and a capture guard for a live input

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,131 @@ the uniform would jump. That combination throws with the remedy in the message. 
 transitions on the main thread and posting them through the `liveUniforms` channel is a
 follow-up.
 
+## Audio-reactive uniforms
+
+`useAudioUniforms` turns a microphone, an `<audio>`/`<video>` element, or an `AudioNode` you
+already own into two uniforms: `u_audioBands` (1-4 log-spaced frequency bands packed into a
+`float`/`vec2`/`vec3`/`vec4`) and `u_audioLevel` (their mean).
+
+The element is `null` on the first render, so the visualizer has to wait for it. Hold the
+element in state with a ref callback and render the visualizer only once it exists:
+
+```tsx
+const Visualizer = ({ element }: { element: HTMLAudioElement }) => {
+    const audio = useAudioUniforms(
+        { type: 'element', element },
+        { bands: 4, attack: 0.01, release: 0.18 }
+    );
+
+    return (
+        <>
+            <BaseShaderComponent
+                programId='audio-bars'
+                shaderConfig={config}
+                uniforms={{ ...audio.uniforms, intensity: { type: 'float', value: 1 } }}
+                frameloop='demand'
+            />
+            <button type='button' onClick={() => { void audio.start() }}>play</button>
+            {audio.status === 'error' && <p>{audio.error?.message}</p>}
+        </>
+    );
+};
+
+export const Player = () => {
+    const [element, setElement] = useState<HTMLAudioElement | null>(null);
+
+    return (
+        <>
+            <audio ref={setElement} src='/track.mp3' controls />
+            {element && <Visualizer element={element} />}
+        </>
+    );
+};
+```
+
+- `useAudioUniforms(source, options?)` returns `{ uniforms, start, stop, status, error }`.
+  `source` is `{ type: 'mic' }`, `{ type: 'element', element }` or `{ type: 'node', node, context }`.
+- **`start()` needs a user gesture.** Call it from a click, not on mount: browsers require a
+  gesture for `getUserMedia` and for resuming a suspended `AudioContext`. It returns a promise
+  that rejects on a denied permission or an insecure context, and the same failure is reported
+  through `status === 'error'` and `error`.
+- `stop()` releases everything the hook owns: the microphone track stops (the OS recording
+  indicator goes out), a mic `AudioContext` is closed, and the uniforms fall back to zero.
+  Unmounting stops the driver too. `stop()` never disconnects a media element from the
+  speakers - stopping the visualizer does not stop the music.
+- Options: `bands` (1-4, default 4), `fftSize`, `smoothingTimeConstant`, `attack`/`release`
+  (an asymmetric envelope in seconds - fast attack, slow release, which the analyser's own
+  symmetric smoothing cannot express), `minDecibels`/`maxDecibels`, `bandLayout`
+  (`'log' | 'linear'`), and `names` to rename the two uniforms. A statically-invalid option
+  (a `bands` outside 1-4, an `fftSize` that is not a power of two, a negative `attack`) throws
+  during render, before any WebAudio object exists. A `bands`/`fftSize` combination that is only
+  impossible against the device's *actual* sample rate - too few bins between the band edges to
+  split - cannot be caught statically: it throws from `start()` or from the reconfigure, and
+  surfaces as `status === 'error'` with the reason in `error`.
+- A third argument, `deps`, lets you inject your own `AudioContext` factory and `getUserMedia`
+  (`{ createContext, getUserMedia }`). It is read once, when the hook builds its driver; changing
+  it afterwards is deliberately ignored, because the hook owns one audio graph for its whole life.
+- Analysis is **frame-driven**: it runs inside the uniform read, once per rendered frame. There
+  is no second rAF loop, an engine that is paused, hidden or offscreen does no audio work at
+  all, and `frameloop='demand'` works - the driver wakes the loop every time it analyses, so the
+  loop keeps itself alive while audio is running and goes idle again the moment you `stop()`.
+- The band count decides the uniform's type, so changing `bands` means changing the uniform's
+  declaration in the shader too (`vec4` -> `vec2`).
+- One hook instance owns one audio graph for its whole life. Changing the `source` under a live
+  hook throws; give the component a `key` that changes with the source so the old graph is
+  stopped before the new one is built.
+- Worker mode works: audio uniforms are function-valued, so list them in `liveUniforms` and the
+  main thread samples them each frame and posts the values to the worker.
+- **A running audio scene cannot be exported deterministically.** The envelope integrates frame
+  to frame, and every frame reads whatever the microphone or media element happens to be playing,
+  so `renderSequence()` and `renderToBlob({ frame })` - the two calls that synthesize a frame time
+  - throw while `status === 'running'`, and the message says so. Call `stop()` first and the same
+  export works. The honest live captures (`renderToBlob()` with no frame, `record()`,
+  `captureStream()`) render the real clock and are never blocked.
+- Known limitation: a CORS-tainted media element (cross-origin audio without permissive CORS
+  headers) feeds the analyser silent zeros. The browser reports no error, so neither can micugl:
+  `status` reads `'running'` and the uniforms read 0.
+
+### Waking a `demand` engine from your own value producer
+
+`useAudioUniforms` is built on two public pieces you can use directly for any live input of your
+own (a webcam, a MIDI knob, a websocket). `UniformParam.invalidation` takes a `FrameInvalidation`;
+whenever your producer calls `request()`, every engine using that uniform renders a frame. Under
+`frameloop='always'` it is a no-op; under `'demand'` it is the whole scheduling mechanism.
+
+```tsx
+const pointerInvalidation = useMemo(() => createFrameInvalidation(), []);
+const pointerRef = useRef<[number, number]>([0, 0]);
+
+useEffect(() => {
+    const onMove = (event: PointerEvent) => {
+        pointerRef.current = [event.clientX, event.clientY];
+        pointerInvalidation.request();
+    };
+    window.addEventListener('pointermove', onMove);
+    return () => { window.removeEventListener('pointermove', onMove) };
+}, [pointerInvalidation]);
+
+<BaseShaderComponent
+    programId='trail'
+    shaderConfig={config}
+    frameloop='demand'
+    uniforms={{
+        u_pointer: {
+            type: 'vec2',
+            value: () => pointerRef.current,
+            invalidation: pointerInvalidation
+        }
+    }}
+/>
+```
+
+`invalidation` must be **referentially stable**. The engine diffs the connected set by object
+identity, so an inline `createFrameInvalidation()` or `combineFrameInvalidation([...])` built
+during render would connect and dispose on every render. Memoize it (or hold it in a ref), as
+above. `combineFrameInvalidation` merges several producers into one when a uniform is woken by
+more than one source.
+
 ## Worker rendering (OffscreenCanvas)
 
 `worker` moves the GL context and the render loop off the main thread, onto an

--- a/demo/scenes/AudioBars.tsx
+++ b/demo/scenes/AudioBars.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+
+import { audioBarsFragmentShader, audioBarsVertexShader } from '../../examples/AudioBars/audioBarsShaders';
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { vec3 } from '../../src/core/lib/vectorUtils';
+import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
+import { useAudioUniforms } from '../../src/react/hooks/useAudioUniforms';
+import type { AudioSourceSpec, Frameloop } from '../../src/types';
+
+const config = createShaderConfig({
+    vertexShader: audioBarsVertexShader,
+    fragmentShader: audioBarsFragmentShader,
+    uniformNames: {
+        u_audioBands: 'vec4',
+        u_audioLevel: 'float',
+        u_colorLow: 'vec3',
+        u_colorHigh: 'vec3'
+    }
+});
+
+const panelStyle = {
+    position: 'absolute',
+    top: '12px',
+    left: '12px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    padding: '12px',
+    background: 'rgba(0, 0, 0, 0.6)',
+    color: '#fff',
+    fontFamily: 'monospace',
+    fontSize: '12px',
+    borderRadius: '4px',
+    maxWidth: '320px'
+} as const;
+
+const buttonStyle = (active: boolean) => ({
+    padding: '6px 10px',
+    background: active ? '#e94560' : '#0f3460',
+    border: 'none',
+    borderRadius: '4px',
+    color: '#fff',
+    cursor: 'pointer'
+});
+
+interface VisualizerProps {
+    source: AudioSourceSpec;
+    frameloop: Frameloop;
+    onStart: () => void;
+}
+
+const Visualizer = ({ source, frameloop, onStart }: VisualizerProps) => {
+    const audio = useAudioUniforms(source, { bands: 4, attack: 0.01, release: 0.18 });
+
+    return (
+        <>
+            <BaseShaderComponent
+                programId='audio-bars-demo'
+                shaderConfig={config}
+                uniforms={{
+                    ...audio.uniforms,
+                    u_colorLow: { type: 'vec3', value: vec3([0.15, 0.45, 0.95]) },
+                    u_colorHigh: { type: 'vec3', value: vec3([0.95, 0.25, 0.45]) }
+                }}
+                frameloop={frameloop}
+                style={{ width: '100%', height: '100%', display: 'block' }}
+            />
+            <div style={panelStyle}>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                    <button
+                        type='button'
+                        style={buttonStyle(audio.status === 'running')}
+                        onClick={() => {
+                            onStart();
+                            void audio.start();
+                        }}
+                    >
+                        start
+                    </button>
+                    <button
+                        type='button'
+                        style={buttonStyle(audio.status !== 'running')}
+                        onClick={audio.stop}
+                    >
+                        stop
+                    </button>
+                </div>
+                <div>source: {source.type}</div>
+                <div>status: {audio.status}</div>
+                <div>frameloop: {frameloop}</div>
+                {audio.error ? <div style={{ color: '#ff8fa3' }}>{audio.error.message}</div> : null}
+                <div>
+                    The bands and the level are ordinary function-valued uniforms, sampled once per rendered
+                    frame. Under frameloop &quot;demand&quot; the driver invalidates the engine every time it
+                    analyses, so the loop keeps itself alive while audio is running and goes idle the moment
+                    you stop it.
+                </div>
+            </div>
+        </>
+    );
+};
+
+export const AudioBars = () => {
+    const [element, setElement] = useState<HTMLAudioElement | null>(null);
+    const [mode, setMode] = useState<'element' | 'mic'>('element');
+    const [frameloop, setFrameloop] = useState<Frameloop>('demand');
+    const [trackUrl, setTrackUrl] = useState<string | null>(null);
+
+    const source: AudioSourceSpec | null = mode === 'mic'
+        ? { type: 'mic' }
+        : (element ? { type: 'element', element } : null);
+
+    return (
+        <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
+            {source
+                ? (
+                    <Visualizer
+                        key={mode}
+                        source={source}
+                        frameloop={frameloop}
+                        onStart={() => {
+                            if (mode === 'element') {
+                                void element?.play();
+                            }
+                        }}
+                    />
+                )
+                : null}
+            <div style={{ ...panelStyle, top: 'auto', bottom: '12px' }}>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                    {(['element', 'mic'] as const).map(entry => (
+                        <button
+                            key={entry}
+                            type='button'
+                            style={buttonStyle(mode === entry)}
+                            onClick={() => { setMode(entry) }}
+                        >
+                            {entry}
+                        </button>
+                    ))}
+                    {(['demand', 'always'] as const).map(entry => (
+                        <button
+                            key={entry}
+                            type='button'
+                            style={buttonStyle(frameloop === entry)}
+                            onClick={() => { setFrameloop(entry) }}
+                        >
+                            {entry}
+                        </button>
+                    ))}
+                </div>
+                <input
+                    type='file'
+                    accept='audio/*'
+                    onChange={event => {
+                        const file = event.target.files?.[0];
+                        if (file) {
+                            setTrackUrl(previous => {
+                                if (previous) {
+                                    URL.revokeObjectURL(previous);
+                                }
+                                return URL.createObjectURL(file);
+                            });
+                        }
+                    }}
+                />
+                <audio ref={setElement} src={trackUrl ?? undefined} controls loop />
+                <div>
+                    Swapping the source remounts the visualizer (the hook owns one audio graph for its whole
+                    life and throws if the source changes under it), so the old graph is stopped first.
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from 'react';
 
+import { AudioBars } from './AudioBars';
 import { DevtoolsDebug } from './DevtoolsDebug';
 import { ExportDemo } from './ExportDemo';
 import { InstancedParticles } from './InstancedParticles';
@@ -27,6 +28,7 @@ export const scenes: Record<string, ComponentType> = {
     'devtools-debug': DevtoolsDebug,
     'reduced-motion': ReducedMotion,
     'transitions': Transitions,
+    'audio-bars': AudioBars,
     'visual-fixed': VisualFixed,
     'export-demo': ExportDemo,
     'instanced-particles': InstancedParticles,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -141,6 +141,10 @@ export default tseslint.config(
           {
             group: ['@/testing', '@/testing/*', '**/testing/**'],
             message: 'micugl/testing is dev/test-only and must stay out of library source; only src/testing/**, src/react/devtools/** and *.test.* files may import it.'
+          },
+          {
+            group: ['@/react/lib/fakeWebAudio', '**/fakeWebAudio'],
+            message: 'fakeWebAudio is a test-only fake and must stay out of library source; only *.test.* files may import it.'
           }
         ]
       }]

--- a/examples/AudioBars/AudioBarsScene.tsx
+++ b/examples/AudioBars/AudioBarsScene.tsx
@@ -1,0 +1,72 @@
+import type { CSSProperties } from 'react';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { vec3 } from '@/core/lib/vectorUtils';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import { useAudioUniforms } from '@/react/hooks/useAudioUniforms';
+import type { AudioSourceSpec, Frameloop } from '@/types';
+
+import { audioBarsFragmentShader, audioBarsVertexShader } from './audioBarsShaders';
+
+type Vec3 = [number, number, number];
+
+const COLOR_LOW: Vec3 = [0.15, 0.45, 0.95];
+const COLOR_HIGH: Vec3 = [0.95, 0.25, 0.45];
+
+const shaderConfig = createShaderConfig({
+    vertexShader: audioBarsVertexShader,
+    fragmentShader: audioBarsFragmentShader,
+    uniformNames: {
+        u_audioBands: 'vec4',
+        u_audioLevel: 'float',
+        u_colorLow: 'vec3',
+        u_colorHigh: 'vec3'
+    }
+});
+
+export interface AudioBarsProps {
+    source: AudioSourceSpec;
+    attack?: number;
+    release?: number;
+    colorLow?: Vec3;
+    colorHigh?: Vec3;
+    frameloop?: Frameloop;
+    className?: string;
+    style?: CSSProperties;
+}
+
+export const AudioBars = ({
+    source,
+    attack = 0.01,
+    release = 0.18,
+    colorLow = COLOR_LOW,
+    colorHigh = COLOR_HIGH,
+    frameloop = 'demand',
+    className = '',
+    style
+}: AudioBarsProps) => {
+    const audio = useAudioUniforms(source, { bands: 4, attack, release });
+
+    return (
+        <>
+            <BaseShaderComponent
+                programId='audio-bars'
+                shaderConfig={shaderConfig}
+                uniforms={{
+                    ...audio.uniforms,
+                    u_colorLow: { type: 'vec3', value: vec3(colorLow) },
+                    u_colorHigh: { type: 'vec3', value: vec3(colorHigh) }
+                }}
+                frameloop={frameloop}
+                className={className}
+                style={style}
+            />
+            {audio.status === 'running'
+                ? <button type='button' onClick={audio.stop}>stop</button>
+                : <button type='button' onClick={() => { void audio.start() }}>start</button>}
+            {audio.error && <p role='alert'>{audio.error.message}</p>}
+        </>
+    );
+};
+
+export default AudioBars;

--- a/examples/AudioBars/audioBarsShaders.ts
+++ b/examples/AudioBars/audioBarsShaders.ts
@@ -1,0 +1,50 @@
+export const audioBarsVertexShader = /* glsl */`
+  attribute vec2 a_position;
+  varying vec2 v_texCoord;
+  void main() {
+    gl_Position = vec4(a_position, 0.0, 1.0);
+    v_texCoord = a_position * 0.5 + 0.5;
+  }
+`;
+
+export const audioBarsFragmentShader = /* glsl */`
+  precision highp float;
+
+  uniform vec2 u_resolution;
+  uniform float u_time;
+  uniform vec4 u_audioBands;
+  uniform float u_audioLevel;
+  uniform vec3 u_colorLow;
+  uniform vec3 u_colorHigh;
+
+  varying vec2 v_texCoord;
+
+  float bandAt(vec4 bands, float slot) {
+    if (slot < 0.5) return bands.x;
+    if (slot < 1.5) return bands.y;
+    if (slot < 2.5) return bands.z;
+    return bands.w;
+  }
+
+  void main() {
+    vec2 uv = v_texCoord;
+
+    float slot = floor(uv.x * 4.0);
+    float column = fract(uv.x * 4.0);
+    float height = bandAt(u_audioBands, slot);
+
+    float gutter = smoothstep(0.06, 0.12, column) * (1.0 - smoothstep(0.88, 0.94, column));
+    float fill = 1.0 - smoothstep(height - 0.012, height + 0.012, uv.y);
+    float cap = exp(-90.0 * abs(uv.y - height)) * gutter;
+
+    vec3 tint = mix(u_colorLow, u_colorHigh, slot / 3.0);
+    vec3 bar = tint * fill * gutter;
+
+    float pulse = 0.5 + 0.5 * sin(u_time * 0.002);
+    float glow = u_audioLevel * (0.25 + 0.1 * pulse) * exp(-2.5 * length(uv - vec2(0.5, 0.15)));
+
+    vec3 color = bar + tint * cap * 0.8 + vec3(glow);
+
+    gl_FragColor = vec4(color, 1.0);
+  }
+`;

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,3 +1,5 @@
+export { AudioBars, type AudioBarsProps } from './AudioBars/AudioBarsScene';
+export { audioBarsFragmentShader, audioBarsVertexShader } from './AudioBars/audioBarsShaders';
 export { Marble, type MarbleProps } from './Marble/MarbleScene';
 export { marbleFragmentShader,marbleVertexShader } from './Marble/marbleShaders';
 export { Ripple, type RippleProps } from './Ripple/RippleScene';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,7 @@
 export { createTypedFloat32Array,mat2, mat3, mat4, vec2, vec3, vec4 } from './lib/vectorUtils';
 export { createShaderConfig } from '@/core/lib/createShaderConfig';
 export type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+export { combineFrameInvalidation, createFrameInvalidation } from '@/core/lib/frameInvalidation';
 export {
     GL_CLAMP_TO_EDGE,
     GL_FLOAT,

--- a/src/core/lib/audioBands.ts
+++ b/src/core/lib/audioBands.ts
@@ -10,8 +10,12 @@ export interface ResolvedAudioNames {
     level: string;
 }
 
+const BAND_COUNTS = [1, 2, 3, 4] as const;
+
+export type BandCount = (typeof BAND_COUNTS)[number];
+
 export interface ResolvedAnalyserOptions {
-    bands: number;
+    bands: BandCount;
     fftSize: number;
     smoothingTimeConstant: number;
     attack: number;
@@ -44,6 +48,10 @@ const BAND_LAYOUTS: Record<BandLayout, true> = { log: true, linear: true };
 
 function isPowerOfTwo(value: number): boolean {
     return Number.isInteger(value) && value > 0 && (value & (value - 1)) === 0;
+}
+
+function isBandCount(value: number): value is BandCount {
+    return (BAND_COUNTS as readonly number[]).includes(value);
 }
 
 function partitionBins(rawEdges: number[], lo: number, hi: number, bands: number): BandRange[] {
@@ -188,7 +196,7 @@ function validateName(value: string, key: string): void {
 
 export function validateAudioOptions(options: AudioUniformsOptions = {}): ResolvedAudioOptions {
     const bands = options.bands ?? DEFAULT_BANDS;
-    if (!Number.isInteger(bands) || bands < 1 || bands > MAX_BANDS) {
+    if (!isBandCount(bands)) {
         throw new Error(
             `micugl audio: "bands" must be an integer between 1 and ${MAX_BANDS}, received ${JSON.stringify(options.bands)}. `
             + `The bands are packed into one float/vec2/vec3/vec4 uniform, which holds at most ${MAX_BANDS} components. `

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export type { FrameInvalidation } from './core';
 export {
+    combineFrameInvalidation,
+    createFrameInvalidation,
     createShaderConfig,
     createTypedFloat32Array,
     FBOManager,
@@ -20,15 +22,17 @@ export {
     vec4,
     WebGLManager
 } from './core';
+export type { AudioAnalyserDriverDeps, AudioUniformsResult } from './react';
 export {
     BaseInstancedShaderComponent,
     BasePingPongShaderComponent,
     BaseShaderComponent,
     createCommonUpdaters,
-    createUniformUpdater, 
+    createUniformUpdater,
     createUniformUpdaters,
     PingPongShaderEngine,
     ShaderEngine,
+    useAudioUniforms,
     useDarkMode,
     usePingPongPasses,
     useReducedMotion,
@@ -38,6 +42,11 @@ export {
 export type {
     AttributeConfig,
     AttributeType,
+    AudioSourceSpec,
+    AudioStatus,
+    AudioUniformNames,
+    AudioUniformsOptions,
+    BandLayout,
     BufferData,
     Dpr,
     EasingFn,

--- a/src/react/components/base/BaseInstancedShaderComponent.tsx
+++ b/src/react/components/base/BaseInstancedShaderComponent.tsx
@@ -64,7 +64,7 @@ const BaseInstancedShaderComponentImpl = forwardRef<ShaderHandle, BaseInstancedS
     renderOptions = RENDER_OPTIONS
 }, ref) => {
     const programConfigs = { [programId]: shaderConfig };
-    const { updaters, port, invalidation, springsInFlight } = useUniformUpdaters(
+    const { updaters, port, invalidation, capturesAreNonReproducible } = useUniformUpdaters(
         programId,
         uniforms,
         { skipDefaultUniforms, reducedMotion, saveData }
@@ -82,7 +82,7 @@ const BaseInstancedShaderComponentImpl = forwardRef<ShaderHandle, BaseInstancedS
             uniformUpdaters={updaters}
             debugPortRef={debugPortRef}
             invalidation={invalidation}
-            springsInFlight={springsInFlight}
+            capturesAreNonReproducible={capturesAreNonReproducible}
             width={width}
             height={height}
             pixelRatio={pixelRatio}

--- a/src/react/components/base/BasePingPongShaderComponent.tsx
+++ b/src/react/components/base/BasePingPongShaderComponent.tsx
@@ -79,7 +79,7 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
         programConfigs[actualSecondaryProgramId] = secondaryShaderConfig;
     }
 
-    const { passes, framebuffers, port, invalidation, springsInFlight } = usePingPongPasses({
+    const { passes, framebuffers, port, invalidation, capturesAreNonReproducible } = usePingPongPasses({
         programId,
         secondaryProgramId: secondaryShaderConfig ? actualSecondaryProgramId : undefined,
         iterations,
@@ -118,7 +118,7 @@ const BasePingPongShaderComponentImpl = forwardRef<PingPongShaderHandle, BasePin
             framebuffers={framebuffers}
             debugPortRef={debugPortRef}
             invalidation={invalidation}
-            springsInFlight={springsInFlight}
+            capturesAreNonReproducible={capturesAreNonReproducible}
             {...workerProps}
             className={className}
             style={style}

--- a/src/react/components/base/BaseShaderComponent.audio.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.audio.test.tsx
@@ -1,0 +1,280 @@
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { BandCount } from '@/core/lib/audioBands';
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { AudioUniformsResult } from '@/react/hooks/useAudioUniforms';
+import { useAudioUniforms } from '@/react/hooks/useAudioUniforms';
+import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
+import { asContext, createFakeStream, FakeContext, latestAnalyser, LOW_HALF } from '@/react/lib/fakeWebAudio';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type { AudioSourceSpec, AudioUniformsOptions, Frameloop, ShaderProgramConfig } from '@/types';
+
+const PROGRAM_ID = 'audio-bars';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+const MIC: AudioSourceSpec = { type: 'mic' };
+
+const BAND_TYPES = { 1: 'float', 2: 'vec2', 3: 'vec3', 4: 'vec4' } as const;
+
+const configFor = (bands: BandCount): ShaderProgramConfig => createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_audioBands: BAND_TYPES[bands], u_audioLevel: 'float' }
+});
+
+const optionsFor = (bands: BandCount): AudioUniformsOptions => ({
+    bands,
+    fftSize: 64,
+    bandLayout: 'linear',
+    attack: 0.05,
+    release: 0.4
+});
+
+interface Fixture {
+    context: FakeContext;
+    deps: AudioAnalyserDriverDeps;
+    hear: () => void;
+}
+
+function createFixture(): Fixture {
+    const context = new FakeContext();
+    const { stream } = createFakeStream();
+    return {
+        context,
+        deps: {
+            createContext: () => asContext(context),
+            getUserMedia: () => Promise.resolve(stream)
+        },
+        hear: () => { latestAnalyser(context).spectrum = LOW_HALF }
+    };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let originalGetContext: unknown;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stub = createGLStub();
+    originalGetContext = (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext;
+    (HTMLCanvasElement.prototype as unknown as { getContext: () => WebGLRenderingContext }).getContext =
+        function stubGetContext() { return stub.gl };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext = originalGetContext;
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+function uploadsOf(name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+function levelUploads(): number[] {
+    return uploadsOf('u_audioLevel') as number[];
+}
+
+function latestBands(): number[] {
+    const calls = uploadsOf('u_audioBands');
+    if (calls.length === 0) {
+        throw new Error('u_audioBands has never been uploaded');
+    }
+    return Array.from(calls[calls.length - 1] as Float32Array);
+}
+
+interface SceneProps {
+    probe: { current: AudioUniformsResult | null };
+    deps: AudioAnalyserDriverDeps;
+    bands: BandCount;
+    frameloop?: Frameloop;
+}
+
+const Scene = ({ probe, deps, bands, frameloop = 'always' }: SceneProps) => {
+    const audio = useAudioUniforms(MIC, optionsFor(bands), deps);
+    probe.current = audio;
+
+    return (
+        <BaseShaderComponent
+            programId={PROGRAM_ID}
+            shaderConfig={configFor(bands)}
+            uniforms={audio.uniforms}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop={frameloop}
+            reducedMotion='ignore'
+            saveData='ignore'
+        />
+    );
+};
+
+function probeRef(): { current: AudioUniformsResult | null } {
+    return { current: null };
+}
+
+function current(probe: { current: AudioUniformsResult | null }): AudioUniformsResult {
+    const value = probe.current;
+    if (!value) {
+        throw new Error('the scene has not rendered yet');
+    }
+    return value;
+}
+
+describe('audio uniforms reaching GL through a mounted BaseShaderComponent (real driver, fake analyser)', () => {
+    it('uploads a level that advances every frame once the analyser hears something', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        await mount(<Scene probe={probe} deps={fixture.deps} bands={2} />);
+        frames.tick(0);
+        expect(levelUploads()).toEqual([0]);
+
+        await act(async () => { await current(probe).start() });
+        fixture.hear();
+
+        for (let time = 16; time <= 160; time += 16) {
+            act(() => { frames.tick(time) });
+        }
+
+        const levels = levelUploads();
+        expect(levels.length).toBeGreaterThan(5);
+        for (let i = 1; i < levels.length; i++) {
+            expect(levels[i]).toBeGreaterThan(levels[i - 1]);
+        }
+        expect(levels[levels.length - 1]).toBeGreaterThan(0.4);
+        expect(levels.every(level => Number.isFinite(level))).toBe(true);
+        expect(latestBands()).toHaveLength(2);
+    });
+
+    it('frameloop="demand": start() wakes the loop, each analysed frame arms the next, and stop() drains it', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        await mount(<Scene probe={probe} deps={fixture.deps} bands={2} frameloop='demand' />);
+        act(() => { frames.tick(0) });
+        expect(levelUploads()).toEqual([0]);
+        expect(frames.pending()).toBe(0);
+
+        await act(async () => { await current(probe).start() });
+        expect(frames.pending()).toBe(1);
+
+        fixture.hear();
+
+        for (let time = 16; time <= 160; time += 16) {
+            act(() => { frames.tick(time) });
+            expect(frames.pending()).toBe(1);
+        }
+
+        const levels = levelUploads();
+        expect(levels.length).toBeGreaterThan(5);
+        for (let i = 1; i < levels.length; i++) {
+            expect(levels[i]).toBeGreaterThan(levels[i - 1]);
+        }
+        expect(levels[levels.length - 1]).toBeGreaterThan(0.4);
+
+        act(() => { current(probe).stop() });
+        expect(frames.pending()).toBe(1);
+
+        act(() => { frames.tick(176) });
+
+        expect(levelUploads()[levelUploads().length - 1]).toBe(0);
+        expect(latestBands()).toEqual([0, 0]);
+        expect(frames.pending()).toBe(0);
+
+        act(() => { frames.tick(192) });
+        expect(frames.pending()).toBe(0);
+    });
+
+    it('widening the bands 1 -> 4 uploads a full vec4, never a short buffer padded with NaN', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        await mount(<Scene probe={probe} deps={fixture.deps} bands={1} />);
+        act(() => { frames.tick(0) });
+
+        await act(async () => { await current(probe).start() });
+        fixture.hear();
+
+        for (let time = 16; time <= 160; time += 16) {
+            act(() => { frames.tick(time) });
+        }
+        expect(uploadsOf('u_audioBands').every(value => Number.isFinite(value))).toBe(true);
+
+        await mount(<Scene probe={probe} deps={fixture.deps} bands={4} />);
+        fixture.hear();
+
+        const series: number[][] = [];
+        for (let time = 176; time <= 336; time += 16) {
+            act(() => { frames.tick(time) });
+            series.push(latestBands());
+        }
+
+        expect(series.every(bands => bands.length === 4)).toBe(true);
+        expect(series.every(bands => bands.every(value => Number.isFinite(value)))).toBe(true);
+        for (let i = 1; i < series.length; i++) {
+            expect(series[i][0]).toBeGreaterThan(series[i - 1][0]);
+        }
+        expect(series[series.length - 1][0]).toBeGreaterThan(0.8);
+    });
+
+    it('a bands change uploads the reallocated vector, still advancing and never NaN', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        await mount(<Scene probe={probe} deps={fixture.deps} bands={4} />);
+        act(() => { frames.tick(0) });
+
+        await act(async () => { await current(probe).start() });
+        fixture.hear();
+
+        for (let time = 16; time <= 320; time += 16) {
+            act(() => { frames.tick(time) });
+        }
+        expect(latestBands()).toHaveLength(4);
+        expect(latestBands()[0]).toBeGreaterThan(0.8);
+
+        await mount(<Scene probe={probe} deps={fixture.deps} bands={2} />);
+        fixture.hear();
+
+        const series: number[][] = [];
+        for (let time = 336; time <= 496; time += 16) {
+            act(() => { frames.tick(time) });
+            series.push(latestBands());
+        }
+
+        expect(series.every(bands => bands.length === 2)).toBe(true);
+        expect(series.every(bands => bands.every(value => Number.isFinite(value)))).toBe(true);
+        expect(series[0][0]).toBeLessThan(0.3);
+        for (let i = 1; i < series.length; i++) {
+            expect(series[i][0]).toBeGreaterThan(series[i - 1][0]);
+        }
+        expect(series[series.length - 1][0]).toBeGreaterThan(0.8);
+    });
+});

--- a/src/react/components/base/BaseShaderComponent.tsx
+++ b/src/react/components/base/BaseShaderComponent.tsx
@@ -59,7 +59,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     renderOptions = RENDER_OPTIONS
 }, ref) => {
     const programConfigs = { [programId]: shaderConfig };
-    const { updaters, port, invalidation, springsInFlight } = useUniformUpdaters(
+    const { updaters, port, invalidation, capturesAreNonReproducible } = useUniformUpdaters(
         programId,
         uniforms,
         { skipDefaultUniforms, reducedMotion, saveData }
@@ -79,7 +79,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
             uniformUpdaters={updaters}
             debugPortRef={debugPortRef}
             invalidation={invalidation}
-            springsInFlight={springsInFlight}
+            capturesAreNonReproducible={capturesAreNonReproducible}
             {...workerProps}
             workerSkipDefaultUniforms={skipDefaultUniforms}
             width={width}

--- a/src/react/components/base/BaseShaderComponent.worker.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.worker.test.tsx
@@ -5,11 +5,21 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createShaderConfig } from '@/core/lib/createShaderConfig';
 import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { AudioUniformsResult } from '@/react/hooks/useAudioUniforms';
+import { useAudioUniforms } from '@/react/hooks/useAudioUniforms';
+import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
+import { asContext, createFakeStream, FakeContext, latestAnalyser, LOW_HALF } from '@/react/lib/fakeWebAudio';
 import type { GLStubHandle } from '@/testing';
 import { createGLStub } from '@/testing';
 import type { FrameQueue } from '@/testing/frameQueue';
 import { createFrameQueue } from '@/testing/frameQueue';
-import type { Frameloop, ShaderHandle, UniformParam } from '@/types';
+import type {
+    AudioSourceSpec,
+    AudioUniformsOptions,
+    Frameloop,
+    ShaderHandle,
+    UniformParam
+} from '@/types';
 import type { MainToWorker, WorkerToMain } from '@/worker/protocol';
 import type { WorkerRuntimeHost } from '@/worker/WorkerRuntime';
 import { WorkerRuntime } from '@/worker/WorkerRuntime';
@@ -24,12 +34,29 @@ const CONFIG = createShaderConfig({
     uniformNames: { u_level: 'float' }
 });
 
+const AUDIO_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_audioBands: 'vec2', u_audioLevel: 'float' }
+});
+
+const MIC: AudioSourceSpec = { type: 'mic' };
+
+const AUDIO_OPTIONS: AudioUniformsOptions = {
+    bands: 2,
+    fftSize: 64,
+    bandLayout: 'linear',
+    attack: 0.05,
+    release: 0.4
+};
+
 interface WorkerHarness {
     createWorker: () => Worker;
     gl: GLStubHandle;
     frames: FrameQueue;
     errors: string[];
     uploads: (name: string) => unknown[];
+    posted: MainToWorker[];
     transfers: () => number;
     mainThreadContexts: () => number;
     failToStart: () => void;
@@ -53,6 +80,7 @@ function createWorkerHarness({ startsScript = true }: WorkerHarnessOptions = {})
 
     const frames = createFrameQueue();
     const errors: string[] = [];
+    const posted: MainToWorker[] = [];
     const listeners: ((event: MessageEvent<WorkerToMain>) => void)[] = [];
     const errorListeners: ((event: Event) => void)[] = [];
 
@@ -75,6 +103,7 @@ function createWorkerHarness({ startsScript = true }: WorkerHarnessOptions = {})
 
     const worker = {
         postMessage: (message: MainToWorker) => {
+            posted.push(message);
             if (startsScript) {
                 runtime.handleMessage(message);
             }
@@ -112,6 +141,7 @@ function createWorkerHarness({ startsScript = true }: WorkerHarnessOptions = {})
         gl: stub,
         frames,
         errors,
+        posted,
         uploads: name => {
             const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
             return stub.uniformCalls
@@ -180,6 +210,118 @@ async function mount(element: ReactElement): Promise<void> {
         root.render(element);
         await Promise.resolve();
     });
+}
+
+interface AudioFixture {
+    context: FakeContext;
+    deps: AudioAnalyserDriverDeps;
+    hear: () => void;
+}
+
+function createAudioFixture(): AudioFixture {
+    const context = new FakeContext();
+    const { stream } = createFakeStream();
+    return {
+        context,
+        deps: {
+            createContext: () => asContext(context),
+            getUserMedia: () => Promise.resolve(stream)
+        },
+        hear: () => { latestAnalyser(context).spectrum = LOW_HALF }
+    };
+}
+
+function countedUniforms(
+    uniforms: Record<string, UniformParam>,
+    samples: string[]
+): Record<string, UniformParam> {
+    const counted: Record<string, UniformParam> = {};
+    for (const [name, param] of Object.entries(uniforms)) {
+        const value = param.value;
+        counted[name] = typeof value === 'function'
+            ? {
+                ...param,
+                value: (time, width, height) => {
+                    samples.push(name);
+                    return value(time, width, height);
+                }
+            }
+            : param;
+    }
+    return counted;
+}
+
+interface AudioSceneProps {
+    worker: WorkerHarness;
+    audio: AudioFixture;
+    probe: { current: AudioUniformsResult | null };
+    frameloop: Frameloop;
+    samples?: string[];
+}
+
+const AudioScene = ({ worker, audio, probe, frameloop, samples }: AudioSceneProps) => {
+    const result = useAudioUniforms(MIC, AUDIO_OPTIONS, audio.deps);
+    probe.current = result;
+
+    return (
+        <BaseShaderComponent
+            worker={true}
+            createWorker={worker.createWorker}
+            programId={PROGRAM_ID}
+            shaderConfig={AUDIO_CONFIG}
+            uniforms={samples ? countedUniforms(result.uniforms, samples) : result.uniforms}
+            liveUniforms={['u_audioBands', 'u_audioLevel']}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop={frameloop}
+            reducedMotion='ignore'
+            saveData='ignore'
+        />
+    );
+};
+
+function currentAudio(probe: { current: AudioUniformsResult | null }): AudioUniformsResult {
+    const value = probe.current;
+    if (!value) {
+        throw new Error('the audio scene has not rendered yet');
+    }
+    return value;
+}
+
+function latestBandsUpload(worker: WorkerHarness): number[] {
+    const calls = worker.uploads('u_audioBands');
+    if (calls.length === 0) {
+        throw new Error('u_audioBands has never been uploaded to the worker');
+    }
+    return Array.from(calls[calls.length - 1] as Float32Array);
+}
+
+function bandsPosts(worker: WorkerHarness): number {
+    return worker.posted.filter(
+        message => message.type === 'setUniformValues' && 'u_audioBands' in message.values
+    ).length;
+}
+
+interface BandFrame {
+    posts: number;
+    uploaded: number[];
+}
+
+function expectAdvancingBands(series: BandFrame[]): void {
+    expect(series.length).toBeGreaterThan(5);
+    expect(series.every(frame => frame.uploaded.length === 2)).toBe(true);
+    expect(series.every(frame => frame.uploaded.every(value => Number.isFinite(value)))).toBe(true);
+
+    for (let i = 1; i < series.length; i++) {
+        expect(series[i].posts).toBeGreaterThan(series[i - 1].posts);
+        expect(series[i].uploaded[0]).toBeGreaterThan(series[i - 1].uploaded[0]);
+    }
+    expect(series[series.length - 1].uploaded[0]).toBeGreaterThan(0.4);
+}
+
+function sampleBands(worker: WorkerHarness): BandFrame {
+    return { posts: bandsPosts(worker), uploaded: latestBandsUpload(worker) };
 }
 
 describe('BaseShaderComponent in worker mode', () => {
@@ -353,4 +495,137 @@ describe('BaseShaderComponent in worker mode', () => {
         expect(worker.errors).toEqual([]);
         expect(worker.uploads('u_level')).toEqual([0, 0.75]);
     });
+
+    it('frameloop="demand": an audio uniform keeps posting advancing values instead of freezing after one frame',
+        async () => {
+            const worker = createWorkerHarness();
+            const audio = createAudioFixture();
+            const probe = { current: null as AudioUniformsResult | null };
+
+            await mount(<AudioScene worker={worker} audio={audio} probe={probe} frameloop='demand' />);
+
+            act(() => { mainFrames.tick(0) });
+            worker.frames.tick(0);
+            expect(worker.uploads('u_audioLevel')).toEqual([0]);
+            expect(mainFrames.pending()).toBe(0);
+
+            await act(async () => { await currentAudio(probe).start() });
+            expect(mainFrames.pending()).toBe(1);
+
+            audio.hear();
+
+            const bandSeries: BandFrame[] = [];
+            for (let time = 16; time <= 160; time += 16) {
+                await act(async () => {
+                    mainFrames.tick(time);
+                    await Promise.resolve();
+                });
+                expect(mainFrames.pending()).toBe(1);
+                worker.frames.tick(time);
+                bandSeries.push(sampleBands(worker));
+            }
+
+            const levels = worker.uploads('u_audioLevel') as number[];
+            expect(worker.errors).toEqual([]);
+            expect(levels.length).toBeGreaterThan(5);
+            for (let i = 1; i < levels.length; i++) {
+                expect(levels[i]).toBeGreaterThan(levels[i - 1]);
+            }
+            expect(levels[levels.length - 1]).toBeGreaterThan(0.4);
+            expect(levels.every(level => Number.isFinite(level))).toBe(true);
+
+            expectAdvancingBands(bandSeries);
+
+            await act(async () => {
+                currentAudio(probe).stop();
+                await Promise.resolve();
+            });
+            await act(async () => {
+                mainFrames.tick(176);
+                await Promise.resolve();
+            });
+            worker.frames.tick(176);
+
+            const after = worker.uploads('u_audioLevel') as number[];
+            expect(after[after.length - 1]).toBe(0);
+            expect(mainFrames.pending()).toBe(0);
+        });
+
+    it('samples each live uniform once per frame: waking the loop from inside the sampler must not re-enter it',
+        async () => {
+            const worker = createWorkerHarness();
+            const audio = createAudioFixture();
+            const probe = { current: null as AudioUniformsResult | null };
+            const samples: string[] = [];
+
+            await mount(
+                <AudioScene worker={worker} audio={audio} probe={probe} frameloop='demand' samples={samples} />
+            );
+            act(() => { mainFrames.tick(0) });
+
+            await act(async () => { await currentAudio(probe).start() });
+            audio.hear();
+
+            const analyser = latestAnalyser(audio.context);
+            const readsBefore = analyser.reads;
+            samples.length = 0;
+
+            const bandSeries: BandFrame[] = [];
+            for (let time = 16; time <= 112; time += 16) {
+                await act(async () => {
+                    mainFrames.tick(time);
+                    await Promise.resolve();
+                });
+                worker.frames.tick(time);
+                bandSeries.push(sampleBands(worker));
+            }
+
+            expect(samples.filter(name => name === 'u_audioLevel')).toHaveLength(7);
+            expect(samples.filter(name => name === 'u_audioBands')).toHaveLength(7);
+            expect(analyser.reads - readsBefore).toBe(7);
+
+            expectAdvancingBands(bandSeries);
+        });
+
+    it('never posts an invalidate ahead of the setUniformValues it is for: the worker cannot redraw stale uniforms',
+        async () => {
+            const worker = createWorkerHarness();
+            const audio = createAudioFixture();
+            const probe = { current: null as AudioUniformsResult | null };
+
+            await mount(<AudioScene worker={worker} audio={audio} probe={probe} frameloop='demand' />);
+            act(() => { mainFrames.tick(0) });
+
+            await act(async () => { await currentAudio(probe).start() });
+            audio.hear();
+
+            worker.posted.length = 0;
+
+            for (let time = 16; time <= 96; time += 16) {
+                await act(async () => {
+                    mainFrames.tick(time);
+                    await Promise.resolve();
+                });
+                worker.frames.tick(time);
+            }
+
+            const order = worker.posted
+                .map(message => message.type)
+                .filter(type => type === 'setUniformValues' || type === 'invalidate');
+
+            expect(order.filter(type => type === 'setUniformValues').length).toBeGreaterThan(4);
+            expect(order.filter(type => type === 'invalidate').length).toBeGreaterThan(4);
+            expect(order[0]).toBe('setUniformValues');
+
+            let posts = 0;
+            let redraws = 0;
+            for (const type of order) {
+                if (type === 'setUniformValues') {
+                    posts += 1;
+                    continue;
+                }
+                redraws += 1;
+                expect(redraws).toBeLessThanOrEqual(posts);
+            }
+        });
 });

--- a/src/react/components/base/captureLiveness.test.tsx
+++ b/src/react/components/base/captureLiveness.test.tsx
@@ -7,11 +7,17 @@ import { createShaderConfig } from '@/core/lib/createShaderConfig';
 import { GL_NEAREST, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
 import { BasePingPongShaderComponent } from '@/react/components/base/BasePingPongShaderComponent';
 import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { AudioUniformsResult } from '@/react/hooks/useAudioUniforms';
+import { useAudioUniforms } from '@/react/hooks/useAudioUniforms';
+import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
+import { asContext, createFakeStream, FakeContext, latestAnalyser, LOW_HALF } from '@/react/lib/fakeWebAudio';
 import type { GLStubHandle } from '@/testing';
 import { createGLStub } from '@/testing';
 import type { FrameQueue } from '@/testing/frameQueue';
 import { createFrameQueue } from '@/testing/frameQueue';
 import type {
+    AudioSourceSpec,
+    AudioUniformsOptions,
     FramebufferOptions,
     PingPongShaderHandle,
     SequenceOptions,
@@ -45,6 +51,22 @@ const CONFIG = createShaderConfig({
     fragmentShader: 'void main() {}',
     uniformNames: { u_swirl: 'float' }
 });
+
+const AUDIO_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_audioBands: 'vec2', u_audioLevel: 'float' }
+});
+
+const MIC: AudioSourceSpec = { type: 'mic' };
+
+const AUDIO_OPTIONS: AudioUniformsOptions = {
+    bands: 2,
+    fftSize: 64,
+    bandLayout: 'linear',
+    attack: 0.05,
+    release: 0.4
+};
 
 class MediaRecorderStub {
     static isTypeSupported = (type: string): boolean => type === 'video/webm;codecs=vp9';
@@ -177,6 +199,59 @@ function settle(): void {
     }
 }
 
+interface AudioFixture {
+    context: FakeContext;
+    deps: AudioAnalyserDriverDeps;
+    hear: () => void;
+}
+
+function createAudioFixture(): AudioFixture {
+    const context = new FakeContext();
+    const { stream } = createFakeStream();
+    return {
+        context,
+        deps: {
+            createContext: () => asContext(context),
+            getUserMedia: () => Promise.resolve(stream)
+        },
+        hear: () => { latestAnalyser(context).spectrum = LOW_HALF }
+    };
+}
+
+interface AudioSceneProps {
+    handleRef: RefObject<ShaderHandle | null>;
+    probe: { current: AudioUniformsResult | null };
+    deps: AudioAnalyserDriverDeps;
+}
+
+const AudioScene = ({ handleRef, probe, deps }: AudioSceneProps) => {
+    const audio = useAudioUniforms(MIC, AUDIO_OPTIONS, deps);
+    probe.current = audio;
+
+    return (
+        <BaseShaderComponent
+            ref={handleRef}
+            programId={PROGRAM_ID}
+            shaderConfig={AUDIO_CONFIG}
+            uniforms={audio.uniforms}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop='demand'
+            reducedMotion='ignore'
+            saveData='ignore'
+        />
+    );
+};
+
+function currentAudio(probe: { current: AudioUniformsResult | null }): AudioUniformsResult {
+    const value = probe.current;
+    if (!value) {
+        throw new Error('the audio scene has not rendered yet');
+    }
+    return value;
+}
+
 describe('deterministic capture with a spring transition in flight, through mounted components', () => {
     it('renderSequence throws while a spring is in flight, and the message says why', async () => {
         const handleRef: RefObject<ShaderHandle | null> = { current: null };
@@ -294,5 +369,98 @@ describe('deterministic capture with a spring transition in flight, through moun
         stub.reset();
         await expect(handleRef.current?.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
         expect(stub.readPixelsCalls.length).toBe(1);
+    });
+});
+
+describe('deterministic capture with a live audio input, through mounted components', () => {
+    it('renderSequence throws while the audio is running, and the message names the audio, not a spring', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        const probe: { current: AudioUniformsResult | null } = { current: null };
+        const fixture = createAudioFixture();
+
+        await mount(<AudioScene handleRef={handleRef} probe={probe} deps={fixture.deps} />);
+        frames.tick(0);
+
+        await act(async () => { await currentAudio(probe).start() });
+        fixture.hear();
+        frames.tick(16);
+
+        expect(() => handleRef.current?.renderSequence(SEQUENCE))
+            .toThrow(/ShaderEngine\.renderSequence: audio is running/);
+        expect(() => handleRef.current?.renderSequence(SEQUENCE)).toThrow(/would not reproduce/);
+        expect(() => handleRef.current?.renderSequence(SEQUENCE)).toThrow(/Call stop\(\) on the audio hook/);
+        expect(() => handleRef.current?.renderSequence(SEQUENCE)).not.toThrow(/spring/);
+    });
+
+    it('renderToBlob({ frame }) rejects while the audio is running, and never reaches the pixel read', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        const probe: { current: AudioUniformsResult | null } = { current: null };
+        const fixture = createAudioFixture();
+
+        await mount(<AudioScene handleRef={handleRef} probe={probe} deps={fixture.deps} />);
+        frames.tick(0);
+
+        await act(async () => { await currentAudio(probe).start() });
+        fixture.hear();
+        frames.tick(16);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob({ frame: 30 }))
+            .rejects.toThrow(/ShaderEngine\.renderToBlob: audio is running/);
+        expect(stub.readPixelsCalls.length).toBe(0);
+
+        expect(() => handleRef.current?.renderToDataURL({ frame: 30 })).toThrow(/audio is running/);
+    });
+
+    it('a stopped audio scene captures fine: the guard asks the driver, it is not a static flag on the uniform', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        const probe: { current: AudioUniformsResult | null } = { current: null };
+        const fixture = createAudioFixture();
+
+        await mount(<AudioScene handleRef={handleRef} probe={probe} deps={fixture.deps} />);
+        frames.tick(0);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
+        expect(stub.readPixelsCalls.length).toBe(1);
+
+        await act(async () => { await currentAudio(probe).start() });
+        fixture.hear();
+        frames.tick(16);
+        expect(currentAudio(probe).status).toBe('running');
+
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).rejects.toThrow(/audio is running/);
+
+        act(() => { currentAudio(probe).stop() });
+        expect(currentAudio(probe).status).toBe('stopped');
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
+        expect(stub.readPixelsCalls.length).toBe(1);
+
+        await expect(handleRef.current?.renderSequence(SEQUENCE)).rejects.toThrow(/WebCodecs|VideoEncoder/);
+    });
+
+    it('a live capture of running audio is honest, so renderToBlob() with no frame and record() both run', async () => {
+        const handleRef: RefObject<ShaderHandle | null> = { current: null };
+        const probe: { current: AudioUniformsResult | null } = { current: null };
+        const fixture = createAudioFixture();
+
+        await mount(<AudioScene handleRef={handleRef} probe={probe} deps={fixture.deps} />);
+        frames.tick(0);
+
+        await act(async () => { await currentAudio(probe).start() });
+        fixture.hear();
+        frames.tick(16);
+
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).rejects.toThrow(/audio is running/);
+
+        stub.reset();
+        await expect(handleRef.current?.renderToBlob()).resolves.toBeInstanceOf(Blob);
+        expect(stub.readPixelsCalls.length).toBe(1);
+
+        const recording = handleRef.current?.record();
+        expect(recording?.stream).toBeDefined();
+        expect(recorderStarts).toBe(1);
     });
 });

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -27,6 +27,8 @@ import { useMotionGate } from '@/react/hooks/useMotionGate';
 import type { WorkerBridgeInitPayload } from '@/react/hooks/useWorkerBridge';
 import { useWorkerBridge } from '@/react/hooks/useWorkerBridge';
 import { pixelsToBlob, pixelsToDataURL } from '@/react/lib/captureBlob';
+import type { CapturesAreNonReproducible } from '@/react/lib/captureLiveness';
+import { nonReproducibleCaptureMessage } from '@/react/lib/captureLiveness';
 import { framebuffersContentKey, programConfigsContentKey } from '@/react/lib/contentKeys';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import { createRecording } from '@/react/lib/record';
@@ -38,8 +40,6 @@ import {
     resolveDeviceResolution,
     resolveResolution
 } from '@/react/lib/resolution';
-import type { SpringsInFlight } from '@/react/lib/springCapture';
-import { springInFlightMessage } from '@/react/lib/springCapture';
 import { frameToMs } from '@/react/lib/timeKeeper';
 import type { WorkerBlock, WorkerProgramUniforms } from '@/react/lib/workerMode';
 import {
@@ -74,7 +74,7 @@ interface PingPongShaderEngineBaseProps extends Omit<RenderControlProps, 'worker
     debug?: boolean;
     debugPortRef?: RefObject<UniformDebugPort | null>;
     invalidation?: FrameInvalidation;
-    springsInFlight?: SpringsInFlight;
+    capturesAreNonReproducible?: CapturesAreNonReproducible;
 }
 
 export type PingPongShaderEngineWorkerProps =
@@ -157,7 +157,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     workerUniforms,
     workerCustomPasses = false,
     invalidation,
-    springsInFlight,
+    capturesAreNonReproducible,
     worker,
     createWorker,
     useDevicePixelRatio,
@@ -255,8 +255,9 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         }
 
         const stepsTheClock = opts.frame !== undefined || opts.steps !== undefined;
-        if (stepsTheClock && springsInFlight?.()) {
-            throw new Error(springInFlightMessage('PingPongShaderEngine', 'renderToBlob'));
+        const blocker = stepsTheClock ? capturesAreNonReproducible?.() : null;
+        if (blocker) {
+            throw new Error(nonReproducibleCaptureMessage('PingPongShaderEngine', 'renderToBlob', blocker));
         }
 
         const timePure = passSystem.isTimePure();
@@ -316,7 +317,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         );
 
         return { ...result, type: opts.type, quality: opts.quality };
-    }, [springsInFlight]);
+    }, [capturesAreNonReproducible]);
 
     const applySize = useCallback(() => {
         const canvas = canvasRef.current;
@@ -799,8 +800,9 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             if (manager.context.isContextLost()) {
                 throw new Error('PingPongShaderEngine.renderSequence: WebGL context is lost');
             }
-            if (springsInFlight?.()) {
-                throw new Error(springInFlightMessage('PingPongShaderEngine', 'renderSequence'));
+            const blocker = capturesAreNonReproducible?.();
+            if (blocker) {
+                throw new Error(nonReproducibleCaptureMessage('PingPongShaderEngine', 'renderSequence', blocker));
             }
             const canvas = manager.context.canvas as HTMLCanvasElement;
             const controller = controllerRef.current;
@@ -825,7 +827,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
                 }
             });
         }
-    }, [workerActive, resetSimulation, captureStill, setStopped, invalidateAll, springsInFlight]);
+    }, [workerActive, resetSimulation, captureStill, setStopped, invalidateAll, capturesAreNonReproducible]);
 
     if (workerActive && block) {
         throw new Error(workerBlockMessage('PingPongShaderEngine', block));

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -28,6 +28,8 @@ import { useMotionGate } from '@/react/hooks/useMotionGate';
 import type { WorkerBridgeInitPayload } from '@/react/hooks/useWorkerBridge';
 import { useWorkerBridge } from '@/react/hooks/useWorkerBridge';
 import { pixelsToBlob, pixelsToDataURL } from '@/react/lib/captureBlob';
+import type { CapturesAreNonReproducible } from '@/react/lib/captureLiveness';
+import { nonReproducibleCaptureMessage } from '@/react/lib/captureLiveness';
 import { instancingContentKey, programConfigContentKey, singleProgramEntry } from '@/react/lib/contentKeys';
 import { createDelegatingInstancingConfig } from '@/react/lib/instancingConfig';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
@@ -40,8 +42,6 @@ import {
     resolveDeviceResolution,
     resolveResolution
 } from '@/react/lib/resolution';
-import type { SpringsInFlight } from '@/react/lib/springCapture';
-import { springInFlightMessage } from '@/react/lib/springCapture';
 import { frameToMs } from '@/react/lib/timeKeeper';
 import type { WorkerBlock, WorkerProgramUniforms } from '@/react/lib/workerMode';
 import {
@@ -85,7 +85,7 @@ interface ShaderEngineBaseProps extends Omit<RenderControlProps, 'worker' | 'cre
     debugPortRef?: RefObject<UniformDebugPort | null>;
     workerSkipDefaultUniforms?: boolean;
     invalidation?: FrameInvalidation;
-    springsInFlight?: SpringsInFlight;
+    capturesAreNonReproducible?: CapturesAreNonReproducible;
 }
 
 export type ShaderEngineWorkerProps =
@@ -175,7 +175,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     workerSkipDefaultUniforms = false,
     liveUniforms,
     invalidation,
-    springsInFlight,
+    capturesAreNonReproducible,
     worker,
     createWorker,
     useDevicePixelRatio,
@@ -212,6 +212,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     const bridgeRef = useRef<WorkerBridge | null>(null);
     const renderSizeRef = useRef({ renderWidth: 0, renderHeight: 0 });
     const workerActiveRef = useRef(false);
+    const samplingRef = useRef(false);
 
     const [epoch, setEpoch] = useState(0);
 
@@ -290,8 +291,9 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         }
 
         const explicitFrame = opts.frame !== undefined;
-        if (explicitFrame && springsInFlight?.()) {
-            throw new Error(springInFlightMessage('ShaderEngine', 'renderToBlob'));
+        const blocker = explicitFrame ? capturesAreNonReproducible?.() : null;
+        if (blocker) {
+            throw new Error(nonReproducibleCaptureMessage('ShaderEngine', 'renderToBlob', blocker));
         }
 
         const canvas = manager.context.canvas as HTMLCanvasElement;
@@ -329,7 +331,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         );
 
         return { ...result, type: opts.type, quality: opts.quality };
-    }, [renderFrame, drawFastPathGeometry, springsInFlight]);
+    }, [renderFrame, drawFastPathGeometry, capturesAreNonReproducible]);
 
     const commitSize = useCallback((
         resolution: { renderWidth: number; renderHeight: number },
@@ -427,13 +429,18 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
     const postLiveUniforms = useCallback((elapsed: number) => {
         const bridge = bridgeRef.current;
         const { programs, programId, names } = liveRef.current;
-        if (!bridge || !programs || names.length === 0) return;
+        if (!bridge || !programs || names.length === 0 || samplingRef.current) return;
 
         const { renderWidth, renderHeight } = renderSizeRef.current;
-        bridge.setUniformValues(
-            programId,
-            sampleLiveUniforms(names, programs[programId], elapsed, renderWidth, renderHeight)
-        );
+        samplingRef.current = true;
+        try {
+            bridge.setUniformValues(
+                programId,
+                sampleLiveUniforms(names, programs[programId], elapsed, renderWidth, renderHeight)
+            );
+        } finally {
+            samplingRef.current = false;
+        }
     }, []);
 
     const driveFrame = useCallback((elapsed: number) => {
@@ -876,8 +883,9 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
             if (options.seed !== undefined) {
                 throw new Error('ShaderEngine.renderSequence: no simulation to seed');
             }
-            if (springsInFlight?.()) {
-                throw new Error(springInFlightMessage('ShaderEngine', 'renderSequence'));
+            const blocker = capturesAreNonReproducible?.();
+            if (blocker) {
+                throw new Error(nonReproducibleCaptureMessage('ShaderEngine', 'renderSequence', blocker));
             }
             const canvas = manager.context.canvas as HTMLCanvasElement;
             const controller = controllerRef.current;
@@ -899,7 +907,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         invalidateAll,
         startSamplerLoop,
         setStopped,
-        springsInFlight
+        capturesAreNonReproducible
     ]);
 
     if (workerActive && block) {

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useAudioUniforms } from './useAudioUniforms';
 export { useDarkMode } from './useDarkMode';
 export { usePingPongPasses } from './usePingPongPasses';
 export { useReducedMotion } from './useReducedMotion';

--- a/src/react/hooks/useAudioUniforms.test.tsx
+++ b/src/react/hooks/useAudioUniforms.test.tsx
@@ -1,0 +1,424 @@
+import { act, StrictMode, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { AudioUniformsResult } from '@/react/hooks/useAudioUniforms';
+import { useAudioUniforms } from '@/react/hooks/useAudioUniforms';
+import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
+import type { FakeTrack } from '@/react/lib/fakeWebAudio';
+import { asContext, asElement, createFakeStream, FakeContext, latestAnalyser, LOW_HALF } from '@/react/lib/fakeWebAudio';
+import type { AudioSourceSpec, AudioUniformsOptions } from '@/types';
+
+const MIC: AudioSourceSpec = { type: 'mic' };
+
+interface Fixture {
+    context: FakeContext;
+    tracks: FakeTrack[];
+    deps: AudioAnalyserDriverDeps;
+    grants: number;
+    contexts: number;
+}
+
+function createFixture(overrides: Partial<AudioAnalyserDriverDeps> = {}): Fixture {
+    const context = new FakeContext();
+    const fixture: Fixture = {
+        context,
+        tracks: [],
+        grants: 0,
+        contexts: 0,
+        deps: {
+            createContext: () => {
+                fixture.contexts += 1;
+                return asContext(context);
+            },
+            getUserMedia: () => {
+                fixture.grants += 1;
+                const granted = createFakeStream();
+                fixture.tracks.push(...granted.tracks);
+                return Promise.resolve(granted.stream);
+            },
+            ...overrides
+        }
+    };
+    return fixture;
+}
+
+interface ProbeProps {
+    probe: { current: AudioUniformsResult | null };
+    source?: AudioSourceSpec;
+    options?: AudioUniformsOptions;
+    deps: AudioAnalyserDriverDeps;
+}
+
+const Probe = ({ probe, source = MIC, options, deps }: ProbeProps) => {
+    probe.current = useAudioUniforms(source, options, deps);
+    return null;
+};
+
+const AutoStarting = ({ probe, source = MIC, options, deps }: ProbeProps) => {
+    const audio = useAudioUniforms(source, options, deps);
+    probe.current = audio;
+
+    const { start, stop } = audio;
+    useEffect(() => {
+        void start();
+        return stop;
+    }, [start, stop]);
+
+    return null;
+};
+
+function sample(result: AudioUniformsResult, name: string, time: number): number[] {
+    const param = result.uniforms[name];
+    if (typeof param.value !== 'function') {
+        throw new Error(`expected "${name}" to be a function-valued uniform`);
+    }
+    const value = param.value(time);
+    return typeof value === 'number' ? [value] : Array.from(value);
+}
+
+const TWO_BAND_LINEAR: AudioUniformsOptions = {
+    bands: 2,
+    fftSize: 64,
+    bandLayout: 'linear',
+    attack: 0.05,
+    release: 0.4
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+});
+
+function render(element: React.ReactElement): void {
+    act(() => { root.render(element) });
+}
+
+function probeRef(): { current: AudioUniformsResult | null } {
+    return { current: null };
+}
+
+function current(probe: { current: AudioUniformsResult | null }): AudioUniformsResult {
+    const value = probe.current;
+    if (!value) {
+        throw new Error('the hook has not rendered yet');
+    }
+    return value;
+}
+
+describe('useAudioUniforms uniforms', () => {
+    it('packs the bands into one uniform whose type follows the band count, alongside the level float', () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        render(<Probe probe={probe} deps={fixture.deps} />);
+        expect(current(probe).uniforms.u_audioBands.type).toBe('vec4');
+        expect(current(probe).uniforms.u_audioLevel.type).toBe('float');
+
+        render(<Probe probe={probe} deps={fixture.deps} options={{ bands: 1 }} />);
+        expect(current(probe).uniforms.u_audioBands.type).toBe('float');
+        expect(sample(current(probe), 'u_audioBands', 16)).toEqual([0]);
+
+        render(<Probe probe={probe} deps={fixture.deps} options={{ bands: 3, names: { bands: 'u_fft', level: 'u_loud' } }} />);
+        expect(Object.keys(current(probe).uniforms)).toEqual(['u_fft', 'u_loud']);
+        expect(current(probe).uniforms.u_fft.type).toBe('vec3');
+    });
+
+    it('hands the engine the driver invalidation on every audio uniform, so a demand engine can be woken', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        render(<Probe probe={probe} deps={fixture.deps} options={TWO_BAND_LINEAR} />);
+
+        const bands = current(probe).uniforms.u_audioBands.invalidation;
+        const level = current(probe).uniforms.u_audioLevel.invalidation;
+        expect(bands).toBeDefined();
+        expect(level).toBe(bands);
+
+        const woken: number[] = [];
+        bands?.connect(() => { woken.push(1) });
+
+        expect(woken).toHaveLength(0);
+        await act(async () => { await current(probe).start() });
+        expect(woken).toHaveLength(1);
+
+        sample(current(probe), 'u_audioBands', 16);
+        expect(woken).toHaveLength(2);
+
+        sample(current(probe), 'u_audioLevel', 16);
+        expect(woken).toHaveLength(2);
+    });
+
+    it('samples the analyser at frame time: the bands advance across frames and the level is their mean', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        render(<Probe probe={probe} deps={fixture.deps} options={TWO_BAND_LINEAR} />);
+        await act(async () => { await current(probe).start() });
+        latestAnalyser(fixture.context).spectrum = LOW_HALF;
+
+        const series: number[][] = [];
+        for (let time = 0; time <= 160; time += 16) {
+            series.push(sample(current(probe), 'u_audioBands', time));
+        }
+
+        expect(series[0]).toEqual([0, 0]);
+        for (let i = 2; i < series.length; i++) {
+            expect(series[i][0]).toBeGreaterThan(series[i - 1][0]);
+        }
+        expect(series[series.length - 1][0]).toBeGreaterThan(0.8);
+        expect(series.every(bands => bands.every(value => Number.isFinite(value)))).toBe(true);
+
+        const bands = sample(current(probe), 'u_audioBands', 176);
+        const level = sample(current(probe), 'u_audioLevel', 176);
+        expect(level).toEqual([(bands[0] + bands[1]) / 2]);
+    });
+
+    it('reads the reallocated scratch after a bands change instead of a buffer captured when the uniforms were built', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        render(<Probe probe={probe} deps={fixture.deps} options={{ ...TWO_BAND_LINEAR, bands: 4 }} />);
+        await act(async () => { await current(probe).start() });
+        latestAnalyser(fixture.context).spectrum = LOW_HALF;
+
+        for (let time = 0; time <= 320; time += 16) {
+            sample(current(probe), 'u_audioBands', time);
+        }
+        expect(sample(current(probe), 'u_audioBands', 336)).toHaveLength(4);
+
+        render(<Probe probe={probe} deps={fixture.deps} options={TWO_BAND_LINEAR} />);
+        latestAnalyser(fixture.context).spectrum = LOW_HALF;
+
+        expect(current(probe).uniforms.u_audioBands.type).toBe('vec2');
+
+        const series: number[][] = [];
+        for (let time = 352; time <= 512; time += 16) {
+            series.push(sample(current(probe), 'u_audioBands', time));
+        }
+
+        expect(series.every(bands => bands.length === 2)).toBe(true);
+        expect(series.every(bands => bands.every(value => Number.isFinite(value)))).toBe(true);
+        expect(series[0][0]).toBeLessThan(0.2);
+        for (let i = 2; i < series.length; i++) {
+            expect(series[i][0]).toBeGreaterThan(series[i - 1][0]);
+        }
+        expect(series[series.length - 1][0]).toBeGreaterThan(0.8);
+    });
+});
+
+describe('useAudioUniforms lifecycle', () => {
+    it('surfaces the driver status and error through React state', async () => {
+        const denied = new Error('NotAllowedError: Permission denied');
+        const probe = probeRef();
+        const fixture = createFixture({ getUserMedia: () => Promise.reject(denied) });
+
+        render(<Probe probe={probe} deps={fixture.deps} />);
+        expect(current(probe).status).toBe('idle');
+        expect(current(probe).error).toBeNull();
+
+        await act(async () => { await expect(current(probe).start()).rejects.toThrow('Permission denied') });
+
+        expect(current(probe).status).toBe('error');
+        expect(current(probe).error).toBe(denied);
+    });
+
+    it('re-renders as the status moves from idle to running to stopped', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+        const seen: string[] = [];
+
+        const Watcher = () => {
+            const audio = useAudioUniforms(MIC, undefined, fixture.deps);
+            probe.current = audio;
+            seen.push(audio.status);
+            return null;
+        };
+
+        render(<Watcher />);
+        await act(async () => { await current(probe).start() });
+        act(() => { current(probe).stop() });
+
+        expect(seen).toContain('idle');
+        expect(seen).toContain('running');
+        expect(seen[seen.length - 1]).toBe('stopped');
+    });
+
+    it("StrictMode's double-invoked start/stop/start effect opens one AudioContext and rebinds the element once", async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+        const element = asElement('strict');
+
+        await act(async () => {
+            root.render(
+                <StrictMode>
+                    <AutoStarting probe={probe} deps={fixture.deps} source={{ type: 'element', element }} />
+                </StrictMode>
+            );
+            await Promise.resolve();
+        });
+
+        expect(fixture.contexts).toBe(1);
+        expect(fixture.grants).toBe(0);
+        expect(fixture.context.elementSources).toHaveLength(1);
+        expect(fixture.context.analysers).toHaveLength(1);
+        expect(current(probe).status).toBe('running');
+
+        const sourceNode = fixture.context.elementSources[0];
+        expect(sourceNode.connections).toEqual([
+            fixture.context.destination,
+            latestAnalyser(fixture.context)
+        ]);
+
+        act(() => { root.unmount() });
+
+        expect(sourceNode.connections).toEqual([fixture.context.destination]);
+        expect(fixture.context.closeCalls).toBe(0);
+    });
+
+    it("StrictMode's double-invoked start/stop/start effect prompts for the microphone exactly once", async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        await act(async () => {
+            root.render(
+                <StrictMode>
+                    <AutoStarting probe={probe} deps={fixture.deps} />
+                </StrictMode>
+            );
+            await Promise.resolve();
+        });
+
+        expect(fixture.grants).toBe(1);
+        expect(fixture.contexts).toBe(1);
+        expect(fixture.tracks).toHaveLength(2);
+        expect(fixture.context.streamSources).toHaveLength(1);
+        expect(fixture.context.analysers).toHaveLength(1);
+        expect(current(probe).status).toBe('running');
+        expect(fixture.tracks.every(track => track.stopped)).toBe(false);
+
+        const sourceNode = fixture.context.streamSources[0];
+        expect(sourceNode.connections).toEqual([latestAnalyser(fixture.context)]);
+        expect(sourceNode.connections).not.toContain(fixture.context.destination);
+
+        act(() => { root.unmount() });
+
+        expect(fixture.tracks.every(track => track.stopped)).toBe(true);
+        expect(fixture.context.closeCalls).toBe(1);
+        expect(fixture.grants).toBe(1);
+    });
+
+    it('releases the microphone and closes the AudioContext on unmount', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        render(<Probe probe={probe} deps={fixture.deps} />);
+        await act(async () => { await current(probe).start() });
+
+        expect(fixture.grants).toBe(1);
+        expect(fixture.contexts).toBe(1);
+        expect(fixture.context.analysers).toHaveLength(1);
+        expect(current(probe).status).toBe('running');
+        expect(fixture.tracks.every(track => track.stopped)).toBe(false);
+
+        act(() => { root.unmount() });
+
+        expect(fixture.tracks.every(track => track.stopped)).toBe(true);
+        expect(fixture.context.closeCalls).toBe(1);
+        expect(fixture.grants).toBe(1);
+    });
+
+    it('throws when the source is swapped under a live hook instead of silently rebinding it', () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+        const first = asElement('first');
+        const second = asElement('second');
+
+        render(<Probe probe={probe} deps={fixture.deps} source={{ type: 'element', element: first }} />);
+
+        expect(() => {
+            render(<Probe probe={probe} deps={fixture.deps} source={{ type: 'element', element: second }} />);
+        }).toThrow(/one audio graph for its whole life/);
+    });
+});
+
+describe('useAudioUniforms reconfiguration', () => {
+    it('renaming the uniforms does not rebuild the analyser, so the smoothing history survives', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        render(<Probe probe={probe} deps={fixture.deps} options={TWO_BAND_LINEAR} />);
+        await act(async () => { await current(probe).start() });
+        latestAnalyser(fixture.context).spectrum = LOW_HALF;
+
+        for (let time = 0; time <= 96; time += 16) {
+            sample(current(probe), 'u_audioBands', time);
+        }
+        const before = sample(current(probe), 'u_audioBands', 112)[0];
+        expect(before).toBeGreaterThan(0);
+
+        render(
+            <Probe
+                probe={probe}
+                deps={fixture.deps}
+                options={{ ...TWO_BAND_LINEAR, names: { bands: 'u_spectrum', level: 'u_loudness' } }}
+            />
+        );
+
+        expect(fixture.context.analysers).toHaveLength(1);
+        expect(Object.keys(current(probe).uniforms)).toEqual(['u_spectrum', 'u_loudness']);
+
+        const after = sample(current(probe), 'u_spectrum', 128)[0];
+        expect(after).toBeGreaterThan(before);
+    });
+
+    it('a reconfigure the device rejects throws, and tears the hook down without leaving the microphone open', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        render(<Probe probe={probe} deps={fixture.deps} options={TWO_BAND_LINEAR} />);
+        await act(async () => { await current(probe).start() });
+        expect(current(probe).status).toBe('running');
+        expect(fixture.tracks.every(track => track.stopped)).toBe(false);
+
+        fixture.context.sampleRate = 384000;
+
+        expect(() => {
+            render(<Probe probe={probe} deps={fixture.deps} options={{ bands: 4, fftSize: 32 }} />);
+        }).toThrow(/cannot be\s+split into 4 non-empty/);
+
+        expect(fixture.tracks.every(track => track.stopped)).toBe(true);
+        expect(fixture.context.closeCalls).toBe(1);
+        expect(fixture.grants).toBe(1);
+    });
+
+    it('changing an analyser option rebuilds the analyser against the same source', async () => {
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        render(<Probe probe={probe} deps={fixture.deps} options={TWO_BAND_LINEAR} />);
+        await act(async () => { await current(probe).start() });
+
+        const original = latestAnalyser(fixture.context);
+        expect(original.fftSize).toBe(64);
+
+        render(<Probe probe={probe} deps={fixture.deps} options={{ ...TWO_BAND_LINEAR, fftSize: 128 }} />);
+
+        expect(fixture.context.analysers).toHaveLength(2);
+        expect(latestAnalyser(fixture.context).fftSize).toBe(128);
+        expect(fixture.context.streamSources).toHaveLength(1);
+        expect(fixture.context.streamSources[0].connections).toEqual([latestAnalyser(fixture.context)]);
+        expect(current(probe).status).toBe('running');
+    });
+});

--- a/src/react/hooks/useAudioUniforms.ts
+++ b/src/react/hooks/useAudioUniforms.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+
+import type { BandCount, ResolvedAnalyserOptions } from '@/core/lib/audioBands';
+import { validateAudioOptions } from '@/core/lib/audioBands';
+import type { AudioAnalyserDriver, AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
+import { createAudioAnalyserDriver } from '@/react/lib/audioAnalyserDriver';
+import type {
+    AudioSourceSpec,
+    AudioStatus,
+    AudioUniformsOptions,
+    UniformParam,
+    UniformType,
+    UniformTypeMap
+} from '@/types';
+
+export interface AudioUniformsResult {
+    uniforms: Record<string, UniformParam>;
+    start: () => Promise<void>;
+    stop: () => void;
+    status: AudioStatus;
+    error: Error | null;
+}
+
+const BAND_UNIFORM_TYPES = {
+    1: 'float',
+    2: 'vec2',
+    3: 'vec3',
+    4: 'vec4'
+} as const satisfies Record<BandCount, UniformType>;
+
+const getServerStatus = (): AudioStatus => 'idle';
+
+const getServerError = (): Error | null => null;
+
+function analyserOptionsKey(options: ResolvedAnalyserOptions): string {
+    return [
+        options.bands,
+        options.fftSize,
+        options.smoothingTimeConstant,
+        options.attack,
+        options.release,
+        options.minDecibels,
+        options.maxDecibels,
+        options.bandLayout
+    ].join('|');
+}
+
+function sourceIdentity(source: AudioSourceSpec): unknown[] {
+    if (source.type === 'element') {
+        return ['element', source.element];
+    }
+    if (source.type === 'node') {
+        return ['node', source.node, source.context];
+    }
+    return ['mic'];
+}
+
+function assertSameSource(previous: AudioSourceSpec, next: AudioSourceSpec): void {
+    const before = sourceIdentity(previous);
+    const after = sourceIdentity(next);
+    const same = before.length === after.length && before.every((part, index) => part === after[index]);
+    if (same) {
+        return;
+    }
+
+    throw new Error(
+        `micugl audio: useAudioUniforms was given a "${previous.type}" source and is now being given a `
+        + `"${next.type}" source, but a hook instance owns one audio graph for its whole life: the microphone `
+        + 'track, the AudioContext and the analyser were all built for the first source, and rebinding them '
+        + 'under a live shader would leave the old source running with nobody stopping it. Give the component '
+        + 'a "key" that changes with the source, so React unmounts the old hook (stopping it) and mounts a new one.'
+    );
+}
+
+export const useAudioUniforms = (
+    source: AudioSourceSpec,
+    options?: AudioUniformsOptions,
+    deps?: AudioAnalyserDriverDeps
+): AudioUniformsResult => {
+    const resolved = validateAudioOptions(options);
+    const optionsKey = analyserOptionsKey(resolved);
+
+    const sourceRef = useRef(source);
+    assertSameSource(sourceRef.current, source);
+
+    const driverRef = useRef<AudioAnalyserDriver | null>(null);
+    driverRef.current ??= createAudioAnalyserDriver(source, resolved, deps);
+    const driver = driverRef.current;
+
+    const appliedKeyRef = useRef(optionsKey);
+
+    useEffect(() => {
+        if (appliedKeyRef.current === optionsKey) {
+            return;
+        }
+        driver.reconfigure(resolved);
+        appliedKeyRef.current = optionsKey;
+    });
+
+    useEffect(() => () => { driver.stop() }, [driver]);
+
+    const status = useSyncExternalStore(driver.subscribe, () => driver.status, getServerStatus);
+    const error = useSyncExternalStore(driver.subscribe, () => driver.error, getServerError);
+
+    const start = useCallback(() => driver.start(), [driver]);
+    const stop = useCallback(() => { driver.stop() }, [driver]);
+
+    const bands = resolved.bands;
+    const bandsName = resolved.names.bands;
+    const levelName = resolved.names.level;
+
+    const nonReproducible = useCallback(() => driver.status === 'running', [driver]);
+
+    const uniforms = useMemo<Record<string, UniformParam>>(() => ({
+        [bandsName]: {
+            type: BAND_UNIFORM_TYPES[bands],
+            value: time => {
+                driver.analyseIfNeeded(time ?? 0);
+                const scratch = driver.bandsScratch;
+                return (bands === 1 ? scratch[0] : scratch) as UniformTypeMap[UniformType];
+            },
+            invalidation: driver.invalidation,
+            nonReproducible
+        },
+        [levelName]: {
+            type: 'float',
+            value: time => {
+                driver.analyseIfNeeded(time ?? 0);
+                return driver.level;
+            },
+            invalidation: driver.invalidation,
+            nonReproducible
+        }
+    }), [driver, bands, bandsName, levelName, nonReproducible]);
+
+    return { uniforms, start, stop, status, error };
+};

--- a/src/react/hooks/usePingPongPasses.ts
+++ b/src/react/hooks/usePingPongPasses.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { combineFrameInvalidation, type FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
+import type { CapturesAreNonReproducible } from '@/react/lib/captureLiveness';
 import { combineUniformDebugPorts, type UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import {
     buildPasses,
@@ -12,7 +13,6 @@ import {
     serializeFramebufferOptions,
     serializeRenderOptions
 } from '@/react/lib/pingPongPasses';
-import type { SpringsInFlight } from '@/react/lib/springCapture';
 import type { FramebufferOptions, MotionPolicy, RenderPass, UniformParam } from '@/types';
 
 interface PingPongPassesOptions {
@@ -34,7 +34,7 @@ const EMPTY_UNIFORMS: Record<string, UniformParam> = {};
 export interface PingPongPassesWithPort extends PingPongPassesResult {
     port: UniformDebugPort;
     invalidation: FrameInvalidation;
-    springsInFlight: SpringsInFlight;
+    capturesAreNonReproducible: CapturesAreNonReproducible;
 }
 
 export const usePingPongPasses = ({
@@ -100,12 +100,12 @@ export const usePingPongPasses = ({
         [primary.invalidation, secondary.invalidation]
     );
 
-    const primarySprings = primary.springsInFlight;
-    const secondarySprings = secondary.springsInFlight;
-    const springsInFlight = useMemo<SpringsInFlight>(
-        () => () => primarySprings() || secondarySprings(),
-        [primarySprings, secondarySprings]
+    const primaryCapture = primary.capturesAreNonReproducible;
+    const secondaryCapture = secondary.capturesAreNonReproducible;
+    const capturesAreNonReproducible = useMemo<CapturesAreNonReproducible>(
+        () => () => primaryCapture() ?? secondaryCapture(),
+        [primaryCapture, secondaryCapture]
     );
 
-    return { ...passesResult, port, invalidation, springsInFlight };
+    return { ...passesResult, port, invalidation, capturesAreNonReproducible };
 };

--- a/src/react/hooks/useUniformUpdaters.ts
+++ b/src/react/hooks/useUniformUpdaters.ts
@@ -1,10 +1,13 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { useMotionGate } from '@/react/hooks/useMotionGate';
+import type { CapturesAreNonReproducible, NonReproducible } from '@/react/lib/captureLiveness';
 import {
     buildLiveUpdaters,
+    collectInvalidations,
     collectLiveValues,
+    collectNonReproducible,
     createUniformDebugPort,
     type LiveValues,
     mergeOverrides,
@@ -14,7 +17,6 @@ import {
     uniformDescriptors,
     uniformStructureKey
 } from '@/react/lib/liveUniformUpdaters';
-import type { SpringsInFlight } from '@/react/lib/springCapture';
 import { createTransitionRuntime, type TransitionRuntime } from '@/react/lib/transitionRuntime';
 import type { MotionPolicy, UniformParam, UniformUpdaterDef } from '@/types';
 
@@ -22,7 +24,7 @@ export interface UniformUpdatersResult {
     updaters: Record<string, UniformUpdaterDef[]>;
     port: UniformDebugPort;
     invalidation: FrameInvalidation;
-    springsInFlight: SpringsInFlight;
+    capturesAreNonReproducible: CapturesAreNonReproducible;
 }
 
 export interface UniformUpdatersOptions {
@@ -48,18 +50,46 @@ export const useUniformUpdaters = (
     const descriptorsRef = useRef<UniformDescriptor[]>(descriptors);
     descriptorsRef.current = descriptors;
 
+    const nonReproducibleRef = useRef<NonReproducible[]>([]);
+    nonReproducibleRef.current = collectNonReproducible(uniforms);
+
     const runtimeRef = useRef<TransitionRuntime | null>(null);
     runtimeRef.current ??= createTransitionRuntime(
         name => Object.prototype.hasOwnProperty.call(overridesRef.current, name)
     );
     const runtime = runtimeRef.current;
 
+    const relayedRef = useRef(new Map<FrameInvalidation, () => void>());
+
     useEffect(() => {
         const base = collectLiveValues(uniforms);
         baseValuesRef.current = base;
         valuesRef.current = mergeOverrides(base, overridesRef.current);
         runtime.applyTargets(uniforms, motionGate);
+
+        const relayed = relayedRef.current;
+        const sources = collectInvalidations(uniforms);
+
+        for (const source of sources) {
+            if (!relayed.has(source)) {
+                relayed.set(source, source.connect(() => { runtime.invalidation.request() }));
+            }
+        }
+        for (const [source, dispose] of relayed) {
+            if (!sources.includes(source)) {
+                dispose();
+                relayed.delete(source);
+            }
+        }
     });
+
+    useEffect(() => {
+        const relayed = relayedRef.current;
+        return () => {
+            relayed.forEach(dispose => { dispose() });
+            relayed.clear();
+        };
+    }, []);
 
     const port = useMemo(
         () => createUniformDebugPort({
@@ -79,10 +109,22 @@ export const useUniformUpdaters = (
         };
     }, [programId, structureKey, runtime]);
 
+    const capturesAreNonReproducible = useCallback<CapturesAreNonReproducible>(() => {
+        if (runtime.springsInFlight()) {
+            return 'spring';
+        }
+        for (const isLive of nonReproducibleRef.current) {
+            if (isLive()) {
+                return 'audio';
+            }
+        }
+        return null;
+    }, [runtime]);
+
     return {
         updaters,
         port,
         invalidation: runtime.invalidation,
-        springsInFlight: runtime.springsInFlight
+        capturesAreNonReproducible
     };
 };

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -3,10 +3,13 @@ export { BasePingPongShaderComponent } from './components/base/BasePingPongShade
 export { BaseShaderComponent } from './components/base/BaseShaderComponent';
 export { PingPongShaderEngine } from './components/engine/PingPongShaderEngine';
 export { ShaderEngine } from './components/engine/ShaderEngine';
+export type { AudioUniformsResult } from './hooks/useAudioUniforms';
+export { useAudioUniforms } from './hooks/useAudioUniforms';
 export { useDarkMode } from './hooks/useDarkMode';
 export { usePingPongPasses } from './hooks/usePingPongPasses';
 export { useReducedMotion } from './hooks/useReducedMotion';
 export { useSaveData } from './hooks/useSaveData';
 export { useUniformUpdaters } from './hooks/useUniformUpdaters';
+export type { AudioAnalyserDriverDeps } from './lib/audioAnalyserDriver';
 export { createCommonUpdaters, createUniformUpdater, createUniformUpdaters } from './lib/createUniformUpdater';
 export type { InstanceAttribute, InstancingConfig, WorkerMode } from '@/types';

--- a/src/react/lib/audioAnalyserDriver.test.ts
+++ b/src/react/lib/audioAnalyserDriver.test.ts
@@ -3,126 +3,23 @@ import { describe, expect, it } from 'vitest';
 import { validateAudioOptions } from '@/core/lib/audioBands';
 import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
 import { createAudioAnalyserDriver } from '@/react/lib/audioAnalyserDriver';
+import type { FakeAnalyser, FakeStream, FakeTrack } from '@/react/lib/fakeWebAudio';
+import {
+    asContext,
+    asElement,
+    createFakeStream,
+    FakeContext,
+    FakeSourceNode,
+    HIGH_HALF,
+    latestAnalyser,
+    LOW_HALF
+} from '@/react/lib/fakeWebAudio';
 import type { AudioSourceSpec, AudioUniformsOptions } from '@/types';
-
-type Spectrum = (bin: number, binCount: number) => number;
-
-class FakeAnalyser {
-    fftSize = 2048;
-    smoothingTimeConstant = 0.8;
-    reads = 0;
-    spectrum: Spectrum = () => 0;
-    private minValue = -100;
-    private maxValue = -30;
-
-    get minDecibels(): number { return this.minValue }
-    set minDecibels(value: number) {
-        if (value >= this.maxValue) {
-            throw new Error(`IndexSizeError: minDecibels ${value} is not below maxDecibels ${this.maxValue}`);
-        }
-        this.minValue = value;
-    }
-
-    get maxDecibels(): number { return this.maxValue }
-    set maxDecibels(value: number) {
-        if (value <= this.minValue) {
-            throw new Error(`IndexSizeError: maxDecibels ${value} is not above minDecibels ${this.minValue}`);
-        }
-        this.maxValue = value;
-    }
-
-    get frequencyBinCount(): number { return this.fftSize / 2 }
-
-    getByteFrequencyData(target: Uint8Array): void {
-        this.reads += 1;
-        for (let i = 0; i < target.length; i++) {
-            target[i] = this.spectrum(i, target.length);
-        }
-    }
-}
-
-class FakeSourceNode {
-    connections: unknown[] = [];
-    constructor(public context: FakeContext) {}
-    connect(target: unknown): void { this.connections.push(target) }
-    disconnect(target: unknown): void { this.connections = this.connections.filter(entry => entry !== target) }
-}
-
-class FakeContext {
-    state: AudioContextState = 'suspended';
-    sampleRate = 48000;
-    destination = { id: 'destination' };
-    analysers: FakeAnalyser[] = [];
-    streamSources: FakeSourceNode[] = [];
-    elementSources: FakeSourceNode[] = [];
-    resumeCalls = 0;
-    closeCalls = 0;
-    bindThrows = false;
-    deferResume = false;
-    releaseResume: (() => void) | null = null;
-
-    createAnalyser(): FakeAnalyser {
-        const analyser = new FakeAnalyser();
-        this.analysers.push(analyser);
-        return analyser;
-    }
-
-    createMediaStreamSource(_stream: MediaStream): FakeSourceNode {
-        const node = new FakeSourceNode(this);
-        this.streamSources.push(node);
-        return node;
-    }
-
-    createMediaElementSource(_element: HTMLMediaElement): FakeSourceNode {
-        if (this.bindThrows) {
-            throw new Error('InvalidStateError: HTMLMediaElement already connected to a different MediaElementSourceNode');
-        }
-        const node = new FakeSourceNode(this);
-        this.elementSources.push(node);
-        return node;
-    }
-
-    resume(): Promise<void> {
-        this.resumeCalls += 1;
-        if (this.deferResume) {
-            return new Promise<void>(resolve => {
-                this.releaseResume = () => {
-                    this.state = 'running';
-                    resolve();
-                };
-            });
-        }
-        this.state = 'running';
-        return Promise.resolve();
-    }
-
-    close(): Promise<void> {
-        this.closeCalls += 1;
-        this.state = 'closed';
-        return Promise.resolve();
-    }
-}
-
-function createFakeStream(): { stream: MediaStream; tracks: { stopped: boolean }[] } {
-    const tracks = [
-        { stopped: false, stop() { this.stopped = true } },
-        { stopped: false, stop() { this.stopped = true } }
-    ];
-    return { stream: { getTracks: () => tracks } as unknown as MediaStream, tracks };
-}
-
-function asContext(context: FakeContext): AudioContext {
-    return context as unknown as AudioContext;
-}
-
-function asElement(id: string): HTMLMediaElement {
-    return { id } as unknown as HTMLMediaElement;
-}
 
 interface Harness {
     driver: ReturnType<typeof createAudioAnalyserDriver>;
     context: FakeContext;
-    tracks: { stopped: boolean }[];
+    tracks: FakeTrack[];
     requests: number[];
     analyser: () => FakeAnalyser;
 }
@@ -148,12 +45,9 @@ function createHarness(
         context,
         tracks,
         requests,
-        analyser: () => context.analysers[context.analysers.length - 1]
+        analyser: () => latestAnalyser(context)
     };
 }
-
-const LOW_HALF: Spectrum = (bin, binCount) => (bin < binCount / 2 ? 255 : 0);
-const HIGH_HALF: Spectrum = (bin, binCount) => (bin < binCount / 2 ? 0 : 255);
 
 const TWO_BAND_LINEAR: AudioUniformsOptions = {
     bands: 2,
@@ -247,25 +141,60 @@ describe('the audio analyser driver, reading a fake analyser whose spectrum the 
         expect(harness.driver.bandsScratch[0]).toBeLessThan(0.9);
     });
 
-    it('a clock that steps backwards freezes the envelope rather than poisoning it', async () => {
+    it('a clock that steps backwards is ignored outright: it reads nothing and cannot steal envelope time', async () => {
+        const rewound = createHarness(TWO_BAND_LINEAR);
+        const control = createHarness(TWO_BAND_LINEAR);
+        await rewound.driver.start();
+        await control.driver.start();
+        rewound.analyser().spectrum = LOW_HALF;
+        control.analyser().spectrum = LOW_HALF;
+
+        for (const harness of [rewound, control]) {
+            harness.driver.analyseIfNeeded(0);
+            harness.driver.analyseIfNeeded(32);
+        }
+        const settled = rewound.driver.bandsScratch[0];
+        expect(settled).toBeGreaterThan(0);
+        expect(control.driver.bandsScratch[0]).toBe(settled);
+
+        const readsBefore = rewound.analyser().reads;
+        rewound.driver.analyseIfNeeded(16);
+        rewound.driver.analyseIfNeeded(32);
+
+        expect(rewound.analyser().reads).toBe(readsBefore);
+        expect(rewound.driver.bandsScratch[0]).toBe(settled);
+
+        rewound.driver.analyseIfNeeded(48);
+        control.driver.analyseIfNeeded(48);
+
+        expect(rewound.driver.bandsScratch[0]).toBeGreaterThan(settled);
+        expect(rewound.driver.bandsScratch[0]).toBe(control.driver.bandsScratch[0]);
+        expect(Number.isFinite(rewound.driver.level)).toBe(true);
+    });
+
+    it('a non-finite frame time analyses nothing and cannot freeze the driver at NaN', async () => {
         const harness = createHarness(TWO_BAND_LINEAR);
         await harness.driver.start();
-        const analyser = harness.analyser();
-        analyser.spectrum = LOW_HALF;
+        harness.analyser().spectrum = LOW_HALF;
+
+        harness.driver.analyseIfNeeded(Number.NaN);
+        expect(harness.analyser().reads).toBe(0);
+        expect(harness.driver.bandsScratch[0]).toBe(0);
 
         harness.driver.analyseIfNeeded(0);
         harness.driver.analyseIfNeeded(32);
         const settled = harness.driver.bandsScratch[0];
         expect(settled).toBeGreaterThan(0);
 
-        harness.driver.analyseIfNeeded(16);
+        harness.driver.analyseIfNeeded(Number.NaN);
+        harness.driver.analyseIfNeeded(Number.POSITIVE_INFINITY);
 
         expect(harness.driver.bandsScratch[0]).toBe(settled);
-        expect(harness.driver.level).toBe(settled / 2);
 
-        harness.driver.analyseIfNeeded(32);
+        harness.driver.analyseIfNeeded(48);
 
         expect(harness.driver.bandsScratch[0]).toBeGreaterThan(settled);
+        expect(harness.driver.bandsScratch.every(value => Number.isFinite(value))).toBe(true);
         expect(Number.isFinite(harness.driver.level)).toBe(true);
     });
 
@@ -563,6 +492,82 @@ describe('audio driver lifecycle', () => {
         expect(harness.context.analysers).toHaveLength(1);
         expect(harness.context.streamSources).toHaveLength(1);
         expect(harness.requests).toHaveLength(1);
+    });
+
+    it('start() -> stop() -> start() while the prompt is still open adopts the grant it already asked for', async () => {
+        const context = new FakeContext();
+        const { stream, tracks } = createFakeStream();
+        let grants = 0;
+        let contexts = 0;
+        let grant: (value: MediaStream) => void = () => undefined;
+
+        const driver = createAudioAnalyserDriver({ type: 'mic' }, validateAudioOptions(), {
+            createContext: () => {
+                contexts += 1;
+                return asContext(context);
+            },
+            getUserMedia: () => {
+                grants += 1;
+                return new Promise<MediaStream>(resolve => { grant = resolve });
+            }
+        });
+
+        const first = driver.start();
+        expect(driver.status).toBe('starting');
+
+        driver.stop();
+        expect(driver.status).toBe('stopped');
+
+        const second = driver.start();
+        expect(driver.status).toBe('starting');
+        expect(grants).toBe(1);
+
+        grant(stream);
+        await Promise.all([first, second]);
+
+        expect(grants).toBe(1);
+        expect(contexts).toBe(1);
+        expect(driver.status).toBe('running');
+        expect(context.analysers).toHaveLength(1);
+        expect(context.streamSources).toHaveLength(1);
+        expect(context.streamSources[0].connections).toEqual([latestAnalyser(context)]);
+        expect(context.closeCalls).toBe(0);
+        expect(tracks.every(track => !track.stopped)).toBe(true);
+    });
+
+    it('stop() then start() AFTER the graph is live tears the first one down and opens exactly one more', async () => {
+        const contexts: FakeContext[] = [];
+        const grants: FakeStream[] = [];
+
+        const driver = createAudioAnalyserDriver({ type: 'mic' }, validateAudioOptions(), {
+            createContext: () => {
+                const context = new FakeContext();
+                contexts.push(context);
+                return asContext(context);
+            },
+            getUserMedia: () => {
+                const grant = createFakeStream();
+                grants.push(grant);
+                return Promise.resolve(grant.stream);
+            }
+        });
+
+        await driver.start();
+        driver.stop();
+
+        expect(grants).toHaveLength(1);
+        expect(grants[0].tracks.every(track => track.stopped)).toBe(true);
+        expect(contexts[0].closeCalls).toBe(1);
+
+        await driver.start();
+
+        expect(driver.status).toBe('running');
+        expect(grants).toHaveLength(2);
+        expect(contexts).toHaveLength(2);
+        expect(grants[1].tracks.every(track => track.stopped)).toBe(false);
+        expect(contexts[1].analysers).toHaveLength(1);
+        expect(contexts[1].resumeCalls).toBe(1);
+        expect(contexts[1].streamSources[0].connections).toEqual([latestAnalyser(contexts[1])]);
     });
 
     it('stop() during starting cancels the attempt and releases the microphone it was granted', async () => {

--- a/src/react/lib/audioAnalyserDriver.ts
+++ b/src/react/lib/audioAnalyserDriver.ts
@@ -14,7 +14,7 @@ export interface AudioAnalyserDriver {
     stop(): void;
     analyseIfNeeded(timeMs: number): void;
     reconfigure(options: ResolvedAnalyserOptions): void;
-    subscribe(onChange: () => void): () => void;
+    subscribe: (onChange: () => void) => () => void;
     readonly bandsScratch: Float32Array;
     readonly level: number;
     readonly status: AudioStatus;
@@ -45,6 +45,8 @@ type DriverState =
     | { kind: 'running'; graph: AudioGraph }
     | { kind: 'stopped' }
     | { kind: 'error'; error: Error };
+
+type DesiredState = 'running' | 'stopped';
 
 interface ElementBinding {
     context: AudioContext;
@@ -160,15 +162,26 @@ export function createAudioAnalyserDriver(
 
     let currentOptions = options;
     let state: DriverState = { kind: 'idle' };
+    let desired: DesiredState = 'stopped';
     let bands = new Float32Array(currentOptions.bands);
     let raw = new Float32Array(currentOptions.bands);
     let level = 0;
     let lastAnalysedTime: number | null = null;
-    let generation = 0;
+
+    function notify(): void {
+        listeners.forEach(listener => { listener() });
+    }
 
     function setState(next: DriverState): void {
         state = next;
-        listeners.forEach(listener => { listener() });
+        notify();
+    }
+
+    function readStatus(): AudioStatus {
+        if (state.kind === 'starting' && desired === 'stopped') {
+            return 'stopped';
+        }
+        return state.kind;
     }
 
     function resetBands(): void {
@@ -225,58 +238,68 @@ export function createAudioAnalyserDriver(
         return { context: source.context, mayCloseContext: false, sourceNode: source.node, stream: null };
     }
 
-    async function beginStart(myGeneration: number): Promise<void> {
+    async function beginStart(): Promise<void> {
         let acquired: SourceGraph | null = null;
+        let started: AudioGraph | null = null;
+        let failure: Error | null = null;
+
         try {
             acquired = await acquireSource();
 
-            if (myGeneration !== generation) {
-                releaseSource(acquired);
-                return;
-            }
-
-            if (acquired.context.state === 'suspended') {
+            if (desired === 'running' && acquired.context.state === 'suspended') {
                 await acquired.context.resume();
             }
 
-            if (myGeneration !== generation) {
-                releaseSource(acquired);
-                return;
+            if (desired === 'running') {
+                const analysis = buildAnalysis(acquired.context, currentOptions);
+                acquired.sourceNode.connect(analysis.analyser);
+                started = { ...acquired, analysis };
             }
-
-            const analysis = buildAnalysis(acquired.context, currentOptions);
-            acquired.sourceNode.connect(analysis.analyser);
-
-            resetBands();
-            const graph: AudioGraph = { ...acquired, analysis };
-            acquired = null;
-            setState({ kind: 'running', graph });
-            invalidation.request();
         } catch (cause) {
-            if (acquired !== null) {
-                releaseSource(acquired);
-            }
-
-            const error = toError(cause);
-            if (myGeneration === generation) {
-                resetBands();
-                setState({ kind: 'error', error });
-                invalidation.request();
-            }
-            throw error;
+            failure = toError(cause);
         }
+
+        if (started === null && acquired !== null) {
+            releaseSource(acquired);
+        }
+
+        if (failure !== null) {
+            resetBands();
+            if (desired === 'running') {
+                desired = 'stopped';
+                setState({ kind: 'error', error: failure });
+            } else {
+                setState({ kind: 'stopped' });
+            }
+            invalidation.request();
+            throw failure;
+        }
+
+        if (started === null) {
+            setState({ kind: 'stopped' });
+            return;
+        }
+
+        resetBands();
+        setState({ kind: 'running', graph: started });
+        invalidation.request();
     }
 
     function start(): Promise<void> {
+        const wasStopping = desired === 'stopped';
+        desired = 'running';
+
         if (state.kind === 'running') {
             return Promise.resolve();
         }
         if (state.kind === 'starting') {
+            if (wasStopping) {
+                notify();
+            }
             return state.pending;
         }
 
-        generation += 1;
-        const run = beginStart(generation);
+        const run = beginStart();
         keepRejectionHandled(run);
         setState({ kind: 'starting', pending: run });
 
@@ -284,23 +307,37 @@ export function createAudioAnalyserDriver(
     }
 
     function stop(): void {
-        if (state.kind !== 'running' && state.kind !== 'starting') {
+        const wasStarting = desired === 'running';
+        desired = 'stopped';
+
+        if (state.kind === 'starting') {
+            if (!wasStarting) {
+                return;
+            }
+            resetBands();
+            notify();
+            invalidation.request();
             return;
         }
 
-        generation += 1;
-
-        if (state.kind === 'running') {
-            releaseGraph(state.graph);
+        if (state.kind !== 'running') {
+            return;
         }
 
+        releaseGraph(state.graph);
         resetBands();
         setState({ kind: 'stopped' });
         invalidation.request();
     }
 
     function analyseIfNeeded(timeMs: number): void {
-        if (state.kind !== 'running' || timeMs === lastAnalysedTime) {
+        if (state.kind !== 'running') {
+            return;
+        }
+        if (!Number.isFinite(timeMs)) {
+            return;
+        }
+        if (lastAnalysedTime !== null && !(timeMs > lastAnalysedTime)) {
             return;
         }
 
@@ -362,13 +399,13 @@ export function createAudioAnalyserDriver(
         stop,
         analyseIfNeeded,
         reconfigure,
-        subscribe(onChange) {
+        subscribe: onChange => {
             listeners.add(onChange);
             return () => { listeners.delete(onChange) };
         },
         get bandsScratch() { return bands },
         get level() { return level },
-        get status() { return state.kind },
+        get status() { return readStatus() },
         get error() { return state.kind === 'error' ? state.error : null },
         invalidation
     };

--- a/src/react/lib/captureLiveness.ts
+++ b/src/react/lib/captureLiveness.ts
@@ -1,0 +1,28 @@
+export type SpringsInFlight = () => boolean;
+
+export type NonReproducible = () => boolean;
+
+export type CaptureBlocker = 'spring' | 'audio';
+
+export type CapturesAreNonReproducible = () => CaptureBlocker | null;
+
+export function nonReproducibleCaptureMessage(
+    engine: string,
+    method: string,
+    blocker: CaptureBlocker
+): string {
+    if (blocker === 'spring') {
+        return (
+            `${engine}.${method}: a spring transition is still in flight. Springs integrate frame to frame, so a `
+            + 'captured frame depends on the frames rendered before it, and this export would not reproduce. Wait for '
+            + 'the spring to settle, or use a tween transition, which is deterministic under setFrame.'
+        );
+    }
+
+    return (
+        `${engine}.${method}: audio is running. The audio envelope integrates frame to frame, and every frame reads `
+        + 'whatever the microphone or media element happens to be playing right now, so a captured frame depends both '
+        + 'on the frames rendered before it and on a live input that no frame number can reproduce. This export would '
+        + 'not reproduce. Call stop() on the audio hook before exporting; a stopped audio scene captures fine.'
+    );
+}

--- a/src/react/lib/fakeWebAudio.ts
+++ b/src/react/lib/fakeWebAudio.ts
@@ -1,0 +1,134 @@
+export type Spectrum = (bin: number, binCount: number) => number;
+
+export const LOW_HALF: Spectrum = (bin, binCount) => (bin < binCount / 2 ? 255 : 0);
+export const HIGH_HALF: Spectrum = (bin, binCount) => (bin < binCount / 2 ? 0 : 255);
+
+export class FakeAnalyser {
+    fftSize = 2048;
+    smoothingTimeConstant = 0.8;
+    reads = 0;
+    spectrum: Spectrum = () => 0;
+    private minValue = -100;
+    private maxValue = -30;
+
+    get minDecibels(): number { return this.minValue }
+    set minDecibels(value: number) {
+        if (value >= this.maxValue) {
+            throw new Error(`IndexSizeError: minDecibels ${value} is not below maxDecibels ${this.maxValue}`);
+        }
+        this.minValue = value;
+    }
+
+    get maxDecibels(): number { return this.maxValue }
+    set maxDecibels(value: number) {
+        if (value <= this.minValue) {
+            throw new Error(`IndexSizeError: maxDecibels ${value} is not above minDecibels ${this.minValue}`);
+        }
+        this.maxValue = value;
+    }
+
+    get frequencyBinCount(): number { return this.fftSize / 2 }
+
+    getByteFrequencyData(target: Uint8Array): void {
+        this.reads += 1;
+        for (let i = 0; i < target.length; i++) {
+            target[i] = this.spectrum(i, target.length);
+        }
+    }
+}
+
+export class FakeSourceNode {
+    connections: unknown[] = [];
+    constructor(public context: FakeContext) {}
+    connect(target: unknown): void { this.connections.push(target) }
+    disconnect(target: unknown): void { this.connections = this.connections.filter(entry => entry !== target) }
+}
+
+export class FakeContext {
+    state: AudioContextState = 'suspended';
+    sampleRate = 48000;
+    destination = { id: 'destination' };
+    analysers: FakeAnalyser[] = [];
+    streamSources: FakeSourceNode[] = [];
+    elementSources: FakeSourceNode[] = [];
+    resumeCalls = 0;
+    closeCalls = 0;
+    bindThrows = false;
+    deferResume = false;
+    releaseResume: (() => void) | null = null;
+
+    createAnalyser(): FakeAnalyser {
+        const analyser = new FakeAnalyser();
+        this.analysers.push(analyser);
+        return analyser;
+    }
+
+    createMediaStreamSource(_stream: MediaStream): FakeSourceNode {
+        const node = new FakeSourceNode(this);
+        this.streamSources.push(node);
+        return node;
+    }
+
+    createMediaElementSource(_element: HTMLMediaElement): FakeSourceNode {
+        if (this.bindThrows) {
+            throw new Error('InvalidStateError: HTMLMediaElement already connected to a different MediaElementSourceNode');
+        }
+        const node = new FakeSourceNode(this);
+        this.elementSources.push(node);
+        return node;
+    }
+
+    resume(): Promise<void> {
+        this.resumeCalls += 1;
+        if (this.deferResume) {
+            return new Promise<void>(resolve => {
+                this.releaseResume = () => {
+                    this.state = 'running';
+                    resolve();
+                };
+            });
+        }
+        this.state = 'running';
+        return Promise.resolve();
+    }
+
+    close(): Promise<void> {
+        this.closeCalls += 1;
+        this.state = 'closed';
+        return Promise.resolve();
+    }
+}
+
+export interface FakeTrack {
+    stopped: boolean;
+    stop: () => void;
+}
+
+export interface FakeStream {
+    stream: MediaStream;
+    tracks: FakeTrack[];
+}
+
+export function createFakeStream(): FakeStream {
+    const tracks: FakeTrack[] = [
+        { stopped: false, stop() { this.stopped = true } },
+        { stopped: false, stop() { this.stopped = true } }
+    ];
+    return { stream: { getTracks: () => tracks } as unknown as MediaStream, tracks };
+}
+
+export function asContext(context: FakeContext): AudioContext {
+    return context as unknown as AudioContext;
+}
+
+export function asElement(id: string): HTMLMediaElement {
+    return { id } as unknown as HTMLMediaElement;
+}
+
+export function latestAnalyser(context: FakeContext): FakeAnalyser {
+    const analyser = context.analysers[context.analysers.length - 1] as FakeAnalyser | undefined;
+    if (!analyser) {
+        throw new Error('fakeWebAudio: no analyser has been created on this context yet');
+    }
+    return analyser;
+}

--- a/src/react/lib/liveUniformUpdaters.ts
+++ b/src/react/lib/liveUniformUpdaters.ts
@@ -1,4 +1,6 @@
+import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
+import type { NonReproducible } from '@/react/lib/captureLiveness';
 import { createCommonUpdaters } from '@/react/lib/createUniformUpdater';
 import type { TransitionRuntime } from '@/react/lib/transitionRuntime';
 import type {
@@ -165,6 +167,26 @@ export function collectLiveValues(uniforms: Record<string, UniformParam>): LiveV
         values[normalizeUniformName(name)] = param.value;
     }
     return values;
+}
+
+export function collectInvalidations(uniforms: Record<string, UniformParam>): FrameInvalidation[] {
+    const sources: FrameInvalidation[] = [];
+    for (const param of Object.values(uniforms)) {
+        if (param.invalidation && !sources.includes(param.invalidation)) {
+            sources.push(param.invalidation);
+        }
+    }
+    return sources;
+}
+
+export function collectNonReproducible(uniforms: Record<string, UniformParam>): NonReproducible[] {
+    const sources: NonReproducible[] = [];
+    for (const param of Object.values(uniforms)) {
+        if (param.nonReproducible && !sources.includes(param.nonReproducible)) {
+            sources.push(param.nonReproducible);
+        }
+    }
+    return sources;
 }
 
 export function uniformStructureKey(descriptors: UniformDescriptor[], skipDefaults: boolean): string {

--- a/src/react/lib/springCapture.ts
+++ b/src/react/lib/springCapture.ts
@@ -1,9 +1,0 @@
-export type SpringsInFlight = () => boolean;
-
-export function springInFlightMessage(engine: string, method: string): string {
-    return (
-        `${engine}.${method}: a spring transition is still in flight. Springs integrate frame to frame, so a `
-        + 'captured frame depends on the frames rendered before it, and this export would not reproduce. Wait for '
-        + 'the spring to settle, or use a tween transition, which is deterministic under setFrame.'
-    );
-}

--- a/src/react/lib/transitionRuntime.ts
+++ b/src/react/lib/transitionRuntime.ts
@@ -8,9 +8,9 @@ import {
     sampleMotion
 } from '@/core/lib/motionDrivers';
 import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
+import type { SpringsInFlight } from '@/react/lib/captureLiveness';
 import { normalizeUniformName } from '@/react/lib/liveUniformUpdaters';
 import type { MotionGate } from '@/react/lib/motionPolicy';
-import type { SpringsInFlight } from '@/react/lib/springCapture';
 import type { UniformParam, UniformType, UniformValue } from '@/types';
 
 export interface TransitionRuntime {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+
 // ===================================================
 // WebGL Data
 // ===================================================
@@ -334,6 +336,8 @@ export interface UniformParam<T extends UniformType = UniformType> {
   value: UniformValue<T>;
   type: T;
   transition?: UniformTransitionConfig;
+  invalidation?: FrameInvalidation;
+  nonReproducible?: () => boolean;
 }
 
 export type UniformParamMap = { [K in UniformType]: UniformParam<K> };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
             tsconfigPath:  './tsconfig.json',
             outDir:             'dist',
             entryRoot:         'src',
-            exclude: ['**/*.test.ts', '**/*.test.tsx'],
+            exclude: ['**/*.test.ts', '**/*.test.tsx', '**/fakeWebAudio.ts'],
         })
     ]
 });


### PR DESCRIPTION
The last slice of track 4. `useAudioUniforms` turns the T3 analyser driver into shader uniforms, and it is a thin wrapper: `analyseIfNeeded(time)` then read `driver.bandsScratch` / `driver.level`, `UniformParam.invalidation = driver.invalidation`, status via `useSyncExternalStore(driver.subscribe, ...)`. The driver seam held — nothing here reaches inside it.

Everything else in this PR is what proving that wrapper honest turned up.

## The relay the plan said already existed

It did not. `UniformParam` had no `invalidation` field, and `useUniformUpdaters` only owned the transition runtime's own invalidation. So this PR builds it: `UniformParam.invalidation?: FrameInvalidation`, a `collectInvalidations()` beside `collectLiveValues()`, and a diff against a connected set in the same post-commit effect that runs `applyTargets`.

Without it, a function-valued uniform under `frameloop='demand'` posts once and freezes forever — on the main thread and in the worker alike. **It only looked like it worked because the default frameloop is `'always'`.** That is the signature bug's exact shape, and it would have shipped green.

Worker mode needed no new machinery beyond the relay, as predicted — but that is now *proven*, not assumed: a real component → real `WorkerBridge` → real `WorkerRuntime` → GL stub, asserting `u_audioLevel` and `u_audioBands` advance across frames under `demand`, and drain to zero on `stop()`.

## A re-entrancy bug the relay exposed

The driver requests invalidation from *inside* `sampleLiveUniforms`, so `invalidateAll` re-entered `postLiveUniforms` and sampled every live uniform **twice per frame**. It hid because `frameToMs(msToFrame(x)) === x` happens to hold, so the driver's per-frame memo silently absorbed the second `getByteFrequencyData`. Guarded with `try/finally` — the `finally` matters, because a throwing user fn would otherwise wedge the flag `true` and freeze all future posts.

## Deterministic capture now fails loud on running audio

Audio is an accumulator **and** a live external input. `renderSequence()` / `renderToBlob({frame})` synthesize frames faster than realtime, so every frame reads the same live spectrum and integrates the envelope with synthetic `dt`: an export that reproduces nothing, with no error and no log. T2 added `springsInFlight` for exactly this class of bug and audio walked straight past it.

`springsInFlight` generalizes to `capturesAreNonReproducible`, which returns the culprit (`'spring' | 'audio' | null`) so the thrown message names it. It is a **predicate**, not a flag — a *stopped* audio scene captures fine, which is why this does not block every export forever. Tested in all four directions: running audio blocks, stopped audio does not, an in-flight tween does not, an in-flight spring still does. `renderToBlob()` with no frame, `record()` and `captureStream()` render the live clock and stay honest.

## The driver asked for the mic twice

StrictMode double-invokes the natural auto-start effect (`useEffect(() => { void audio.start(); return audio.stop }, [audio])`), and the generation-counter lifecycle raced: a **mic** source issued **two `getUserMedia` grants** and built two AudioContexts. It converged to one live mic and released the stale stream — no leak — but a user without prior permission could see a second prompt.

`start()`/`stop()` now set a **desired state**, and one in-flight acquisition reconciles against it: one grant, one context. Publishing the running state also moves outside the `try` — a throwing subscriber used to run the `catch` with the stream already nulled, overwriting the live graph with `'error'` and dropping it forever.

## Smaller things

- `analyseIfNeeded` dedupes on **monotonicity**, not equality, written positively so a NaN or a rewound clock cannot steal envelope time (worker `invalidateAll` samples at a *quantized* frame time that is not the loop's `elapsed`).
- The reconfigure key is committed only **after** the reconfigure succeeds — `computeBandRanges` can throw on a `{bands, fftSize}` combination that only fails against the device's real sample rate, which `validateAudioOptions` structurally cannot pre-empt.
- `getServerSnapshot` on both `useSyncExternalStore` calls, so SSR reaches the driver's own "WebAudio is browser-only" message instead of a cryptic React error.
- `fakeWebAudio` lifts out of the T3 test as an internal test-only helper. It stays out of `src/testing/` (a published entry point) and that is now enforced by an **eslint rule** rather than a vite glob.
- `createFrameInvalidation` / `combineFrameInvalidation` are public — `UniformParam.invalidation` is what gives them a use. README shows a custom per-frame producer waking a `demand` engine, and notes the field must be referentially stable.

794 tests, 9/9 worker e2e.

---

## Manual hardware checklist

**Nothing in the audio feature is machine-verified — no test may ever touch a real microphone.** Unit tests stub `getUserMedia` and inject a fake `AudioContext`. This is the part only you can run: `bun run dev`, then `?scene=audio-bars`.

### Microphone / privacy — the critical ones

1. Pick `mic`, click **start** → allow → OS mic indicator lights, bars react to your voice.
2. Click **stop** → **the OS mic indicator goes out** (macOS menubar dot, Chrome tab dot). Status reads `stopped`, bars fall to zero.
3. Click **start** again → works. No second indicator, no duplicate stream.
4. Start the mic, then navigate away / hard-reload → **the indicator clears on unmount.**
5. Click **start**, and *while the permission prompt is still open* click **stop**, then dismiss the prompt with **Allow** → **the indicator must never light.** The grant lands after `stop()` and must be released immediately.
6. Click **start** and **Block** → status `error`, the message names the failure, no indicator. A later **start** still succeeds once you re-allow in site settings.
7. Add `&strict=1` (StrictMode) and start the mic → **exactly one permission prompt.** This is the bug this PR fixes; worth seeing it not happen.
8. Serve over plain `http://` (not localhost) → **start** rejects with the "secure context" message rather than hanging.

### Element source — the music must survive the visualizer

9. Pick `element`, choose an audio file, **start** → music plays *and* bars move.
10. Click **stop** while it plays → **the music keeps playing.** Bars go to zero.
11. **start** again on the same element → bars come back (the element rebinds to its cached source node; it is never re-created, because `createMediaElementSource` may only ever be called once per element).
12. Toggle `element` → `mic` → `element` → each remount works, the previous graph stops, the music never dies.
13. **start** before pressing play on the `<audio>` element → analyser reads zeros, status `running`. That is the documented idle-signal state, not a bug.

### Frameloop / CPU

14. With `demand` selected and audio running, animation is smooth; **stop** → the canvas goes still and rAF stops firing (check the performance panel). **start** → it wakes.
15. Scroll the canvas offscreen or switch tabs while audio runs → CPU drops to ~zero. Come back → it resumes.
16. `demand` vs `always` while running: identical.

### Capture

17. With audio **running**, call `renderSequence()` → it should **throw**, with a message naming audio.
18. Call `stop()`, then `renderSequence()` → it should **work**.

### Known limitation (documented, not guessed at)

A CORS-tainted media element makes the browser feed the analyser **silent zeros**. It is undetectable without a heuristic, so `status` reads `running` and the uniforms read 0. The demo only loads local files, so you should not hit it.
