### PR TITLE
embed: micugl/embed micro-runtime - 1.8 KB, honors reduced motion, and a size guard that guards something

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,87 @@ export default function App() {
 }
 ```
 
+## Embed (loading screens, no React)
+
+`micugl/embed` is a standalone micro-runtime that renders one animated fullscreen fragment
+shader **before or without** React. It is a separate ~1.6 KB gzip runtime, not a re-export of
+`micugl/core`: it has no FBOs, no ping-pong, no capability probing and no resource registry,
+because a loading screen needs none of them. (`WebGLManager` builds an `FBOManager` and probes
+four extensions in its constructor, which costs ~4.4 KB gzip for a fullscreen quad. CI enforces
+the embed runtime's size budget so it cannot drift back toward that.)
+
+```js
+import { embed } from "micugl/embed";
+
+const handle = embed(document.getElementById("loader"), {
+  fragment: FRAGMENT,           // your fragment shader source
+  uniforms: { u_tint: [0.2, 0.4, 0.9] },
+  clearColor: [0, 0, 0, 1],     // default [0,0,0,1]
+  dpr: 2,                       // devicePixelRatio cap, default 2
+});
+
+// later, once the real app has painted:
+handle.destroy();
+```
+
+Your fragment shader receives `uniform float u_time` (seconds), `uniform vec2 u_resolution`
+(drawing-buffer pixels) and `varying vec2 v_uv` (0..1) — the same convention as
+`BaseShaderComponent`, so a shader written for the React component drops straight in.
+The canvas is sized to the viewport, so give it `position:fixed;inset:0`.
+
+`embed()` returns `{ canvas, gl, animating, destroy }`. `destroy()` cancels the loop, removes the
+resize listener, deletes the program/shaders/buffer and calls `WEBGL_lose_context.loseContext()`,
+so a later React mount on a fresh canvas is a clean handoff.
+
+### Static HTML (the `<script>` build)
+
+`dist/embed.global.js` is a prebuilt minified IIFE for a static page with no bundler. Copy it out
+of `node_modules/micugl/dist/` and it exposes `window.micuglEmbed`:
+
+```html
+<canvas id="loader" style="position:fixed;inset:0"></canvas>
+<script src="/vendor/embed.global.js"></script>
+<script>
+  window.__loader = micuglEmbed.embed(document.getElementById("loader"), {
+    fragment: `precision highp float; uniform float u_time; varying vec2 v_uv;
+               void main(){ gl_FragColor = vec4(v_uv, 0.5 + 0.5 * sin(u_time), 1.0); }`,
+  });
+</script>
+```
+
+### Handing off to React
+
+The loader owns its canvas and context for its whole life; React mounts its own component on a
+**fresh** canvas. Let React paint one frame (a double `requestAnimationFrame`, or a ~200 ms opacity
+crossfade on the loader canvas), then call `handle.destroy()` and remove the loader canvas. Two GL
+contexts exist for that brief overlap, which browsers allow.
+
+### Reduced motion & Save-Data
+
+`embed()` honors `prefers-reduced-motion` and the Save-Data hint **on by default**, consistent with
+the React components (see below). When either is active it draws exactly one poster frame and never
+starts the rAF loop; `handle.animating` reports which happened.
+
+- `reducedMotion` / `saveData`: `'static-frame' | 'ignore'`, default `'static-frame'`.
+- `staticFrame` (default `0`) is the poster frame, on the same 60fps timebase as the React
+  `staticFrame` prop, so a poster picked for the React component reproduces exactly here.
+- A loading screen that animates against a user's OS accessibility preference while the rest of the
+  library respects it would read as a bug, so opting out is explicit: `reducedMotion: 'ignore'`.
+
+### Failing loud, and the one place it does not
+
+Everything fails loud with a `micugl/embed:` prefixed error: no WebGL context, shader compile
+failure (info log included), program link failure, and a uniform that is not a finite number or an
+array of 2 to 4 finite numbers.
+
+The **one deliberate exception**: a uniform whose `getUniformLocation` returns `null` is **skipped**,
+not thrown. GLSL compilers legitimately optimize out declared-but-unused uniforms, so `null` is an
+expected outcome that is indistinguishable from a typo at the GL level. `WebGLManager` already
+behaves this way. If a uniform seems to have no effect, check that the shader actually reads it.
+
+Caller uniforms are set **once**, at init. Only `u_time` and `u_resolution` are live per frame;
+animate everything else from `u_time` inside the shader.
+
 ## Core
 
 - **WebGLManager**  

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ export default function App() {
 ## Embed (loading screens, no React)
 
 `micugl/embed` is a standalone micro-runtime that renders one animated fullscreen fragment
-shader **before or without** React. It is a separate ~1.6 KB gzip runtime, not a re-export of
+shader **before or without** React. It is a separate ~1.8 KB gzip runtime, not a re-export of
 `micugl/core`: it has no FBOs, no ping-pong, no capability probing and no resource registry,
 because a loading screen needs none of them. (`WebGLManager` builds an `FBOManager` and probes
 four extensions in its constructor, which costs ~4.4 KB gzip for a fullscreen quad. CI enforces
@@ -64,7 +64,9 @@ const handle = embed(document.getElementById("loader"), {
   fragment: FRAGMENT,           // your fragment shader source
   uniforms: { u_tint: [0.2, 0.4, 0.9] },
   clearColor: [0, 0, 0, 1],     // default [0,0,0,1]
-  dpr: 2,                       // devicePixelRatio cap, default 2
+  dpr: [1, 2],                  // same meaning as the React dpr prop, default [1,2]
+  contextAttributes: {},        // merged over { alpha:false, antialias:false, depth:false,
+                                //               stencil:false, powerPreference:'low-power' }
 });
 
 // later, once the real app has painted:
@@ -72,13 +74,26 @@ handle.destroy();
 ```
 
 Your fragment shader receives `uniform float u_time` (seconds), `uniform vec2 u_resolution`
-(drawing-buffer pixels) and `varying vec2 v_uv` (0..1) — the same convention as
-`BaseShaderComponent`, so a shader written for the React component drops straight in.
+(drawing-buffer pixels) and the 0..1 quad coordinate under **both** names the library's shaders
+use, `varying vec2 v_uv` and `varying vec2 v_texCoord` (the examples in this README all name it
+`v_texCoord`), so a fragment shader written for a React component drops straight in.
 The canvas is sized to the viewport, so give it `position:fixed;inset:0`.
 
-`embed()` returns `{ canvas, gl, animating, destroy }`. `destroy()` cancels the loop, removes the
-resize listener, deletes the program/shaders/buffer and calls `WEBGL_lose_context.loseContext()`,
-so a later React mount on a fresh canvas is a clean handoff.
+`dpr` mirrors the React `dpr` prop exactly: a **tuple** `[min, max]` clamps `devicePixelRatio` into
+that range (default `[1, 2]`, so a 3x phone renders at 2x and a zoomed-out 0.5x window still renders
+at 1x), and a **number** is a fixed ratio (`dpr: 2` renders at 2x even on a 1x display). Unlike the
+React components, embed does **not** apply a `maxPixelCount` cap (React defaults to 8,294,400 px);
+a loading screen is one cheap fullscreen quad, so pass `dpr: 1` if you need a hard floor on cost.
+
+`embed()` returns `{ canvas, gl, animating, destroy }`. `animating` is live: it is `false` when the
+motion gate rendered a poster instead of starting the loop, and `false` after `destroy()`.
+`destroy()` cancels the loop, removes the resize and context-loss listeners, deletes the
+program/shaders/buffer and calls `WEBGL_lose_context.loseContext()`, so a later React mount on a
+fresh canvas is a clean handoff. It is idempotent.
+
+If the WebGL context is lost (GPU-process restart, mobile tab eviction) the canvas stops updating;
+embed does not restore it, but it logs a `micugl/embed:` prefixed error rather than going silently
+blank. Recover by removing the canvas and calling `embed()` again on a fresh one.
 
 ### Static HTML (the `<script>` build)
 
@@ -99,9 +114,28 @@ of `node_modules/micugl/dist/` and it exposes `window.micuglEmbed`:
 ### Handing off to React
 
 The loader owns its canvas and context for its whole life; React mounts its own component on a
-**fresh** canvas. Let React paint one frame (a double `requestAnimationFrame`, or a ~200 ms opacity
-crossfade on the loader canvas), then call `handle.destroy()` and remove the loader canvas. Two GL
-contexts exist for that brief overlap, which browsers allow.
+**fresh** canvas. Mount React first, let it paint, and only then destroy the loader — destroying it
+before React's first paint is the black-flash trap:
+
+```jsx
+function App() {
+  useEffect(() => {
+    // two frames: one to commit, one to let the browser paint it
+    const outer = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.__loader?.destroy();
+        document.getElementById("loader")?.remove();
+      });
+    });
+    return () => { cancelAnimationFrame(outer) };
+  }, []);
+
+  return <RippleScene style={{ width: "100vw", height: "100vh" }} />;
+}
+```
+
+Two GL contexts exist for that brief overlap, which browsers allow. A ~200 ms opacity crossfade on
+the loader canvas works the same way: fade first, destroy on transition end.
 
 ### Reduced motion & Save-Data
 
@@ -109,11 +143,19 @@ contexts exist for that brief overlap, which browsers allow.
 the React components (see below). When either is active it draws exactly one poster frame and never
 starts the rAF loop; `handle.animating` reports which happened.
 
-- `reducedMotion` / `saveData`: `'static-frame' | 'ignore'`, default `'static-frame'`.
+- `reducedMotion` / `saveData`: `'static-frame' | 'pause' | 'ignore'` (the same `MotionPolicy`
+  members as the React props), default `'static-frame'`. Only `'ignore'` animates: `'pause'` folds
+  to a static frame here, because a loading screen's clock starts at 0, so pausing it at its current
+  time and posing it at frame 0 are the same picture. Anything else — a typo, a value from a CMS —
+  gates rather than animating, since the `<script>` build has no TypeScript to catch it.
 - `staticFrame` (default `0`) is the poster frame, on the same 60fps timebase as the React
-  `staticFrame` prop, so a poster picked for the React component reproduces exactly here.
+  `staticFrame` prop, so a poster picked for the React component reproduces exactly here. With an
+  explicit `staticFrame`, a gated embed shows that poster rather than frame 0.
 - A loading screen that animates against a user's OS accessibility preference while the rest of the
   library respects it would read as a bug, so opting out is explicit: `reducedMotion: 'ignore'`.
+- The media query is read **once**, at `embed()`. React's `useReducedMotion` subscribes and reacts
+  live; a loading screen lives for a few seconds, so embed spends no bytes on a listener. If the user
+  flips the OS preference mid-load, the loader keeps whatever it started with.
 
 ### Failing loud, and the one place it does not
 
@@ -121,10 +163,13 @@ Everything fails loud with a `micugl/embed:` prefixed error: no WebGL context, s
 failure (info log included), program link failure, and a uniform that is not a finite number or an
 array of 2 to 4 finite numbers.
 
-The **one deliberate exception**: a uniform whose `getUniformLocation` returns `null` is **skipped**,
-not thrown. GLSL compilers legitimately optimize out declared-but-unused uniforms, so `null` is an
-expected outcome that is indistinguishable from a typo at the GL level. `WebGLManager` already
-behaves this way. If a uniform seems to have no effect, check that the shader actually reads it.
+The **one deliberate exception**: a uniform whose `getUniformLocation` returns `null` has its
+**upload** skipped, not thrown. GLSL compilers legitimately optimize out declared-but-unused
+uniforms, so `null` is an expected outcome that is indistinguishable from a typo at the GL level.
+`WebGLManager` already behaves this way. If a uniform seems to have no effect, check that the shader
+actually reads it. The **value is still validated**: `{ u_tint: 'red' }` or a `NaN` from a
+`done / total` with `total === 0` throws whether or not the shader kept the uniform, so a bad value
+cannot hide behind a renamed uniform.
 
 Caller uniforms are set **once**, at init. Only `u_time` and `u_resolution` are live per frame;
 animate everything else from `u_time` inside the shader.

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "ajv": "^8",
+        "esbuild": "^0.28.1",
         "eslint": "^9.25.0",
         "eslint-plugin-react-dom": "^1.48.4",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -103,57 +104,57 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.6", "", { "os": "aix", "cpu": "ppc64" }, "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.6", "", { "os": "android", "cpu": "arm" }, "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.6", "", { "os": "android", "cpu": "arm64" }, "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.6", "", { "os": "android", "cpu": "x64" }, "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.6", "", { "os": "linux", "cpu": "arm" }, "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.6", "", { "os": "linux", "cpu": "ia32" }, "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.6", "", { "os": "linux", "cpu": "none" }, "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.6", "", { "os": "linux", "cpu": "none" }, "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.6", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.6", "", { "os": "linux", "cpu": "none" }, "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.6", "", { "os": "linux", "cpu": "s390x" }, "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.6", "", { "os": "linux", "cpu": "x64" }, "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.6", "", { "os": "none", "cpu": "arm64" }, "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.6", "", { "os": "none", "cpu": "x64" }, "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.6", "", { "os": "none", "cpu": "arm64" }, "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.6", "", { "os": "sunos", "cpu": "x64" }, "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.6", "", { "os": "win32", "cpu": "x64" }, "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.7.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw=="],
 
@@ -429,7 +430,7 @@
 
     "es-module-lexer": ["es-module-lexer@2.3.0", "", {}, "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw=="],
 
-    "esbuild": ["esbuild@0.25.6", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.6", "@esbuild/android-arm": "0.25.6", "@esbuild/android-arm64": "0.25.6", "@esbuild/android-x64": "0.25.6", "@esbuild/darwin-arm64": "0.25.6", "@esbuild/darwin-x64": "0.25.6", "@esbuild/freebsd-arm64": "0.25.6", "@esbuild/freebsd-x64": "0.25.6", "@esbuild/linux-arm": "0.25.6", "@esbuild/linux-arm64": "0.25.6", "@esbuild/linux-ia32": "0.25.6", "@esbuild/linux-loong64": "0.25.6", "@esbuild/linux-mips64el": "0.25.6", "@esbuild/linux-ppc64": "0.25.6", "@esbuild/linux-riscv64": "0.25.6", "@esbuild/linux-s390x": "0.25.6", "@esbuild/linux-x64": "0.25.6", "@esbuild/netbsd-arm64": "0.25.6", "@esbuild/netbsd-x64": "0.25.6", "@esbuild/openbsd-arm64": "0.25.6", "@esbuild/openbsd-x64": "0.25.6", "@esbuild/openharmony-arm64": "0.25.6", "@esbuild/sunos-x64": "0.25.6", "@esbuild/win32-arm64": "0.25.6", "@esbuild/win32-ia32": "0.25.6", "@esbuild/win32-x64": "0.25.6" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg=="],
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -817,6 +818,8 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
+    "vite/esbuild": ["esbuild@0.25.6", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.6", "@esbuild/android-arm": "0.25.6", "@esbuild/android-arm64": "0.25.6", "@esbuild/android-x64": "0.25.6", "@esbuild/darwin-arm64": "0.25.6", "@esbuild/darwin-x64": "0.25.6", "@esbuild/freebsd-arm64": "0.25.6", "@esbuild/freebsd-x64": "0.25.6", "@esbuild/linux-arm": "0.25.6", "@esbuild/linux-arm64": "0.25.6", "@esbuild/linux-ia32": "0.25.6", "@esbuild/linux-loong64": "0.25.6", "@esbuild/linux-mips64el": "0.25.6", "@esbuild/linux-ppc64": "0.25.6", "@esbuild/linux-riscv64": "0.25.6", "@esbuild/linux-s390x": "0.25.6", "@esbuild/linux-x64": "0.25.6", "@esbuild/netbsd-arm64": "0.25.6", "@esbuild/netbsd-x64": "0.25.6", "@esbuild/openbsd-arm64": "0.25.6", "@esbuild/openbsd-x64": "0.25.6", "@esbuild/openharmony-arm64": "0.25.6", "@esbuild/sunos-x64": "0.25.6", "@esbuild/win32-arm64": "0.25.6", "@esbuild/win32-ia32": "0.25.6", "@esbuild/win32-x64": "0.25.6" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg=="],
+
     "vitest/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "vitest/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
@@ -840,6 +843,58 @@
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.6", "", { "os": "aix", "cpu": "ppc64" }, "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.6", "", { "os": "android", "cpu": "arm" }, "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.6", "", { "os": "android", "cpu": "arm64" }, "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.6", "", { "os": "android", "cpu": "x64" }, "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.6", "", { "os": "linux", "cpu": "arm" }, "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.6", "", { "os": "linux", "cpu": "ia32" }, "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.6", "", { "os": "linux", "cpu": "none" }, "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.6", "", { "os": "linux", "cpu": "none" }, "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.6", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.6", "", { "os": "linux", "cpu": "none" }, "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.6", "", { "os": "linux", "cpu": "s390x" }, "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.6", "", { "os": "linux", "cpu": "x64" }, "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig=="],
+
+    "vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.6", "", { "os": "none", "cpu": "arm64" }, "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.6", "", { "os": "none", "cpu": "x64" }, "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g=="],
+
+    "vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw=="],
+
+    "vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.6", "", { "os": "none", "cpu": "arm64" }, "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.6", "", { "os": "sunos", "cpu": "x64" }, "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.6", "", { "os": "win32", "cpu": "x64" }, "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA=="],
 
     "vitest/magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/react.mjs",
       "require": "./dist/react.js"
     },
+    "./embed": {
+      "types": "./dist/embed/index.d.ts",
+      "import": "./dist/embed.mjs",
+      "require": "./dist/embed.js"
+    },
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing.mjs",
@@ -47,7 +52,7 @@
   ],
   "scripts": {
     "dev": "vite --config demo/vite.config.ts",
-    "build": "vite build && vite build --config vite.worker.config.ts && node scripts/assertTreeshaken.mjs",
+    "build": "vite build && vite build --config vite.worker.config.ts && esbuild src/embed/index.ts --bundle --minify --format=iife --global-name=micuglEmbed --target=es2020 --outfile=dist/embed.global.js && node scripts/assertTreeshaken.mjs && node scripts/checkEmbedSize.mjs",
     "prepublishOnly": "npm run build",
     "test": "vitest run",
     "lint": "eslint . --ext .ts,.tsx",
@@ -78,6 +83,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "ajv": "^8",
+    "esbuild": "^0.28.1",
     "eslint": "^9.25.0",
     "eslint-plugin-react-dom": "^1.48.4",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/scripts/checkEmbedSize.mjs
+++ b/scripts/checkEmbedSize.mjs
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+const distRoot = resolve(process.cwd(), process.argv[2] ?? 'dist');
+
+const BUDGETS = [
+    { file: 'embed.mjs', gzipBudget: 1800 },
+    { file: 'embed.global.js', gzipBudget: 1900 }
+];
+
+const RELATIVE_IMPORT = /\bfrom\s*['"]\.|(?:^|[;\n])\s*import\s*['"]\./;
+
+const failures = [];
+const measured = [];
+
+for (const { file, gzipBudget } of BUDGETS) {
+    const path = resolve(distRoot, file);
+
+    if (!existsSync(path)) {
+        failures.push(`${file} was not emitted, so the micugl/embed size budget guards nothing.`);
+        continue;
+    }
+
+    const bytes = readFileSync(path);
+    const source = bytes.toString('utf8');
+
+    if (RELATIVE_IMPORT.test(source)) {
+        failures.push(
+            `${file} statically imports another module, so it is a re-export shim rather than the runtime `
+            + 'itself. Gzipping it would measure the shim and pass no matter how large the runtime grew. Keep '
+            + 'the embed runtime a single self-contained module (src/embed/index.ts) with no imports.'
+        );
+    }
+
+    const gzipSize = gzipSync(bytes, { level: 9 }).length;
+    measured.push(`${file}: ${gzipSize} B gzip / ${bytes.length} B raw (budget ${gzipBudget} B gzip)`);
+
+    if (gzipSize > gzipBudget) {
+        failures.push(
+            `${file} is ${gzipSize} B gzip, which is ${gzipSize - gzipBudget} B over its ${gzipBudget} B budget. `
+            + 'The embed runtime exists because reusing WebGLManager costs ~4.4 KB gzip for a fullscreen quad; a '
+            + 'runtime that drifts back toward that size has lost its reason to exist. Cut bytes rather than '
+            + 'raising the budget.'
+        );
+    }
+}
+
+if (failures.length > 0) {
+    console.error('checkEmbedSize: the micugl/embed artifacts do not meet their budget:');
+    for (const failure of failures) {
+        console.error(`  - ${failure}`);
+    }
+    process.exit(1);
+}
+
+console.log(`checkEmbedSize: ${measured.join('; ')}`);

--- a/scripts/checkEmbedSize.mjs
+++ b/scripts/checkEmbedSize.mjs
@@ -9,7 +9,27 @@ const BUDGETS = [
     { file: 'embed.global.js', gzipBudget: 1900 }
 ];
 
-const RELATIVE_IMPORT = /\bfrom\s*['"]\.|(?:^|[;\n])\s*import\s*['"]\./;
+const EXPORT_TARGETS = ['embed.js', 'embed/index.d.ts'];
+
+const FROM_SPECIFIER = /\bfrom\s*['"]([^'"]+)['"]/g;
+const BARE_IMPORT = /(?:^|[;\n])\s*import\s*['"]([^'"]+)['"]/g;
+const DYNAMIC_IMPORT = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+const matchAll = (source, pattern) => {
+    const specifiers = [];
+    let match;
+    while ((match = pattern.exec(source)) !== null) {
+        specifiers.push(match[1]);
+    }
+    pattern.lastIndex = 0;
+    return specifiers;
+};
+
+const importedSpecifiers = source => [
+    ...matchAll(source, FROM_SPECIFIER),
+    ...matchAll(source, BARE_IMPORT),
+    ...matchAll(source, DYNAMIC_IMPORT)
+];
 
 const failures = [];
 const measured = [];
@@ -24,12 +44,14 @@ for (const { file, gzipBudget } of BUDGETS) {
 
     const bytes = readFileSync(path);
     const source = bytes.toString('utf8');
+    const imports = importedSpecifiers(source);
 
-    if (RELATIVE_IMPORT.test(source)) {
+    if (imports.length > 0) {
         failures.push(
-            `${file} statically imports another module, so it is a re-export shim rather than the runtime `
-            + 'itself. Gzipping it would measure the shim and pass no matter how large the runtime grew. Keep '
-            + 'the embed runtime a single self-contained module (src/embed/index.ts) with no imports.'
+            `${file} imports ${imports.join(', ')}, so it is a re-export shim rather than the runtime itself. `
+            + 'Gzipping it would measure the shim and pass no matter how large the runtime grew. Keep the embed '
+            + 'runtime a single self-contained module (src/embed/index.ts) with no static, bare or dynamic '
+            + 'imports.'
         );
     }
 
@@ -42,6 +64,15 @@ for (const { file, gzipBudget } of BUDGETS) {
             + 'The embed runtime exists because reusing WebGLManager costs ~4.4 KB gzip for a fullscreen quad; a '
             + 'runtime that drifts back toward that size has lost its reason to exist. Cut bytes rather than '
             + 'raising the budget.'
+        );
+    }
+}
+
+for (const file of EXPORT_TARGETS) {
+    if (!existsSync(resolve(distRoot, file))) {
+        failures.push(
+            `${file} was not emitted, but package.json maps the micugl/embed export at it, so the subpath would `
+            + 'resolve to nothing (or ship untyped) with a green build.'
         );
     }
 }

--- a/src/embed/index.test.ts
+++ b/src/embed/index.test.ts
@@ -33,6 +33,8 @@ interface GLStubHandle {
     locationFor: (name: string) => object | null;
     named: (name: string) => GLCall[];
     countOf: (name: string) => number;
+    fireContextLost: () => void;
+    contextLostListenerCount: () => number;
 }
 
 function createStub(options: GLStubOptions = {}): GLStubHandle {
@@ -40,6 +42,7 @@ function createStub(options: GLStubOptions = {}): GLStubHandle {
     const contextAttributes: WebGLContextAttributes[] = [];
     const nullUniforms = new Set(options.nullUniforms ?? []);
     const locations = new Map<string, object>();
+    const contextLostListeners = new Set<() => void>();
 
     const record = (name: string, args: unknown[]): void => {
         calls.push({ name, args });
@@ -67,8 +70,12 @@ function createStub(options: GLStubOptions = {}): GLStubHandle {
         FLOAT: GL_FLOAT,
         COLOR_BUFFER_BIT: GL_COLOR_BUFFER_BIT,
         TRIANGLE_STRIP: GL_TRIANGLE_STRIP,
-        drawingBufferWidth: options.drawingBufferWidth ?? 1600,
-        drawingBufferHeight: options.drawingBufferHeight ?? 1200,
+        get drawingBufferWidth(): number {
+            return options.drawingBufferWidth ?? canvas.width;
+        },
+        get drawingBufferHeight(): number {
+            return options.drawingBufferHeight ?? canvas.height;
+        },
         createShader: (type: number): object => {
             record('createShader', [type]);
             return { shader: type };
@@ -160,6 +167,16 @@ function createStub(options: GLStubOptions = {}): GLStubHandle {
             record('getContext', [contextId, attributes]);
             contextAttributes.push(attributes);
             return (options.noContext ?? false) ? null : gl;
+        },
+        addEventListener: (type: string, listener: () => void): void => {
+            if (type === 'webglcontextlost') {
+                contextLostListeners.add(listener);
+            }
+        },
+        removeEventListener: (type: string, listener: () => void): void => {
+            if (type === 'webglcontextlost') {
+                contextLostListeners.delete(listener);
+            }
         }
     };
 
@@ -171,7 +188,13 @@ function createStub(options: GLStubOptions = {}): GLStubHandle {
         contextAttributes,
         locationFor,
         named,
-        countOf: (name: string): number => named(name).length
+        countOf: (name: string): number => named(name).length,
+        fireContextLost: (): void => {
+            for (const listener of [...contextLostListeners]) {
+                listener();
+            }
+        },
+        contextLostListenerCount: (): number => contextLostListeners.size
     };
 }
 
@@ -181,6 +204,16 @@ interface EnvironmentOptions {
     devicePixelRatio?: number;
     innerWidth?: number;
     innerHeight?: number;
+    noMatchMedia?: boolean;
+}
+
+interface WindowStub {
+    devicePixelRatio: number;
+    innerWidth: number;
+    innerHeight: number;
+    matchMedia?: (query: string) => { matches: boolean };
+    addEventListener: (type: string, listener: () => void) => void;
+    removeEventListener: (type: string, listener: () => void) => void;
 }
 
 interface EnvironmentHandle {
@@ -196,7 +229,7 @@ function installEnvironment(options: EnvironmentOptions = {}): EnvironmentHandle
     let nextFrameId = 1;
     let now = 1000;
 
-    const win = {
+    const win: WindowStub = {
         devicePixelRatio: options.devicePixelRatio ?? 1,
         innerWidth: options.innerWidth ?? 800,
         innerHeight: options.innerHeight ?? 600,
@@ -214,6 +247,10 @@ function installEnvironment(options: EnvironmentOptions = {}): EnvironmentHandle
             }
         }
     };
+
+    if (options.noMatchMedia ?? false) {
+        delete win.matchMedia;
+    }
 
     vi.stubGlobal('window', win);
     vi.stubGlobal('navigator', { connection: { saveData: options.saveData ?? false } });
@@ -254,6 +291,7 @@ const FRAGMENT = 'precision highp float;void main(){gl_FragColor=vec4(1.0);}';
 afterEach(() => {
     vi.unstubAllGlobals();
     vi.resetModules();
+    vi.restoreAllMocks();
 });
 
 describe('embed fail-loud paths', () => {
@@ -279,6 +317,16 @@ describe('embed fail-loud paths', () => {
 
         expect(() => embed(canvas, { fragment: FRAGMENT }))
             .toThrow(/^micugl\/embed: program link failed: ERROR: varying v_uv is not written/);
+    });
+
+    it('deletes the program and both shaders before throwing on a link failure', () => {
+        installEnvironment();
+        const stub = createStub({ linkFails: true });
+
+        expect(() => embed(stub.canvas, { fragment: FRAGMENT })).toThrow();
+
+        expect(stub.countOf('deleteShader')).toBe(2);
+        expect(stub.countOf('deleteProgram')).toBe(1);
     });
 
     it('throws for a uniform array that is not 2 to 4 components', () => {
@@ -371,17 +419,91 @@ describe('embed setup', () => {
         expect(stub.named('clearColor')[0]?.args).toEqual([0.1, 0.2, 0.3, 1]);
     });
 
-    it('clamps the drawing buffer to the dpr cap and sizes the canvas to the viewport', () => {
+    it('sizes the css box to the viewport', () => {
         installEnvironment({ devicePixelRatio: 3, innerWidth: 800, innerHeight: 600 });
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+
+        expect(stub.canvas.style.width).toBe('800px');
+        expect(stub.canvas.style.height).toBe('600px');
+    });
+});
+
+describe('embed dpr', () => {
+    it('reads a numeric dpr as a fixed ratio, exactly as the React dpr prop does', () => {
+        installEnvironment({ devicePixelRatio: 1, innerWidth: 800, innerHeight: 600 });
         const stub = createStub();
 
         embed(stub.canvas, { fragment: FRAGMENT, dpr: 2 });
 
         expect(stub.canvas.width).toBe(1600);
         expect(stub.canvas.height).toBe(1200);
-        expect(stub.canvas.style.width).toBe('800px');
-        expect(stub.canvas.style.height).toBe('600px');
-        expect(stub.named('viewport')[0]?.args).toEqual([0, 0, 1600, 1200]);
+    });
+
+    it('clamps devicePixelRatio into the range when dpr is a tuple', () => {
+        installEnvironment({ devicePixelRatio: 3, innerWidth: 800, innerHeight: 600 });
+        const capped = createStub();
+
+        embed(capped.canvas, { fragment: FRAGMENT, dpr: [1, 1.5] });
+
+        expect(capped.canvas.width).toBe(1200);
+        expect(capped.canvas.height).toBe(900);
+
+        installEnvironment({ devicePixelRatio: 0.5, innerWidth: 800, innerHeight: 600 });
+        const floored = createStub();
+
+        embed(floored.canvas, { fragment: FRAGMENT, dpr: [1, 1.5] });
+
+        expect(floored.canvas.width).toBe(800);
+        expect(floored.canvas.height).toBe(600);
+    });
+
+    it('defaults to the React [1, 2] range: capped above 2x, floored below 1x', () => {
+        installEnvironment({ devicePixelRatio: 3, innerWidth: 800, innerHeight: 600 });
+        const dense = createStub();
+
+        embed(dense.canvas, { fragment: FRAGMENT });
+
+        expect(dense.canvas.width).toBe(1600);
+        expect(dense.canvas.height).toBe(1200);
+
+        installEnvironment({ devicePixelRatio: 0.5, innerWidth: 800, innerHeight: 600 });
+        const zoomedOut = createStub();
+
+        embed(zoomedOut.canvas, { fragment: FRAGMENT });
+
+        expect(zoomedOut.canvas.width).toBe(800);
+        expect(zoomedOut.canvas.height).toBe(600);
+    });
+});
+
+describe('embed viewport', () => {
+    it('sets the viewport from the real drawing buffer, not the requested canvas size', () => {
+        const environment = installEnvironment({ devicePixelRatio: 2, innerWidth: 800, innerHeight: 600 });
+        const stub = createStub({ drawingBufferWidth: 1024, drawingBufferHeight: 768 });
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+
+        expect(stub.canvas.width).toBe(1600);
+        expect(stub.canvas.height).toBe(1200);
+        expect(stub.named('viewport').at(-1)?.args).toEqual([0, 0, 1024, 768]);
+
+        environment.tick();
+
+        expect(stub.named('uniform2f').at(-1)?.args).toEqual([stub.locationFor('u_resolution'), 1024, 768]);
+    });
+
+    it('keeps the viewport on the real drawing buffer across a resize', () => {
+        const environment = installEnvironment({ devicePixelRatio: 2, innerWidth: 800, innerHeight: 600 });
+        const stub = createStub({ drawingBufferWidth: 1024, drawingBufferHeight: 768 });
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+        environment.setViewport(1200, 900);
+        environment.fireResize();
+
+        expect(stub.canvas.width).toBe(2400);
+        expect(stub.named('viewport').at(-1)?.args).toEqual([0, 0, 1024, 768]);
     });
 });
 
@@ -433,12 +555,37 @@ describe('embed uniform dispatch', () => {
         expect(uploads.some(call => call.args[0] === null)).toBe(false);
     });
 
-    it('does not validate a uniform that the shader optimized away', () => {
+    it('still validates a uniform that the shader optimized away', () => {
         installEnvironment();
-        const stub = createStub({ nullUniforms: ['u_unused'] });
 
-        expect(() => embed(stub.canvas, { fragment: FRAGMENT, uniforms: { u_unused: [1] } })).not.toThrow();
+        expect(() => embed(
+            createStub({ nullUniforms: ['u_unused'] }).canvas,
+            { fragment: FRAGMENT, uniforms: { u_unused: [1] } }
+        )).toThrow(/^micugl\/embed: uniform "u_unused" must be a finite number or an array of 2 to 4/);
+
+        expect(() => embed(
+            createStub({ nullUniforms: ['u_unused'] }).canvas,
+            { fragment: FRAGMENT, uniforms: { u_unused: Number.NaN } }
+        )).toThrow(/^micugl\/embed: uniform "u_unused" must be a finite number/);
+
+        const typo = { u_unused: 'red' } as unknown as Record<string, number>;
+        expect(() => embed(
+            createStub({ nullUniforms: ['u_unused'] }).canvas,
+            { fragment: FRAGMENT, uniforms: typo }
+        )).toThrow(/^micugl\/embed: uniform "u_unused" must be a finite number/);
+    });
+
+    it('skips the upload, without throwing, for a valid value the shader optimized away', () => {
+        installEnvironment();
+        const stub = createStub({ nullUniforms: ['u_unused', 'u_scalar'] });
+
+        expect(() => embed(stub.canvas, {
+            fragment: FRAGMENT,
+            uniforms: { u_unused: [1, 2], u_scalar: 0.5 }
+        })).not.toThrow();
+
         expect(stub.countOf('uniform2fv')).toBe(0);
+        expect(stub.countOf('uniform1f')).toBe(0);
     });
 });
 
@@ -462,8 +609,8 @@ describe('embed render loop', () => {
     });
 
     it('draws the quad and uploads the drawing-buffer resolution on every frame', () => {
-        const environment = installEnvironment();
-        const stub = createStub({ drawingBufferWidth: 1600, drawingBufferHeight: 1200 });
+        const environment = installEnvironment({ devicePixelRatio: 2, innerWidth: 800, innerHeight: 600 });
+        const stub = createStub({ drawingBufferWidth: 1024, drawingBufferHeight: 768 });
 
         embed(stub.canvas, { fragment: FRAGMENT });
 
@@ -474,7 +621,7 @@ describe('embed render loop', () => {
         expect(stub.countOf('drawArrays')).toBe(2);
         expect(stub.named('drawArrays')[0]?.args).toEqual([GL_TRIANGLE_STRIP, 0, 4]);
         expect(stub.named('uniform2f')).toHaveLength(2);
-        expect(stub.named('uniform2f')[0]?.args).toEqual([stub.locationFor('u_resolution'), 1600, 1200]);
+        expect(stub.named('uniform2f')[0]?.args).toEqual([stub.locationFor('u_resolution'), 1024, 768]);
     });
 
     it('uploads no time when the shader declares no u_time', () => {
@@ -549,6 +696,77 @@ describe('embed destroy', () => {
         expect(stub.named('getExtension').at(-1)?.args).toEqual(['WEBGL_lose_context']);
         expect(stub.countOf('loseContext')).toBe(1);
     });
+
+    it('stops the loop when destroyed before the first frame runs', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT }).destroy();
+        environment.tick();
+        environment.tick();
+
+        expect(stub.countOf('drawArrays')).toBe(0);
+    });
+
+    it('is idempotent: a second destroy neither throws nor restarts the loop', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT });
+        environment.tick();
+        handle.destroy();
+
+        expect(() => { handle.destroy() }).not.toThrow();
+
+        environment.tick();
+        environment.tick();
+
+        expect(stub.countOf('drawArrays')).toBe(1);
+        expect(handle.animating).toBe(false);
+    });
+
+    it('reports animating false once destroyed, and stops drawing', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT });
+        environment.tick();
+        expect(handle.animating).toBe(true);
+        expect(stub.countOf('drawArrays')).toBe(1);
+
+        handle.destroy();
+        environment.tick();
+
+        expect(handle.animating).toBe(false);
+        expect(stub.countOf('drawArrays')).toBe(1);
+    });
+});
+
+describe('embed context loss', () => {
+    it('logs loudly when the WebGL context is lost rather than going silently blank', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+        const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+        environment.tick();
+        stub.fireContextLost();
+
+        expect(errors).toHaveBeenCalledTimes(1);
+        expect(errors.mock.calls[0]?.[0]).toMatch(/^micugl\/embed: the WebGL context was lost/);
+    });
+
+    it('does not log a lost context that destroy() caused itself', () => {
+        installEnvironment();
+        const stub = createStub();
+        const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        embed(stub.canvas, { fragment: FRAGMENT }).destroy();
+        stub.fireContextLost();
+
+        expect(stub.contextLostListenerCount()).toBe(0);
+        expect(errors).not.toHaveBeenCalled();
+    });
 });
 
 describe('embed motion gate', () => {
@@ -616,6 +834,7 @@ describe('embed motion gate', () => {
 
         const handle = embed(stub.canvas, { fragment: FRAGMENT });
         environment.tick();
+        environment.tick();
 
         expect(handle.animating).toBe(false);
         expect(stub.countOf('drawArrays')).toBe(1);
@@ -627,9 +846,56 @@ describe('embed motion gate', () => {
 
         const handle = embed(stub.canvas, { fragment: FRAGMENT, saveData: 'ignore' });
         environment.tick();
+        environment.tick();
 
         expect(handle.animating).toBe(true);
+        expect(stub.countOf('drawArrays')).toBe(2);
+    });
+
+    it('folds pause into a static frame rather than animating', () => {
+        const environment = installEnvironment({ reducedMotion: true, saveData: true });
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, {
+            fragment: FRAGMENT,
+            reducedMotion: 'pause',
+            saveData: 'pause',
+            staticFrame: 30
+        });
+        environment.tick();
+        environment.tick();
+
+        expect(handle.animating).toBe(false);
         expect(stub.countOf('drawArrays')).toBe(1);
+        expect(stub.named('uniform1f')[0]?.args).toEqual([stub.locationFor('u_time'), 0.5]);
+    });
+
+    it('gates on an unknown policy string rather than animating against the preference', () => {
+        const environment = installEnvironment({ reducedMotion: true });
+        const stub = createStub();
+        const options = {
+            fragment: FRAGMENT,
+            reducedMotion: 'static_frame'
+        } as unknown as { fragment: string };
+
+        const handle = embed(stub.canvas, options);
+        environment.tick();
+        environment.tick();
+
+        expect(handle.animating).toBe(false);
+        expect(stub.countOf('drawArrays')).toBe(1);
+    });
+
+    it('animates without throwing in a DOM shim that has no matchMedia', () => {
+        const environment = installEnvironment({ noMatchMedia: true });
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT });
+        environment.tick();
+        environment.tick();
+
+        expect(handle.animating).toBe(true);
+        expect(stub.countOf('drawArrays')).toBe(2);
     });
 });
 

--- a/src/embed/index.test.ts
+++ b/src/embed/index.test.ts
@@ -1,0 +1,647 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { embed } from '@/embed';
+
+const GL_VERTEX_SHADER = 0x8b31;
+const GL_FRAGMENT_SHADER = 0x8b30;
+const GL_COMPILE_STATUS = 0x8b81;
+const GL_LINK_STATUS = 0x8b82;
+const GL_ARRAY_BUFFER = 0x8892;
+const GL_STATIC_DRAW = 0x88e4;
+const GL_FLOAT = 0x1406;
+const GL_COLOR_BUFFER_BIT = 0x4000;
+const GL_TRIANGLE_STRIP = 0x0005;
+
+interface GLCall {
+    name: string;
+    args: unknown[];
+}
+
+interface GLStubOptions {
+    noContext?: boolean;
+    compileFails?: boolean;
+    linkFails?: boolean;
+    nullUniforms?: string[];
+    drawingBufferWidth?: number;
+    drawingBufferHeight?: number;
+}
+
+interface GLStubHandle {
+    canvas: HTMLCanvasElement;
+    calls: GLCall[];
+    contextAttributes: WebGLContextAttributes[];
+    locationFor: (name: string) => object | null;
+    named: (name: string) => GLCall[];
+    countOf: (name: string) => number;
+}
+
+function createStub(options: GLStubOptions = {}): GLStubHandle {
+    const calls: GLCall[] = [];
+    const contextAttributes: WebGLContextAttributes[] = [];
+    const nullUniforms = new Set(options.nullUniforms ?? []);
+    const locations = new Map<string, object>();
+
+    const record = (name: string, args: unknown[]): void => {
+        calls.push({ name, args });
+    };
+
+    const locationFor = (name: string): object | null => {
+        if (nullUniforms.has(name)) {
+            return null;
+        }
+        let location = locations.get(name);
+        if (!location) {
+            location = { uniform: name };
+            locations.set(name, location);
+        }
+        return location;
+    };
+
+    const gl = {
+        VERTEX_SHADER: GL_VERTEX_SHADER,
+        FRAGMENT_SHADER: GL_FRAGMENT_SHADER,
+        COMPILE_STATUS: GL_COMPILE_STATUS,
+        LINK_STATUS: GL_LINK_STATUS,
+        ARRAY_BUFFER: GL_ARRAY_BUFFER,
+        STATIC_DRAW: GL_STATIC_DRAW,
+        FLOAT: GL_FLOAT,
+        COLOR_BUFFER_BIT: GL_COLOR_BUFFER_BIT,
+        TRIANGLE_STRIP: GL_TRIANGLE_STRIP,
+        drawingBufferWidth: options.drawingBufferWidth ?? 1600,
+        drawingBufferHeight: options.drawingBufferHeight ?? 1200,
+        createShader: (type: number): object => {
+            record('createShader', [type]);
+            return { shader: type };
+        },
+        shaderSource: (shader: object, source: string): void => { record('shaderSource', [shader, source]) },
+        compileShader: (shader: object): void => { record('compileShader', [shader]) },
+        getShaderParameter: (shader: object, pname: number): boolean => {
+            record('getShaderParameter', [shader, pname]);
+            return !(options.compileFails ?? false);
+        },
+        getShaderInfoLog: (shader: object): string => {
+            record('getShaderInfoLog', [shader]);
+            return 'ERROR: 0:3 undefined variable';
+        },
+        deleteShader: (shader: object): void => { record('deleteShader', [shader]) },
+        createProgram: (): object => {
+            record('createProgram', []);
+            return { program: true };
+        },
+        attachShader: (program: object, shader: object): void => { record('attachShader', [program, shader]) },
+        linkProgram: (program: object): void => { record('linkProgram', [program]) },
+        getProgramParameter: (program: object, pname: number): boolean => {
+            record('getProgramParameter', [program, pname]);
+            return !(options.linkFails ?? false);
+        },
+        getProgramInfoLog: (program: object): string => {
+            record('getProgramInfoLog', [program]);
+            return 'ERROR: varying v_uv is not written';
+        },
+        useProgram: (program: object): void => { record('useProgram', [program]) },
+        deleteProgram: (program: object): void => { record('deleteProgram', [program]) },
+        createBuffer: (): object => {
+            record('createBuffer', []);
+            return { buffer: true };
+        },
+        bindBuffer: (target: number, buffer: object): void => { record('bindBuffer', [target, buffer]) },
+        bufferData: (target: number, data: Float32Array, usage: number): void => {
+            record('bufferData', [target, data, usage]);
+        },
+        deleteBuffer: (buffer: object): void => { record('deleteBuffer', [buffer]) },
+        getAttribLocation: (program: object, name: string): number => {
+            record('getAttribLocation', [program, name]);
+            return 0;
+        },
+        enableVertexAttribArray: (index: number): void => { record('enableVertexAttribArray', [index]) },
+        vertexAttribPointer: (
+            index: number,
+            size: number,
+            type: number,
+            normalized: boolean,
+            stride: number,
+            offset: number
+        ): void => {
+            record('vertexAttribPointer', [index, size, type, normalized, stride, offset]);
+        },
+        getUniformLocation: (program: object, name: string): object | null => {
+            record('getUniformLocation', [program, name]);
+            return locationFor(name);
+        },
+        uniform1f: (location: object, value: number): void => { record('uniform1f', [location, value]) },
+        uniform2f: (location: object, x: number, y: number): void => { record('uniform2f', [location, x, y]) },
+        uniform2fv: (location: object, value: Float32Array): void => { record('uniform2fv', [location, value]) },
+        uniform3fv: (location: object, value: Float32Array): void => { record('uniform3fv', [location, value]) },
+        uniform4fv: (location: object, value: Float32Array): void => { record('uniform4fv', [location, value]) },
+        clearColor: (r: number, g: number, b: number, a: number): void => { record('clearColor', [r, g, b, a]) },
+        clear: (mask: number): void => { record('clear', [mask]) },
+        viewport: (x: number, y: number, width: number, height: number): void => {
+            record('viewport', [x, y, width, height]);
+        },
+        drawArrays: (mode: number, first: number, count: number): void => {
+            record('drawArrays', [mode, first, count]);
+        },
+        getExtension: (name: string): object | null => {
+            record('getExtension', [name]);
+            if (name !== 'WEBGL_lose_context') {
+                return null;
+            }
+            return {
+                loseContext: (): void => { record('loseContext', []) }
+            };
+        }
+    };
+
+    const canvas = {
+        width: 300,
+        height: 150,
+        style: { width: '', height: '' },
+        getContext: (contextId: string, attributes: WebGLContextAttributes): unknown => {
+            record('getContext', [contextId, attributes]);
+            contextAttributes.push(attributes);
+            return (options.noContext ?? false) ? null : gl;
+        }
+    };
+
+    const named = (name: string): GLCall[] => calls.filter(call => call.name === name);
+
+    return {
+        canvas: canvas as unknown as HTMLCanvasElement,
+        calls,
+        contextAttributes,
+        locationFor,
+        named,
+        countOf: (name: string): number => named(name).length
+    };
+}
+
+interface EnvironmentOptions {
+    reducedMotion?: boolean;
+    saveData?: boolean;
+    devicePixelRatio?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+}
+
+interface EnvironmentHandle {
+    tick: (deltaMs?: number) => void;
+    fireResize: () => void;
+    resizeListenerCount: () => number;
+    setViewport: (width: number, height: number) => void;
+}
+
+function installEnvironment(options: EnvironmentOptions = {}): EnvironmentHandle {
+    const frames = new Map<number, FrameRequestCallback>();
+    const resizeListeners = new Set<() => void>();
+    let nextFrameId = 1;
+    let now = 1000;
+
+    const win = {
+        devicePixelRatio: options.devicePixelRatio ?? 1,
+        innerWidth: options.innerWidth ?? 800,
+        innerHeight: options.innerHeight ?? 600,
+        matchMedia: (query: string): { matches: boolean } => ({
+            matches: query === '(prefers-reduced-motion: reduce)' && (options.reducedMotion ?? false)
+        }),
+        addEventListener: (type: string, listener: () => void): void => {
+            if (type === 'resize') {
+                resizeListeners.add(listener);
+            }
+        },
+        removeEventListener: (type: string, listener: () => void): void => {
+            if (type === 'resize') {
+                resizeListeners.delete(listener);
+            }
+        }
+    };
+
+    vi.stubGlobal('window', win);
+    vi.stubGlobal('navigator', { connection: { saveData: options.saveData ?? false } });
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback): number => {
+        const id = nextFrameId;
+        nextFrameId += 1;
+        frames.set(id, callback);
+        return id;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number): void => {
+        frames.delete(id);
+    });
+
+    return {
+        tick: (deltaMs = 16): void => {
+            now += deltaMs;
+            const pending = [...frames.values()];
+            frames.clear();
+            for (const callback of pending) {
+                callback(now);
+            }
+        },
+        fireResize: (): void => {
+            for (const listener of [...resizeListeners]) {
+                listener();
+            }
+        },
+        resizeListenerCount: (): number => resizeListeners.size,
+        setViewport: (width: number, height: number): void => {
+            win.innerWidth = width;
+            win.innerHeight = height;
+        }
+    };
+}
+
+const FRAGMENT = 'precision highp float;void main(){gl_FragColor=vec4(1.0);}';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+});
+
+describe('embed fail-loud paths', () => {
+    it('throws when the canvas yields no WebGL context', () => {
+        installEnvironment();
+        const { canvas } = createStub({ noContext: true });
+
+        expect(() => embed(canvas, { fragment: FRAGMENT }))
+            .toThrow(/^micugl\/embed: could not get a WebGL context/);
+    });
+
+    it('throws with the shader info log when compilation fails', () => {
+        installEnvironment();
+        const { canvas } = createStub({ compileFails: true });
+
+        expect(() => embed(canvas, { fragment: FRAGMENT }))
+            .toThrow(/^micugl\/embed: shader compilation failed: ERROR: 0:3 undefined variable/);
+    });
+
+    it('throws with the program info log when linking fails', () => {
+        installEnvironment();
+        const { canvas } = createStub({ linkFails: true });
+
+        expect(() => embed(canvas, { fragment: FRAGMENT }))
+            .toThrow(/^micugl\/embed: program link failed: ERROR: varying v_uv is not written/);
+    });
+
+    it('throws for a uniform array that is not 2 to 4 components', () => {
+        installEnvironment();
+
+        expect(() => embed(createStub().canvas, { fragment: FRAGMENT, uniforms: { u_a: [1] } }))
+            .toThrow(/^micugl\/embed: uniform "u_a" must be a finite number or an array of 2 to 4 finite numbers/);
+        expect(() => embed(createStub().canvas, { fragment: FRAGMENT, uniforms: { u_a: [1, 2, 3, 4, 5] } }))
+            .toThrow(/received 1,2,3,4,5$/);
+    });
+
+    it('throws for a uniform that is neither a number nor an array', () => {
+        installEnvironment();
+        const uniforms = { u_a: 'red' } as unknown as Record<string, number>;
+
+        expect(() => embed(createStub().canvas, { fragment: FRAGMENT, uniforms }))
+            .toThrow(/^micugl\/embed: uniform "u_a" must be a finite number or an array of 2 to 4 finite numbers/);
+    });
+
+    it('throws for a non-finite uniform value rather than uploading NaN', () => {
+        installEnvironment();
+
+        expect(() => embed(createStub().canvas, { fragment: FRAGMENT, uniforms: { u_a: Number.NaN } }))
+            .toThrow(/^micugl\/embed: uniform "u_a" must be a finite number/);
+        expect(() => embed(createStub().canvas, { fragment: FRAGMENT, uniforms: { u_a: [1, Number.NaN] } }))
+            .toThrow(/received 1,NaN$/);
+    });
+});
+
+describe('embed setup', () => {
+    it('compiles one vertex and one fragment shader into a single linked program', () => {
+        installEnvironment();
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+
+        expect(stub.named('createShader').map(call => call.args[0])).toEqual([
+            GL_VERTEX_SHADER,
+            GL_FRAGMENT_SHADER
+        ]);
+        expect(stub.countOf('createProgram')).toBe(1);
+        expect(stub.countOf('linkProgram')).toBe(1);
+        expect(stub.countOf('useProgram')).toBe(1);
+
+        const sources = stub.named('shaderSource').map(call => call.args[1]);
+        expect(sources[0]).toContain('attribute vec2 a_position');
+        expect(sources[1]).toBe(FRAGMENT);
+    });
+
+    it('uploads the fullscreen quad and binds a_position as a 2-component float attribute', () => {
+        installEnvironment();
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+
+        const bufferData = stub.named('bufferData')[0];
+        expect(bufferData.args[0]).toBe(GL_ARRAY_BUFFER);
+        expect(bufferData.args[1]).toEqual(new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]));
+        expect(bufferData.args[2]).toBe(GL_STATIC_DRAW);
+
+        expect(stub.named('getAttribLocation')[0]?.args[1]).toBe('a_position');
+        expect(stub.named('enableVertexAttribArray')[0]?.args).toEqual([0]);
+        expect(stub.named('vertexAttribPointer')[0]?.args).toEqual([0, 2, GL_FLOAT, false, 0, 0]);
+    });
+
+    it('merges caller context attributes over the low-power defaults', () => {
+        installEnvironment();
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT, contextAttributes: { alpha: true } });
+
+        expect(stub.contextAttributes[0]).toEqual({
+            alpha: true,
+            antialias: false,
+            depth: false,
+            stencil: false,
+            powerPreference: 'low-power'
+        });
+    });
+
+    it('sets the clear color once at init rather than every frame', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT, clearColor: [0.1, 0.2, 0.3, 1] });
+        environment.tick();
+        environment.tick();
+
+        expect(stub.named('clearColor')).toHaveLength(1);
+        expect(stub.named('clearColor')[0]?.args).toEqual([0.1, 0.2, 0.3, 1]);
+    });
+
+    it('clamps the drawing buffer to the dpr cap and sizes the canvas to the viewport', () => {
+        installEnvironment({ devicePixelRatio: 3, innerWidth: 800, innerHeight: 600 });
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT, dpr: 2 });
+
+        expect(stub.canvas.width).toBe(1600);
+        expect(stub.canvas.height).toBe(1200);
+        expect(stub.canvas.style.width).toBe('800px');
+        expect(stub.canvas.style.height).toBe('600px');
+        expect(stub.named('viewport')[0]?.args).toEqual([0, 0, 1600, 1200]);
+    });
+});
+
+describe('embed uniform dispatch', () => {
+    it('dispatches caller uniforms by shape and uploads the values', () => {
+        installEnvironment();
+        const stub = createStub();
+
+        embed(stub.canvas, {
+            fragment: FRAGMENT,
+            uniforms: {
+                u_scalar: 0.5,
+                u_vec2: [1, 2],
+                u_vec3: [1, 2, 3],
+                u_vec4: [1, 2, 3, 4]
+            }
+        });
+
+        const scalar = stub.named('uniform1f').find(call => call.args[0] === stub.locationFor('u_scalar'));
+        expect(scalar?.args[1]).toBe(0.5);
+
+        expect(stub.named('uniform2fv')[0]?.args).toEqual([
+            stub.locationFor('u_vec2'),
+            new Float32Array([1, 2])
+        ]);
+        expect(stub.named('uniform3fv')[0]?.args).toEqual([
+            stub.locationFor('u_vec3'),
+            new Float32Array([1, 2, 3])
+        ]);
+        expect(stub.named('uniform4fv')[0]?.args).toEqual([
+            stub.locationFor('u_vec4'),
+            new Float32Array([1, 2, 3, 4])
+        ]);
+    });
+
+    it('skips a uniform whose location is null while still uploading every other uniform', () => {
+        installEnvironment();
+        const stub = createStub({ nullUniforms: ['u_unused'] });
+
+        embed(stub.canvas, {
+            fragment: FRAGMENT,
+            uniforms: { u_unused: [1, 2], u_used: [3, 4] }
+        });
+
+        const uploads = stub.named('uniform2fv');
+        expect(uploads).toHaveLength(1);
+        expect(uploads[0]?.args[0]).toBe(stub.locationFor('u_used'));
+        expect(uploads[0]?.args[1]).toEqual(new Float32Array([3, 4]));
+        expect(uploads.some(call => call.args[0] === null)).toBe(false);
+    });
+
+    it('does not validate a uniform that the shader optimized away', () => {
+        installEnvironment();
+        const stub = createStub({ nullUniforms: ['u_unused'] });
+
+        expect(() => embed(stub.canvas, { fragment: FRAGMENT, uniforms: { u_unused: [1] } })).not.toThrow();
+        expect(stub.countOf('uniform2fv')).toBe(0);
+    });
+});
+
+describe('embed render loop', () => {
+    it('advances u_time across successive frames', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+
+        environment.tick(500);
+        environment.tick(500);
+        environment.tick(1000);
+
+        const timeLocation = stub.locationFor('u_time');
+        const times = stub.named('uniform1f')
+            .filter(call => call.args[0] === timeLocation)
+            .map(call => call.args[1] as number);
+
+        expect(times).toEqual([0, 0.5, 1.5]);
+    });
+
+    it('draws the quad and uploads the drawing-buffer resolution on every frame', () => {
+        const environment = installEnvironment();
+        const stub = createStub({ drawingBufferWidth: 1600, drawingBufferHeight: 1200 });
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+
+        environment.tick();
+        environment.tick();
+
+        expect(stub.countOf('clear')).toBe(2);
+        expect(stub.countOf('drawArrays')).toBe(2);
+        expect(stub.named('drawArrays')[0]?.args).toEqual([GL_TRIANGLE_STRIP, 0, 4]);
+        expect(stub.named('uniform2f')).toHaveLength(2);
+        expect(stub.named('uniform2f')[0]?.args).toEqual([stub.locationFor('u_resolution'), 1600, 1200]);
+    });
+
+    it('uploads no time when the shader declares no u_time', () => {
+        const environment = installEnvironment();
+        const stub = createStub({ nullUniforms: ['u_time'] });
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+
+        environment.tick();
+        environment.tick();
+
+        expect(stub.countOf('uniform1f')).toBe(0);
+        expect(stub.countOf('drawArrays')).toBe(2);
+    });
+
+    it('re-sizes the drawing buffer when the window resizes', () => {
+        const environment = installEnvironment({ innerWidth: 800, innerHeight: 600 });
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT });
+        environment.setViewport(1024, 768);
+        environment.fireResize();
+
+        expect(stub.canvas.width).toBe(1024);
+        expect(stub.canvas.height).toBe(768);
+        expect(stub.named('viewport').at(-1)?.args).toEqual([0, 0, 1024, 768]);
+    });
+});
+
+describe('embed destroy', () => {
+    it('stops the render loop so no further draw is issued', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT });
+        environment.tick();
+        environment.tick();
+        expect(stub.countOf('drawArrays')).toBe(2);
+
+        handle.destroy();
+        environment.tick();
+        environment.tick();
+
+        expect(stub.countOf('drawArrays')).toBe(2);
+    });
+
+    it('removes the resize listener so a later resize touches no GL state', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT });
+        expect(environment.resizeListenerCount()).toBe(1);
+
+        handle.destroy();
+        const viewportCalls = stub.countOf('viewport');
+        environment.setViewport(1024, 768);
+        environment.fireResize();
+
+        expect(environment.resizeListenerCount()).toBe(0);
+        expect(stub.countOf('viewport')).toBe(viewportCalls);
+    });
+
+    it('deletes every GL resource and releases the context', () => {
+        installEnvironment();
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT }).destroy();
+
+        expect(stub.countOf('deleteProgram')).toBe(1);
+        expect(stub.countOf('deleteShader')).toBe(2);
+        expect(stub.countOf('deleteBuffer')).toBe(1);
+        expect(stub.named('getExtension').at(-1)?.args).toEqual(['WEBGL_lose_context']);
+        expect(stub.countOf('loseContext')).toBe(1);
+    });
+});
+
+describe('embed motion gate', () => {
+    it('animates when the user expresses no preference', () => {
+        const environment = installEnvironment();
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT });
+        environment.tick();
+        environment.tick();
+
+        expect(handle.animating).toBe(true);
+        expect(stub.countOf('drawArrays')).toBe(2);
+    });
+
+    it('renders a single static frame when prefers-reduced-motion is set', () => {
+        const environment = installEnvironment({ reducedMotion: true });
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT });
+        environment.tick();
+        environment.tick();
+
+        expect(handle.animating).toBe(false);
+        expect(stub.countOf('drawArrays')).toBe(1);
+        expect(stub.named('uniform1f')[0]?.args).toEqual([stub.locationFor('u_time'), 0]);
+    });
+
+    it('poses the static frame on the same 60fps timebase as the React staticFrame prop', () => {
+        installEnvironment({ reducedMotion: true });
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT, staticFrame: 90 });
+
+        expect(stub.named('uniform1f')[0]?.args).toEqual([stub.locationFor('u_time'), 1.5]);
+    });
+
+    it('keeps the static frame painted across a resize', () => {
+        const environment = installEnvironment({ reducedMotion: true });
+        const stub = createStub();
+
+        embed(stub.canvas, { fragment: FRAGMENT, staticFrame: 60 });
+        environment.setViewport(1024, 768);
+        environment.fireResize();
+
+        expect(stub.countOf('drawArrays')).toBe(2);
+        expect(stub.named('uniform1f').at(-1)?.args).toEqual([stub.locationFor('u_time'), 1]);
+    });
+
+    it('animates against prefers-reduced-motion only when the caller opts out', () => {
+        const environment = installEnvironment({ reducedMotion: true });
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT, reducedMotion: 'ignore' });
+        environment.tick();
+        environment.tick();
+
+        expect(handle.animating).toBe(true);
+        expect(stub.countOf('drawArrays')).toBe(2);
+    });
+
+    it('renders a single static frame when the connection asks to save data', () => {
+        const environment = installEnvironment({ saveData: true });
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT });
+        environment.tick();
+
+        expect(handle.animating).toBe(false);
+        expect(stub.countOf('drawArrays')).toBe(1);
+    });
+
+    it('animates against save-data only when the caller opts out', () => {
+        const environment = installEnvironment({ saveData: true });
+        const stub = createStub();
+
+        const handle = embed(stub.canvas, { fragment: FRAGMENT, saveData: 'ignore' });
+        environment.tick();
+
+        expect(handle.animating).toBe(true);
+        expect(stub.countOf('drawArrays')).toBe(1);
+    });
+});
+
+describe('embed module scope', () => {
+    it('imports without touching a browser global', async () => {
+        vi.unstubAllGlobals();
+        vi.resetModules();
+
+        expect(globalThis.window as unknown).toBeUndefined();
+
+        const module = await import('@/embed');
+
+        expect(typeof module.embed).toBe('function');
+    });
+});

--- a/src/embed/index.ts
+++ b/src/embed/index.ts
@@ -1,0 +1,193 @@
+export type EmbedUniformValue = number | readonly number[];
+
+export type EmbedMotionPolicy = 'static-frame' | 'ignore';
+
+export interface EmbedOptions {
+    fragment: string;
+    uniforms?: Record<string, EmbedUniformValue>;
+    clearColor?: readonly [number, number, number, number];
+    dpr?: number;
+    reducedMotion?: EmbedMotionPolicy;
+    saveData?: EmbedMotionPolicy;
+    staticFrame?: number;
+    contextAttributes?: WebGLContextAttributes;
+}
+
+export interface EmbedHandle {
+    canvas: HTMLCanvasElement;
+    gl: WebGLRenderingContext;
+    animating: boolean;
+    destroy: () => void;
+}
+
+const VERTEX_SHADER =
+    'attribute vec2 a_position;varying vec2 v_uv;'
+    + 'void main(){gl_Position=vec4(a_position,0.0,1.0);v_uv=a_position*0.5+0.5;}';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+function compile(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
+    const shader = gl.createShader(type);
+    if (!shader) {
+        throw new Error('micugl/embed: could not create shader');
+    }
+
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const info = gl.getShaderInfoLog(shader);
+        gl.deleteShader(shader);
+        throw new Error(`micugl/embed: shader compilation failed: ${info ?? ''}`);
+    }
+
+    return shader;
+}
+
+function badUniform(name: string, value: EmbedUniformValue): Error {
+    return new Error(
+        `micugl/embed: uniform "${name}" must be a finite number or an array of 2 to 4 finite numbers, `
+        + `received ${value}`
+    );
+}
+
+function setUniform(
+    gl: WebGLRenderingContext,
+    location: WebGLUniformLocation,
+    name: string,
+    value: EmbedUniformValue
+): void {
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            throw badUniform(name, value);
+        }
+        gl.uniform1f(location, value);
+        return;
+    }
+
+    const data = new Float32Array(value);
+    if (data.length < 2 || data.length > 4 || !data.every(component => Number.isFinite(component))) {
+        throw badUniform(name, value);
+    }
+
+    if (data.length === 2) {
+        gl.uniform2fv(location, data);
+    } else if (data.length === 3) {
+        gl.uniform3fv(location, data);
+    } else {
+        gl.uniform4fv(location, data);
+    }
+}
+
+export function embed(canvas: HTMLCanvasElement, options: EmbedOptions): EmbedHandle {
+    const gl = canvas.getContext('webgl', {
+        alpha: false,
+        antialias: false,
+        depth: false,
+        stencil: false,
+        powerPreference: 'low-power',
+        ...options.contextAttributes
+    });
+    if (!gl) {
+        throw new Error('micugl/embed: could not get a WebGL context from the canvas');
+    }
+
+    const vertexShader = compile(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+    const fragmentShader = compile(gl, gl.FRAGMENT_SHADER, options.fragment);
+
+    const program = gl.createProgram();
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        const info = gl.getProgramInfoLog(program);
+        throw new Error(`micugl/embed: program link failed: ${info ?? ''}`);
+    }
+    gl.useProgram(program);
+
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]), gl.STATIC_DRAW);
+
+    const position = gl.getAttribLocation(program, 'a_position');
+    gl.enableVertexAttribArray(position);
+    gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+
+    for (const [name, value] of Object.entries(options.uniforms ?? {})) {
+        const location = gl.getUniformLocation(program, name);
+        if (location !== null) {
+            setUniform(gl, location, name, value);
+        }
+    }
+
+    const timeLocation = gl.getUniformLocation(program, 'u_time');
+    const resolutionLocation = gl.getUniformLocation(program, 'u_resolution');
+
+    const color = options.clearColor ?? [0, 0, 0, 1];
+    gl.clearColor(color[0], color[1], color[2], color[3]);
+
+    const dprCap = options.dpr ?? 2;
+    const staticSeconds = (options.staticFrame ?? 0) / 60;
+
+    const still =
+        ((options.reducedMotion ?? 'static-frame') === 'static-frame'
+            && window.matchMedia(REDUCED_MOTION_QUERY).matches)
+        || ((options.saveData ?? 'static-frame') === 'static-frame'
+            && navigator.connection?.saveData === true);
+
+    const draw = (seconds: number): void => {
+        gl.clear(gl.COLOR_BUFFER_BIT);
+        if (timeLocation !== null) {
+            gl.uniform1f(timeLocation, seconds);
+        }
+        if (resolutionLocation !== null) {
+            gl.uniform2f(resolutionLocation, gl.drawingBufferWidth, gl.drawingBufferHeight);
+        }
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    };
+
+    const resize = (): void => {
+        const ratio = Math.min(window.devicePixelRatio, dprCap);
+        const width = Math.round(window.innerWidth * ratio);
+        const height = Math.round(window.innerHeight * ratio);
+        if (canvas.width !== width || canvas.height !== height) {
+            canvas.width = width;
+            canvas.height = height;
+        }
+        canvas.style.width = `${window.innerWidth}px`;
+        canvas.style.height = `${window.innerHeight}px`;
+        gl.viewport(0, 0, width, height);
+        if (still) {
+            draw(staticSeconds);
+        }
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+
+    let start: number | null = null;
+    let frame = 0;
+    const loop = (now: number): void => {
+        start ??= now;
+        draw((now - start) * 0.001);
+        frame = requestAnimationFrame(loop);
+    };
+    if (!still) {
+        frame = requestAnimationFrame(loop);
+    }
+
+    return {
+        canvas,
+        gl,
+        animating: !still,
+        destroy: (): void => {
+            cancelAnimationFrame(frame);
+            window.removeEventListener('resize', resize);
+            gl.deleteProgram(program);
+            gl.deleteShader(vertexShader);
+            gl.deleteShader(fragmentShader);
+            gl.deleteBuffer(buffer);
+            gl.getExtension('WEBGL_lose_context')?.loseContext();
+        }
+    };
+}

--- a/src/embed/index.ts
+++ b/src/embed/index.ts
@@ -1,12 +1,14 @@
 export type EmbedUniformValue = number | readonly number[];
 
-export type EmbedMotionPolicy = 'static-frame' | 'ignore';
+export type EmbedMotionPolicy = 'static-frame' | 'pause' | 'ignore';
+
+export type EmbedDpr = number | readonly [number, number];
 
 export interface EmbedOptions {
     fragment: string;
     uniforms?: Record<string, EmbedUniformValue>;
     clearColor?: readonly [number, number, number, number];
-    dpr?: number;
+    dpr?: EmbedDpr;
     reducedMotion?: EmbedMotionPolicy;
     saveData?: EmbedMotionPolicy;
     staticFrame?: number;
@@ -16,15 +18,18 @@ export interface EmbedOptions {
 export interface EmbedHandle {
     canvas: HTMLCanvasElement;
     gl: WebGLRenderingContext;
-    animating: boolean;
+    readonly animating: boolean;
     destroy: () => void;
 }
 
 const VERTEX_SHADER =
-    'attribute vec2 a_position;varying vec2 v_uv;'
-    + 'void main(){gl_Position=vec4(a_position,0.0,1.0);v_uv=a_position*0.5+0.5;}';
+    'attribute vec2 a_position;varying vec2 v_uv;varying vec2 v_texCoord;'
+    + 'void main(){gl_Position=vec4(a_position,0.0,1.0);v_uv=a_position*0.5+0.5;v_texCoord=v_uv;}';
 
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+const QUAD_VERTICES = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]);
+const STATIC_FRAME_FPS = 60;
+const DEFAULT_DPR: readonly [number, number] = [1, 2];
 
 function compile(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
     const shader = gl.createShader(type);
@@ -53,7 +58,7 @@ function badUniform(name: string, value: EmbedUniformValue): Error {
 
 function setUniform(
     gl: WebGLRenderingContext,
-    location: WebGLUniformLocation,
+    location: WebGLUniformLocation | null,
     name: string,
     value: EmbedUniformValue
 ): void {
@@ -61,13 +66,19 @@ function setUniform(
         if (!Number.isFinite(value)) {
             throw badUniform(name, value);
         }
-        gl.uniform1f(location, value);
+        if (location !== null) {
+            gl.uniform1f(location, value);
+        }
         return;
     }
 
     const data = new Float32Array(value);
-    if (data.length < 2 || data.length > 4 || !data.every(component => Number.isFinite(component))) {
+    if (data.length < 2 || data.length > 4 || !data.every(Number.isFinite)) {
         throw badUniform(name, value);
+    }
+
+    if (location === null) {
+        return;
     }
 
     if (data.length === 2) {
@@ -101,23 +112,23 @@ export function embed(canvas: HTMLCanvasElement, options: EmbedOptions): EmbedHa
     gl.linkProgram(program);
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
         const info = gl.getProgramInfoLog(program);
+        gl.deleteShader(vertexShader);
+        gl.deleteShader(fragmentShader);
+        gl.deleteProgram(program);
         throw new Error(`micugl/embed: program link failed: ${info ?? ''}`);
     }
     gl.useProgram(program);
 
     const buffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, QUAD_VERTICES, gl.STATIC_DRAW);
 
     const position = gl.getAttribLocation(program, 'a_position');
     gl.enableVertexAttribArray(position);
     gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
 
     for (const [name, value] of Object.entries(options.uniforms ?? {})) {
-        const location = gl.getUniformLocation(program, name);
-        if (location !== null) {
-            setUniform(gl, location, name, value);
-        }
+        setUniform(gl, gl.getUniformLocation(program, name), name, value);
     }
 
     const timeLocation = gl.getUniformLocation(program, 'u_time');
@@ -126,13 +137,14 @@ export function embed(canvas: HTMLCanvasElement, options: EmbedOptions): EmbedHa
     const color = options.clearColor ?? [0, 0, 0, 1];
     gl.clearColor(color[0], color[1], color[2], color[3]);
 
-    const dprCap = options.dpr ?? 2;
-    const staticSeconds = (options.staticFrame ?? 0) / 60;
+    const dpr = options.dpr ?? DEFAULT_DPR;
+    const staticSeconds = (options.staticFrame ?? 0) / STATIC_FRAME_FPS;
 
     const still =
-        ((options.reducedMotion ?? 'static-frame') === 'static-frame'
+        ((options.reducedMotion ?? 'static-frame') !== 'ignore'
+            && typeof window.matchMedia === 'function'
             && window.matchMedia(REDUCED_MOTION_QUERY).matches)
-        || ((options.saveData ?? 'static-frame') === 'static-frame'
+        || ((options.saveData ?? 'static-frame') !== 'ignore'
             && navigator.connection?.saveData === true);
 
     const draw = (seconds: number): void => {
@@ -147,7 +159,9 @@ export function embed(canvas: HTMLCanvasElement, options: EmbedOptions): EmbedHa
     };
 
     const resize = (): void => {
-        const ratio = Math.min(window.devicePixelRatio, dprCap);
+        const ratio = typeof dpr === 'number'
+            ? dpr
+            : Math.min(Math.max(window.devicePixelRatio, dpr[0]), dpr[1]);
         const width = Math.round(window.innerWidth * ratio);
         const height = Math.round(window.innerHeight * ratio);
         if (canvas.width !== width || canvas.height !== height) {
@@ -156,33 +170,45 @@ export function embed(canvas: HTMLCanvasElement, options: EmbedOptions): EmbedHa
         }
         canvas.style.width = `${window.innerWidth}px`;
         canvas.style.height = `${window.innerHeight}px`;
-        gl.viewport(0, 0, width, height);
+        gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
         if (still) {
             draw(staticSeconds);
         }
     };
 
+    const contextLost = (): void => {
+        console.error(
+            'micugl/embed: the WebGL context was lost, so this canvas will stay blank until it is recreated'
+        );
+    };
+
+    canvas.addEventListener('webglcontextlost', contextLost);
     resize();
     window.addEventListener('resize', resize);
 
     let start: number | null = null;
     let frame = 0;
+    let running = !still;
     const loop = (now: number): void => {
         start ??= now;
         draw((now - start) * 0.001);
         frame = requestAnimationFrame(loop);
     };
-    if (!still) {
+    if (running) {
         frame = requestAnimationFrame(loop);
     }
 
     return {
         canvas,
         gl,
-        animating: !still,
+        get animating(): boolean {
+            return running;
+        },
         destroy: (): void => {
+            running = false;
             cancelAnimationFrame(frame);
             window.removeEventListener('resize', resize);
+            canvas.removeEventListener('webglcontextlost', contextLost);
             gl.deleteProgram(program);
             gl.deleteShader(vertexShader);
             gl.deleteShader(fragmentShader);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
                 index: resolve(__dirname, 'src/index.ts'),
                 core:  resolve(__dirname, 'src/core/index.ts'),
                 react: resolve(__dirname, 'src/react/index.ts'),
+                embed: resolve(__dirname, 'src/embed/index.ts'),
                 testing: resolve(__dirname, 'src/testing/index.ts'),
                 devtools: resolve(__dirname, 'src/react/devtools/index.ts'),
             },


### PR DESCRIPTION
Ships `micugl/embed`: a purpose-written micro-runtime that renders one animated fullscreen fragment shader in static HTML **before or without React** (a loading screen), then hands off cleanly to a later React mount via `destroy()`. E1 (runtime + ESM/CJS entry) and E2 (IIFE artifact + CI size guard + docs) combined, since E2 is meaningless without E1.

**Rewrite, not reuse — and the number is measured.** `new WebGLManager(canvas)` eagerly constructs an `FBOManager` and probes four extensions, and `FBOManager`'s constructor runs capability probing. None of it is tree-shakable (it executes at construction) and a fullscreen quad needs none of it. Reusing `src/core` measures **4.4 KB gzip**; the purpose-written runtime is **1.77 KB**.

### API

```ts
embed(canvas, {
    fragment, uniforms?, clearColor?, dpr?,
    reducedMotion?, saveData?, staticFrame?, contextAttributes?
}) => { canvas, gl, animating, destroy }
```

Ships three ways: `import { embed } from 'micugl/embed'` (ESM+CJS+types), `dist/embed.global.js` (prebuilt IIFE, `window.micuglEmbed`, for a `<script>` tag on a page with no bundler), and a `scripts/checkEmbedSize.mjs` size guard wired into `build`.

### It honors `prefers-reduced-motion`, by default

Costs 124 B gzip, measured by ablation. A 1.8 KB loading screen that animates a fullscreen plasma against the user's OS accessibility preference — while `BaseShaderComponent` two lines away respects it — is not a byte saving, it is an inconsistency that reads as a bug. `'static-frame'` is not a blank canvas; it is a real rendered poster, painted synchronously inside `embed()` before it returns (verified through the built IIFE, not just the stub). `staticFrame` is a frame number on the **same 60 fps timebase as the React prop**, so a poster chosen for `<BaseShaderComponent staticFrame={90}>` reproduces exactly in `embed({ staticFrame: 90 })`.

### The plan's own size guard would have passed forever, measuring nothing

The plan prescribed `embed.ts` + an `index.ts` barrel, and a guard on `gzip(dist/embed.mjs)`. Under this repo's `preserveModules` rollup config, a barrel entry emits a **re-export shim**: `dist/embed.mjs` would have been **76 bytes**, and the guard would have gone green at 76 B no matter how large the runtime grew behind it. A passing check blessing the bug it exists to catch — in the guard whose entire job is to be the fail-loud regression check on the premise.

Fixed by collapsing the runtime into one file, and by making the guard **fail if `embed.mjs` imports anything at all**. Review then caught that the first version of that check only matched *relative* static specifiers — a bare `import ... from 'some-dep'` is externalized by vite, so it is neither in the gzipped bytes nor caught by the regex. A shim built from a bare import plus a dynamic import reported `116 B` and exited 0. It now reuses all three specifier patterns from `assertTreeshaken.mjs` and fails on any of them.

### Review caught (double Opus pass, correctness + API-consistency lenses)

- **The viewport disagreed with `u_resolution`.** `canvas.width = w` is a *request*; when the UA cannot allocate it (Safari caps canvas area at ~16.7 Mpx) it silently hands back a smaller drawing buffer. The viewport was set from the requested size and `u_resolution` from the real one, so a 20 Mpx request on a Pro Display XDR rendered a **zoomed-in crop** while `u_resolution` reported the true smaller size. Silent, forever. Both now read `drawingBufferWidth/Height`. The test stub hid it — its default `drawingBufferWidth` was exactly `canvas.width * 2`, the same numbers the dpr test derived — so the stub now *derives* the drawing buffer from the canvas, and a test that wants them to disagree must say so.
- **Uniform validation was gated behind the null-location skip.** The documented exception (skip a uniform the GLSL compiler optimized out) also swallowed *invalid values* whenever the name happened to be unused: rename `u_tint` to `u_color` and leave `uniforms: { u_tint: NaN }` and you got no throw, no warning, defaults. **A test in the diff blessed it**, asserting an invalid array did not throw. Validation is now unconditional; only the upload is gated.
- **The motion gate failed OPEN on any unrecognized policy string** — including `'pause'`, a valid member of the library's own `MotionPolicy`. TypeScript catches that in a bundler, but the entire point of the IIFE is a `<script>` tag with no TypeScript: copying `reducedMotion="pause"` out of the React docs silently animated at full rate against an OS accessibility preference. The check is inverted to `!== 'ignore'` so unknown values fail *safe*, and the union now mirrors the library's three members.
- **`dpr` was a false friend.** React's bare `dpr={2}` is a *fixed ratio*; embed's was a *cap*. Same name, same type, opposite meaning — a permanent papercut on a new public entry point. It now accepts `number | [min, max]`, default `[1, 2]`, matching `DEFAULT_DPR`.
- **Two save-data tests were vacuous** — they ticked once, so `drawArrays === 1` was satisfied identically by "gate fired, one poster" and "gate dead, one loop frame". Proven by deleting the motion gate and watching them pass. They tick twice now.
- **The `webglcontextlost` listener would have false-alarmed on every clean handoff**, because `destroy()` calls `loseContext()` itself. Found by the applying agent, not on the fix list. It is removed before teardown, and tested in both directions.
- Link failure leaked the program and both shaders; `animating` was a frozen snapshot that still read `true` after `destroy()`; the README promised React shaders "drop straight in" while every example in the repo names its varying `v_texCoord` and the built-in vertex shader only wrote `v_uv` (a link error). The vertex shader now writes both.

### Size

| artifact | gzip | budget |
|---|---:|---:|
| `dist/embed.mjs` | 1,773 B | 1,800 |
| `dist/embed.global.js` | 1,831 B | 1,900 |

Budgets were raised once, from the plan's 1,500/1,700, and **loudly**: the plan's numbers were measured against an `esbuild` prototype, but the shipped artifact comes out of vite/rollup, which is ~100 B gzip larger for identical source. Every byte over the reference is attributed by ablation build. Headroom on `embed.mjs` is now **27 B** — the next feature will not be free, which is the point.

838 tests. `assertTreeshaken` passes unchanged.

### Known gaps (deliberate)
No context-loss *recovery* (it logs loudly; a restore path is out of budget). The media query is read once, not subscribed — React's `useReducedMotion` uses `useSyncExternalStore`; documented. No `maxPixelCount` equivalent; documented. `local/ascii-only` does not lint `.mjs` scripts — a pre-existing gap shared with `assertTreeshaken.mjs`, filed separately.
