### PR TITLE
uniforms: fail loud on an undeclared or mistyped uniform - and every ping-pong test in the repo had a dead sampler

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -16,6 +16,8 @@ export { WebGLManager } from '@/core/managers/WebGLManager';
 export { Passes } from '@/core/systems/Passes';
 export { Postprocessing } from '@/core/systems/Postprocessing';
 export type {
+    ActiveUniform,
+    ActiveUniformTypes,
     AttributeConfig,
     BufferData,
     FramebufferOptions,
@@ -35,6 +37,7 @@ export type {
     UniformConfig,
     UniformType,
     UniformUpdateFn,
+    UniformUploadCall,
     WebGLExtensionName,
     WebGLExtensionTypes
 } from '@/types';

--- a/src/core/lib/passPlanning.test.ts
+++ b/src/core/lib/passPlanning.test.ts
@@ -9,7 +9,7 @@ describe('planPassSwaps', () => {
     it('swaps the output framebuffer once for a read-input ping-pong pass', () => {
         const pass: RenderPass = {
             programId: 'sim',
-            inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+            inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
             outputFramebuffer: 'fb-b'
         };
 
@@ -19,7 +19,7 @@ describe('planPassSwaps', () => {
     it('swaps a readwrite self-feedback framebuffer exactly once, not twice', () => {
         const pass: RenderPass = {
             programId: 'sim',
-            inputTextures: [{ id: 'state', textureUnit: 0, bindingType: 'readwrite' }],
+            inputTextures: [{ id: 'state', textureUnit: 0, bindingType: 'readwrite', samplerName: 'u_texture0' }],
             outputFramebuffer: 'state'
         };
 
@@ -29,7 +29,7 @@ describe('planPassSwaps', () => {
     it('swaps output and a distinct readwrite input separately', () => {
         const pass: RenderPass = {
             programId: 'sim',
-            inputTextures: [{ id: 'feedback', textureUnit: 1, bindingType: 'readwrite' }],
+            inputTextures: [{ id: 'feedback', textureUnit: 1, bindingType: 'readwrite', samplerName: 'u_texture1' }],
             outputFramebuffer: 'target'
         };
 
@@ -39,7 +39,7 @@ describe('planPassSwaps', () => {
     it('does not swap non-ping-pong ids', () => {
         const pass: RenderPass = {
             programId: 'sim',
-            inputTextures: [{ id: 'state', textureUnit: 0, bindingType: 'readwrite' }],
+            inputTextures: [{ id: 'state', textureUnit: 0, bindingType: 'readwrite', samplerName: 'u_texture0' }],
             outputFramebuffer: 'state'
         };
 
@@ -49,7 +49,7 @@ describe('planPassSwaps', () => {
     it('does not swap when rendering to the screen', () => {
         const pass: RenderPass = {
             programId: 'render',
-            inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+            inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
             outputFramebuffer: null
         };
 
@@ -58,19 +58,18 @@ describe('planPassSwaps', () => {
 });
 
 describe('compilePass', () => {
-    it('resolves the sampler name from the binding, defaulting to u_<id>', () => {
+    it('carries the sampler name of each binding through, independent of the framebuffer id', () => {
         const pass: RenderPass = {
             programId: 'sim',
             inputTextures: [
                 { id: 'sim-fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' },
-                { id: 'noise', textureUnit: 1, bindingType: 'read' }
+                { id: 'noise', textureUnit: 1, bindingType: 'read', samplerName: 'u_noise' }
             ],
             outputFramebuffer: null
         };
 
         const compiled = compilePass(pass, allPingPong);
-        expect(compiled.inputs[0].samplerName).toBe('u_texture0');
-        expect(compiled.inputs[1].samplerName).toBe('u_noise');
+        expect(compiled.inputs.map(input => input.samplerName)).toEqual(['u_texture0', 'u_noise']);
     });
 
     it('flattens pass uniforms into an ordered entry array once', () => {
@@ -93,9 +92,9 @@ describe('compilePass', () => {
         const pass: RenderPass = {
             programId: 'sim',
             inputTextures: [
-                { id: 'a', textureUnit: 0, bindingType: 'read' },
-                { id: 'b', textureUnit: 1, bindingType: 'write' },
-                { id: 'c', textureUnit: 2, bindingType: 'readwrite' }
+                { id: 'a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' },
+                { id: 'b', textureUnit: 1, bindingType: 'write', samplerName: 'u_texture1' },
+                { id: 'c', textureUnit: 2, bindingType: 'readwrite', samplerName: 'u_texture2' }
             ],
             outputFramebuffer: null
         };

--- a/src/core/lib/passPlanning.ts
+++ b/src/core/lib/passPlanning.ts
@@ -53,7 +53,7 @@ export function compilePass(pass: RenderPass, isPingPong: (id: string) => boolea
     const inputs: CompiledInput[] = pass.inputTextures.map(texture => ({
         id: texture.id,
         textureUnit: texture.textureUnit,
-        samplerName: texture.samplerName ?? `u_${texture.id}`,
+        samplerName: texture.samplerName,
         isPingPong: isPingPong(texture.id),
         pingPongUseReadIndex: texture.bindingType === 'read' || texture.bindingType === 'readwrite',
         staticIndex: texture.bindingType === 'read' ? 0 : 1

--- a/src/core/lib/passPurity.test.ts
+++ b/src/core/lib/passPurity.test.ts
@@ -35,7 +35,7 @@ describe('chainIsTimePure', () => {
     it('is stateful for a readwrite self-feedback accumulator', () => {
         const passes: RenderPass[] = [{
             programId: 'sim',
-            inputTextures: [{ id: 'state', textureUnit: 0, bindingType: 'readwrite' }],
+            inputTextures: [{ id: 'state', textureUnit: 0, bindingType: 'readwrite', samplerName: 'u_texture0' }],
             outputFramebuffer: 'state'
         }];
 
@@ -45,7 +45,7 @@ describe('chainIsTimePure', () => {
     it('is stateful when a pass reads an id before anything writes it', () => {
         const passes: RenderPass[] = [{
             programId: 'render',
-            inputTextures: [{ id: 'never-written', textureUnit: 0, bindingType: 'read' }],
+            inputTextures: [{ id: 'never-written', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
             outputFramebuffer: null
         }];
 
@@ -62,7 +62,7 @@ describe('chainIsTimePure', () => {
             },
             {
                 programId: 'render',
-                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
                 outputFramebuffer: null
             }
         ];
@@ -75,7 +75,7 @@ describe('chainIsTimePure', () => {
             { programId: 'seed', inputTextures: [], outputFramebuffer: 'fb-a' },
             {
                 programId: 'render',
-                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
                 outputFramebuffer: null
             }
         ];
@@ -94,7 +94,7 @@ describe('chainIsTimePure', () => {
             },
             {
                 programId: 'render',
-                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
                 outputFramebuffer: null
             }
         ];

--- a/src/core/lib/uniformReflection.test.ts
+++ b/src/core/lib/uniformReflection.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
+import {
+    activeUniformTypes,
+    GL_UNIFORM_TYPES,
+    uploadCallFor,
+    uploadReaches
+} from '@/core/lib/uniformReflection';
+import type { ActiveUniform, UniformType } from '@/types';
+
+const ALL_TYPES = Object.keys(UNIFORM_COMPONENTS) as UniformType[];
+
+const GL_BOOL = 0x8b56;
+const GL_BOOL_VEC2 = 0x8b57;
+const GL_INT_VEC2 = 0x8b53;
+const GL_SAMPLER_CUBE = 0x8b60;
+
+function reflect(name: string, glType: number): ActiveUniform {
+    const active = activeUniformTypes([{ name, type: glType, size: 1 }])[name];
+    if (!active) {
+        throw new Error(`activeUniformTypes dropped ${name}`);
+    }
+    return active;
+}
+
+function accepts(glType: number, type: UniformType): boolean {
+    return uploadReaches(reflect('u_x', glType), type);
+}
+
+describe('the GL enum table', () => {
+    it('agrees with the reflection table for every UniformType micugl can upload', () => {
+        for (const type of ALL_TYPES) {
+            expect(accepts(GL_UNIFORM_TYPES[type], type)).toBe(true);
+        }
+    });
+
+    it('accepts an int upload for a sampler2D and a sampler2D upload for an int, because both are uniform1i', () => {
+        expect(uploadCallFor('int')).toBe('uniform1i');
+        expect(uploadCallFor('sampler2D')).toBe('uniform1i');
+        expect(accepts(GL_UNIFORM_TYPES.sampler2D, 'int')).toBe(true);
+        expect(accepts(GL_UNIFORM_TYPES.int, 'sampler2D')).toBe(true);
+    });
+
+    it('rejects every upload whose GL call differs from the one the GLSL type requires', () => {
+        expect(accepts(GL_UNIFORM_TYPES.vec3, 'vec4')).toBe(false);
+        expect(accepts(GL_UNIFORM_TYPES.float, 'int')).toBe(false);
+        expect(accepts(GL_UNIFORM_TYPES.float, 'vec2')).toBe(false);
+        expect(accepts(GL_UNIFORM_TYPES.mat3, 'mat4')).toBe(false);
+        expect(accepts(GL_UNIFORM_TYPES.sampler2D, 'float')).toBe(false);
+    });
+});
+
+describe('a GLSL type micugl has no UniformType for', () => {
+    it('accepts the int upload a bool and a samplerCube take, because WebGL sets both with uniform1i', () => {
+        expect(reflect('u_dark', GL_BOOL).glslType).toBe('bool');
+        expect(accepts(GL_BOOL, 'int')).toBe(true);
+        expect(accepts(GL_SAMPLER_CUBE, 'sampler2D')).toBe(true);
+    });
+
+    it('rejects a float upload to a bool, which WebGL would reject with INVALID_OPERATION', () => {
+        expect(accepts(GL_BOOL, 'float')).toBe(false);
+    });
+
+    it('rejects every upload to an ivec or a bvec, which micugl cannot set at all', () => {
+        expect(reflect('u_size', GL_INT_VEC2).glslType).toBe('ivec2');
+        expect(reflect('u_flags', GL_BOOL_VEC2).glslType).toBe('bvec2');
+
+        for (const type of ALL_TYPES) {
+            expect(accepts(GL_INT_VEC2, type)).toBe(false);
+            expect(accepts(GL_BOOL_VEC2, type)).toBe(false);
+        }
+    });
+});
+
+describe('activeUniformTypes', () => {
+    it('reads the real GLSL type of each active uniform', () => {
+        const types = activeUniformTypes([
+            { name: 'u_time', type: GL_UNIFORM_TYPES.float, size: 1 },
+            { name: 'u_resolution', type: GL_UNIFORM_TYPES.vec2, size: 1 },
+            { name: 'u_texture0', type: GL_UNIFORM_TYPES.sampler2D, size: 1 }
+        ]);
+
+        expect(Object.keys(types)).toEqual(['u_time', 'u_resolution', 'u_texture0']);
+        expect(types.u_time?.glslType).toBe('float');
+        expect(types.u_resolution?.glslType).toBe('vec2');
+        expect(types.u_texture0?.glslType).toBe('sampler2D');
+    });
+
+    it('omits an array uniform, which WebGL reports as "u_x[0]" and micugl cannot upload', () => {
+        const types = activeUniformTypes([
+            { name: 'u_weights[0]', type: GL_UNIFORM_TYPES.float, size: 8 },
+            { name: 'u_gain', type: GL_UNIFORM_TYPES.float, size: 1 }
+        ]);
+
+        expect(Object.keys(types)).toEqual(['u_gain']);
+    });
+
+    it('throws for a GL type that is not a WebGL 1 uniform type at all, instead of skipping it', () => {
+        expect(() => activeUniformTypes([{ name: 'u_x', type: 0x1234, size: 1 }]))
+            .toThrow(/u_x.*0x1234.*not a WebGL 1 uniform type/);
+    });
+
+    it('reads back nothing for a uniform named after an Object.prototype member', () => {
+        const types = activeUniformTypes([{ name: 'u_gain', type: GL_UNIFORM_TYPES.float, size: 1 }]);
+        expect(Object.getPrototypeOf(types)).toBe(null);
+        expect('toString' in types).toBe(false);
+        expect('constructor' in types).toBe(false);
+    });
+});

--- a/src/core/lib/uniformReflection.ts
+++ b/src/core/lib/uniformReflection.ts
@@ -1,0 +1,85 @@
+import { GL_FLOAT } from '@/core/lib/glConstants';
+import type { ActiveUniform, ActiveUniformTypes, UniformType, UniformUploadCall } from '@/types';
+
+export const GL_UNIFORM_TYPES = {
+    float: GL_FLOAT,
+    int: 0x1404,
+    sampler2D: 0x8b5e,
+    vec2: 0x8b50,
+    vec3: 0x8b51,
+    vec4: 0x8b52,
+    mat2: 0x8b5a,
+    mat3: 0x8b5b,
+    mat4: 0x8b5c
+} as const satisfies Record<UniformType, number>;
+
+const UPLOAD_CALL_BY_UNIFORM_TYPE = {
+    float: 'uniform1f',
+    int: 'uniform1i',
+    sampler2D: 'uniform1i',
+    vec2: 'uniform2fv',
+    vec3: 'uniform3fv',
+    vec4: 'uniform4fv',
+    mat2: 'uniformMatrix2fv',
+    mat3: 'uniformMatrix3fv',
+    mat4: 'uniformMatrix4fv'
+} as const satisfies Record<UniformType, UniformUploadCall>;
+
+const ACTIVE_UNIFORM_BY_GL_TYPE = new Map<number, ActiveUniform>([
+    [GL_FLOAT, { glslType: 'float', uploadCall: 'uniform1f' }],
+    [0x8b50, { glslType: 'vec2', uploadCall: 'uniform2fv' }],
+    [0x8b51, { glslType: 'vec3', uploadCall: 'uniform3fv' }],
+    [0x8b52, { glslType: 'vec4', uploadCall: 'uniform4fv' }],
+    [0x1404, { glslType: 'int', uploadCall: 'uniform1i' }],
+    [0x8b53, { glslType: 'ivec2', uploadCall: 'uniform2iv' }],
+    [0x8b54, { glslType: 'ivec3', uploadCall: 'uniform3iv' }],
+    [0x8b55, { glslType: 'ivec4', uploadCall: 'uniform4iv' }],
+    [0x8b56, { glslType: 'bool', uploadCall: 'uniform1i' }],
+    [0x8b57, { glslType: 'bvec2', uploadCall: 'uniform2iv' }],
+    [0x8b58, { glslType: 'bvec3', uploadCall: 'uniform3iv' }],
+    [0x8b59, { glslType: 'bvec4', uploadCall: 'uniform4iv' }],
+    [0x8b5a, { glslType: 'mat2', uploadCall: 'uniformMatrix2fv' }],
+    [0x8b5b, { glslType: 'mat3', uploadCall: 'uniformMatrix3fv' }],
+    [0x8b5c, { glslType: 'mat4', uploadCall: 'uniformMatrix4fv' }],
+    [0x8b5e, { glslType: 'sampler2D', uploadCall: 'uniform1i' }],
+    [0x8b60, { glslType: 'samplerCube', uploadCall: 'uniform1i' }]
+]);
+
+export interface ActiveUniformInfo {
+    name: string;
+    type: number;
+    size: number;
+}
+
+export function uploadCallFor(type: UniformType): UniformUploadCall {
+    return UPLOAD_CALL_BY_UNIFORM_TYPE[type];
+}
+
+export function uploadReaches(active: ActiveUniform, type: UniformType): boolean {
+    return active.uploadCall === uploadCallFor(type);
+}
+
+function isArrayUniformName(name: string): boolean {
+    return name.endsWith(']');
+}
+
+export function activeUniformTypes(infos: ActiveUniformInfo[]): ActiveUniformTypes {
+    const types = Object.create(null) as ActiveUniformTypes;
+
+    for (const info of infos) {
+        if (isArrayUniformName(info.name) || info.size > 1) {
+            continue;
+        }
+
+        const active = ACTIVE_UNIFORM_BY_GL_TYPE.get(info.type);
+        if (!active) {
+            throw new Error(
+                `Uniform "${info.name}" has GL type 0x${info.type.toString(16)}, which is not a WebGL 1 uniform type`
+            );
+        }
+
+        types[info.name] = active;
+    }
+
+    return types;
+}

--- a/src/core/managers/WebGLManager.ts
+++ b/src/core/managers/WebGLManager.ts
@@ -12,7 +12,9 @@ import type {
 } from '@/core';
 import { FBOManager } from '@/core';
 import { createScalarUpdater, createVectorUpdater } from '@/core/lib/uniformDirtyCheck';
-import type { BufferData, UniformTypeMap } from '@/types';
+import type { ActiveUniformInfo } from '@/core/lib/uniformReflection';
+import { activeUniformTypes, uploadReaches } from '@/core/lib/uniformReflection';
+import type { ActiveUniformTypes, BufferData, UniformTypeMap } from '@/types';
 
 declare global {
     interface WebGLRenderingContext {
@@ -89,7 +91,7 @@ export class WebGLManager {
             throw new Error(`Could not link shader program: ${info}`);
         }
 
-        const uniformLocations: ShaderUniformLocations = {};
+        const uniformLocations = Object.create(null) as ShaderUniformLocations;
         for (const uniform of uniforms) {
             uniformLocations[uniform.name] = gl.getUniformLocation(program, uniform.name);
         }
@@ -101,9 +103,24 @@ export class WebGLManager {
             }
         }
 
+        const activeUniforms = this.reflectActiveUniforms(program);
+
+        for (const uniform of uniforms) {
+            const active = activeUniforms[uniform.name];
+            if (active && !uploadReaches(active, uniform.type)) {
+                gl.deleteProgram(program);
+                throw new Error(
+                    `Uniform "${uniform.name}" on program "${id}" is a ${active.glslType} in the shader source, `
+                    + `but the uniformNames passed to createShaderConfig declare it as a ${uniform.type}. `
+                    + 'Make the two agree.'
+                );
+            }
+        }
+
         const resources: ShaderResources = {
             program,
             uniforms: uniformLocations,
+            activeUniforms,
             attributes: attributeLocations,
             buffers: {}
         };
@@ -112,6 +129,21 @@ export class WebGLManager {
         this.uniformUpdateFns.set(id, new Map());
     
         return resources;
+    }
+
+    private reflectActiveUniforms(program: WebGLProgram): ActiveUniformTypes {
+        const gl = this.gl;
+        const count = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS) as number;
+        const infos: ActiveUniformInfo[] = [];
+
+        for (let index = 0; index < count; index++) {
+            const info = gl.getActiveUniform(program, index);
+            if (info) {
+                infos.push({ name: info.name, type: info.type, size: info.size });
+            }
+        }
+
+        return activeUniformTypes(infos);
     }
 
     private getOrCompileShader(cacheKey: string, type: number, source: string): WebGLShader {
@@ -220,7 +252,46 @@ export class WebGLManager {
         gl.bufferSubData(gl.ARRAY_BUFFER, offset, data);
     }
 
-   
+    private checkedUniformLocation(
+        resources: ShaderResources,
+        programId: string,
+        uniformName: string,
+        type: UniformType
+    ): WebGLUniformLocation | null {
+        const location = resources.uniforms[uniformName];
+
+        if (location === undefined) {
+            throw new Error(
+                `Uniform "${uniformName}" is uploaded to program "${programId}" but was never declared for it. `
+                + 'Declare it in the uniformNames passed to createShaderConfig, or stop uploading it.'
+            );
+        }
+
+        if (location === null) {
+            return null;
+        }
+
+        const active = resources.activeUniforms[uniformName];
+        if (active && !uploadReaches(active, type)) {
+            throw new Error(
+                `Uniform "${uniformName}" on program "${programId}" is a ${active.glslType} in the shader source, `
+                + `but is uploaded as a ${type}. Upload it as a ${active.glslType}, or change the shader source and `
+                + 'the uniformNames passed to createShaderConfig.'
+            );
+        }
+
+        return location;
+    }
+
+    assertUniformDeclared(programId: string, uniformName: string, type: UniformType): void {
+        const resources = this.resources.get(programId);
+        if (!resources) {
+            throw new Error(`Program with id ${programId} not found`);
+        }
+
+        this.checkedUniformLocation(resources, programId, uniformName, type);
+    }
+
     registerUniformUpdater<T extends UniformType>(
         programId: string,
         uniformName: string,
@@ -236,8 +307,8 @@ export class WebGLManager {
         if (!programUniforms) {
             throw new Error(`Program uniforms for id ${programId} not found`);
         }
-    
-        const location = resources.uniforms[uniformName];
+
+        const location = this.checkedUniformLocation(resources, programId, uniformName, type);
         if (location === null) {
             return;
         }

--- a/src/core/systems/Passes.test.ts
+++ b/src/core/systems/Passes.test.ts
@@ -11,6 +11,12 @@ const CONFIG: ShaderProgramConfig = {
     uniforms: []
 };
 
+const SAMPLER_CONFIG: ShaderProgramConfig = {
+    vertexShader: '',
+    fragmentShader: '',
+    uniforms: [{ name: 'u_texture0', type: 'sampler2D' }]
+};
+
 describe('Passes.reset', () => {
     it('clears every texture index of each output framebuffer and restores the null binding', () => {
         const { canvas, calls, reset: resetStub } = createCanvasStub();
@@ -56,7 +62,7 @@ describe('Passes.renderFinalPassTo', () => {
         const { canvas, calls } = createCanvasStub();
         const manager = new WebGLManager(canvas);
         manager.createProgram('seed', CONFIG);
-        manager.createProgram('render', CONFIG);
+        manager.createProgram('render', SAMPLER_CONFIG);
         manager.fbo.createFramebuffer('fb-a', { width: 4, height: 4, textureCount: 2 });
         manager.fbo.createFramebuffer('scratch', { width: 8, height: 8, textureCount: 1 });
 
@@ -118,7 +124,7 @@ describe('Passes.isTimePure', () => {
 
         passSystem.addPass({
             programId: 'seed',
-            inputTextures: [{ id: 'state', textureUnit: 0, bindingType: 'readwrite' }],
+            inputTextures: [{ id: 'state', textureUnit: 0, bindingType: 'readwrite', samplerName: 'u_texture0' }],
             outputFramebuffer: 'state'
         });
 

--- a/src/core/systems/Passes.ts
+++ b/src/core/systems/Passes.ts
@@ -140,30 +140,50 @@ export class Passes {
         return chainIsTimePure(this.passes);
     }
 
-    initializeResources(): void {
-        for (const pass of this.passes) {
-            const resources = this.webglManager.resources.get(pass.programId);
-            if (resources && !('a_position' in resources.buffers)) {
-                this.webglManager.createBuffer(
-                    pass.programId,
-                    'a_position',
-                    new Float32Array([
-                        -1.0, -1.0,
-                        1.0, -1.0,
-                        -1.0, 1.0,
-                        1.0, 1.0,
-                    ])
-                );
+    private assertUniformsDeclared(pass: CompiledPass): void {
+        for (const input of pass.inputs) {
+            this.webglManager.assertUniformDeclared(pass.programId, input.samplerName, 'sampler2D');
+        }
 
-                this.webglManager.setAttributeOnce(pass.programId, 'a_position', {
-                    name: 'a_position',
-                    size: 2,
-                    type: 'FLOAT',
-                    normalized: false,
-                    stride: 0,
-                    offset: 0
-                });
+        for (const uniform of pass.uniforms) {
+            this.webglManager.assertUniformDeclared(pass.programId, uniform.name, uniform.type);
+        }
+    }
+
+    initializeResources(): void {
+        this.compiled ??= this.compilePasses();
+
+        for (const pass of this.compiled) {
+            const resources = this.webglManager.resources.get(pass.programId);
+            if (!resources) {
+                throw new Error(`Program with id ${pass.programId} not found`);
             }
+
+            this.assertUniformsDeclared(pass);
+
+            if ('a_position' in resources.buffers) {
+                continue;
+            }
+
+            this.webglManager.createBuffer(
+                pass.programId,
+                'a_position',
+                new Float32Array([
+                    -1.0, -1.0,
+                    1.0, -1.0,
+                    -1.0, 1.0,
+                    1.0, 1.0,
+                ])
+            );
+
+            this.webglManager.setAttributeOnce(pass.programId, 'a_position', {
+                name: 'a_position',
+                size: 2,
+                type: 'FLOAT',
+                normalized: false,
+                stride: 0,
+                offset: 0
+            });
         }
     }
 }

--- a/src/core/systems/Postprocessing.test.ts
+++ b/src/core/systems/Postprocessing.test.ts
@@ -1,30 +1,35 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import type { WebGLManager } from '@/core/managers/WebGLManager';
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { WebGLManager } from '@/core/managers/WebGLManager';
 import type { PostProcessEffect } from '@/core/systems/Postprocessing';
 import { Postprocessing } from '@/core/systems/Postprocessing';
-import type { ShaderProgramConfig } from '@/types';
+import type { GLStubHandle } from '@/testing';
+import { createCanvasStub } from '@/testing';
+import type { FramebufferOptions, UniformType } from '@/types';
 
-const SHADER_CONFIG: ShaderProgramConfig = {
-    vertexShader: '',
-    fragmentShader: '',
-    uniforms: []
+const WIDTH = 64;
+const HEIGHT = 32;
+
+const FRAMEBUFFERS: FramebufferOptions = { width: WIDTH, height: HEIGHT, textureCount: 1 };
+
+const ACTIVE_UNIFORMS: Record<string, UniformType> = {
+    u_texture0: 'sampler2D',
+    u_amount: 'float'
 };
 
-function createManagerStub(): WebGLManager {
-    const resources = new Map<string, object>();
+const SHADER_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_texture0: 'sampler2D', u_amount: 'float' }
+});
 
-    const stub = {
-        resources,
-        createProgram: (id: string): void => { resources.set(id, {}) },
-        destroy: (id: string): void => { resources.delete(id) },
-        fbo: {
-            createFramebuffer: (): void => undefined,
-            destroy: (): void => undefined
-        }
-    };
-
-    return stub as unknown as WebGLManager;
+function createManager(): { manager: WebGLManager; stub: GLStubHandle } {
+    const stub = createCanvasStub({ activeUniforms: ACTIVE_UNIFORMS });
+    const manager = new WebGLManager(stub.canvas);
+    manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+    manager.fbo.createFramebuffer('input', FRAMEBUFFERS);
+    return { manager, stub };
 }
 
 function makeEffect(id: string, enabled: boolean): PostProcessEffect {
@@ -32,9 +37,17 @@ function makeEffect(id: string, enabled: boolean): PostProcessEffect {
         id,
         programId: `${id}-program`,
         shaderConfig: SHADER_CONFIG,
-        uniforms: {},
+        uniforms: { amount: { type: 'float', value: 0.25 } },
         enabled
     };
+}
+
+function uploadsOf(stub: GLStubHandle, name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    if (location === null) {
+        return [];
+    }
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
 }
 
 describe('Postprocessing pass caching', () => {
@@ -43,12 +56,12 @@ describe('Postprocessing pass caching', () => {
     let bloom: PostProcessEffect;
 
     beforeEach(() => {
-        post = new Postprocessing(createManagerStub());
+        post = new Postprocessing(createManager().manager);
         blur = makeEffect('blur', true);
         bloom = makeEffect('bloom', true);
         post.registerEffect(blur);
         post.registerEffect(bloom);
-        post.createChain('chain', ['blur', 'bloom'], 'input', null);
+        post.createChain('chain', ['blur', 'bloom'], 'input', null, FRAMEBUFFERS);
     });
 
     it('returns the same cached array across calls when nothing changes', () => {
@@ -93,7 +106,7 @@ describe('Postprocessing pass caching', () => {
 
 describe('Postprocessing removeEffect program lifecycle', () => {
     it('keeps a shared program alive until the last effect using it is removed', () => {
-        const manager = createManagerStub();
+        const { manager } = createManager();
         const post = new Postprocessing(manager);
 
         const a: PostProcessEffect = {
@@ -112,5 +125,62 @@ describe('Postprocessing removeEffect program lifecycle', () => {
 
         post.removeEffect('b');
         expect(manager.resources.has('shared')).toBe(false);
+    });
+});
+
+describe('the sampler and the effect uniforms Postprocessing uploads for every effect', () => {
+    it('reach GL with their real values, once the chain has been built', () => {
+        const { manager, stub } = createManager();
+        const post = new Postprocessing(manager);
+
+        post.registerEffect(makeEffect('blur', true));
+        post.createChain('chain', ['blur'], 'input', null, FRAMEBUFFERS);
+
+        stub.reset();
+        post.process('chain', 0);
+
+        expect(uploadsOf(stub, 'u_texture0')).toEqual([0]);
+        expect(uploadsOf(stub, 'u_amount')).toEqual([0.25]);
+        expect(stub.uniformCalls.some(call => call.location === null)).toBe(false);
+    });
+
+    it('throw when the effect shader never declared the sampler, instead of rendering black by accident', () => {
+        const { manager } = createManager();
+        const post = new Postprocessing(manager);
+
+        post.registerEffect({
+            id: 'blur',
+            programId: 'blur-program',
+            shaderConfig: createShaderConfig({
+                vertexShader: 'void main() {}',
+                fragmentShader: 'void main() {}',
+                uniformNames: { u_amount: 'float' }
+            }),
+            uniforms: { amount: { type: 'float', value: 0.25 } },
+            enabled: true
+        });
+        post.createChain('chain', ['blur'], 'input', null, FRAMEBUFFERS);
+
+        expect(() => post.generatePasses('chain', 0)).toThrow(/Uniform "u_texture0".*never declared/s);
+    });
+
+    it('throw when an effect uniform was never declared by the effect shader', () => {
+        const { manager } = createManager();
+        const post = new Postprocessing(manager);
+
+        post.registerEffect({
+            id: 'blur',
+            programId: 'blur-program',
+            shaderConfig: createShaderConfig({
+                vertexShader: 'void main() {}',
+                fragmentShader: 'void main() {}',
+                uniformNames: { u_texture0: 'sampler2D' }
+            }),
+            uniforms: { amount: { type: 'float', value: 0.25 } },
+            enabled: true
+        });
+        post.createChain('chain', ['blur'], 'input', null, FRAMEBUFFERS);
+
+        expect(() => post.generatePasses('chain', 0)).toThrow(/Uniform "u_amount".*never declared/s);
     });
 });

--- a/src/core/systems/Postprocessing.ts
+++ b/src/core/systems/Postprocessing.ts
@@ -224,6 +224,22 @@ export class Postprocessing {
         return passes;
     }
 
+    private assertUniformsDeclared(passes: RenderPass[]): void {
+        for (const pass of passes) {
+            if (pass.programId === COPY_PROGRAM_ID) {
+                this.ensureCopyProgram();
+            }
+
+            for (const texture of pass.inputTextures) {
+                this.webglManager.assertUniformDeclared(pass.programId, texture.samplerName, 'sampler2D');
+            }
+
+            for (const [name, uniform] of Object.entries(pass.uniforms ?? {})) {
+                this.webglManager.assertUniformDeclared(pass.programId, name, uniform.type);
+            }
+        }
+    }
+
     generatePasses(chainId: string, _time: number): RenderPass[] {
         const chain = this.chains.get(chainId);
         if (!chain) {
@@ -239,6 +255,7 @@ export class Postprocessing {
         }
 
         const passes = this.buildPasses(chain, enabledEffects);
+        this.assertUniformsDeclared(passes);
         this.passCache.set(chainId, { key, passes });
         return passes;
     }
@@ -264,7 +281,7 @@ export class Postprocessing {
                 this.webglManager.fbo.bindTexture(texture.id, texture.textureUnit);
                 this.webglManager.setUniform(
                     pass.programId,
-                    texture.samplerName ?? `u_texture${texture.textureUnit}`,
+                    texture.samplerName,
                     texture.textureUnit,
                     'sampler2D'
                 );

--- a/src/core/uniformGuardPipeline.test.ts
+++ b/src/core/uniformGuardPipeline.test.ts
@@ -1,0 +1,551 @@
+import { describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { GL_FLOAT, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
+import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
+import { uploadCallFor } from '@/core/lib/uniformReflection';
+import { vec3 } from '@/core/lib/vectorUtils';
+import { WebGLManager } from '@/core/managers/WebGLManager';
+import { Passes } from '@/core/systems/Passes';
+import {
+    buildLiveUpdaters,
+    collectLiveValues,
+    parseUniformStructureKey,
+    uniformDescriptors,
+    uniformStructureKey
+} from '@/react/lib/liveUniformUpdaters';
+import {
+    buildPasses,
+    declarePingPongSampler,
+    DEFAULT_FRAMEBUFFER_OPTIONS,
+    DEFAULT_RENDER_OPTIONS
+} from '@/react/lib/pingPongPasses';
+import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
+import type { GLStubConfig, GLStubHandle } from '@/testing';
+import { createCanvasStub, createGLStub } from '@/testing';
+import type {
+    RenderPass,
+    ShaderProgramConfig,
+    UniformParam,
+    UniformType,
+    UniformUpdaterDef
+} from '@/types';
+import type { WorkerToMain } from '@/worker/protocol';
+import type { WorkerRuntimeHost } from '@/worker/WorkerRuntime';
+import { WorkerRuntime } from '@/worker/WorkerRuntime';
+
+const PROGRAM_ID = 'guard';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+const FBO_CONFIG: Partial<GLStubConfig> = {
+    extensions: { OES_texture_float: true, OES_texture_float_linear: true },
+    renderableTypes: [GL_UNSIGNED_BYTE, GL_FLOAT]
+};
+
+function realUpdaters(uniforms: Record<string, UniformParam>, skipDefaults: boolean): UniformUpdaterDef[] {
+    const parsed = parseUniformStructureKey(uniformStructureKey(uniformDescriptors(uniforms), skipDefaults));
+    const valuesRef = { current: collectLiveValues(uniforms) };
+    const runtime = createTransitionRuntime(() => false);
+    return buildLiveUpdaters(parsed.descriptors, parsed.skipDefaults, valuesRef, runtime);
+}
+
+function register(
+    manager: WebGLManager,
+    updaters: UniformUpdaterDef[]
+): void {
+    updaters.forEach(updater => {
+        manager.registerUniformUpdater(PROGRAM_ID, updater.name, updater.type, updater.updateFn);
+    });
+}
+
+function build(
+    config: ShaderProgramConfig,
+    activeUniforms: Record<string, UniformType>,
+    stubConfig: Partial<GLStubConfig> = {}
+): { manager: WebGLManager; stub: GLStubHandle } {
+    const stub = createCanvasStub({ ...stubConfig, activeUniforms });
+    const manager = new WebGLManager(stub.canvas);
+    manager.createProgram(PROGRAM_ID, config);
+    manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
+    return { manager, stub };
+}
+
+function uploadsOf(stub: GLStubHandle, name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    if (location === null) {
+        return [];
+    }
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+function uploadCallsOf(stub: GLStubHandle, name: string): string[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.name);
+}
+
+function readable(value: unknown): unknown {
+    return value instanceof Float32Array ? Array.from(value) : value;
+}
+
+describe('the GL call each uniform type is uploaded with', () => {
+    it('is the one the reflection table compares against, for every type WebGLManager can upload', () => {
+        const types = Object.keys(UNIFORM_COMPONENTS) as UniformType[];
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: Object.fromEntries(types.map(type => [`u_${type}`, type]))
+        });
+        const { manager, stub } = build(
+            config,
+            Object.fromEntries(types.map(type => [`u_${type}`, type]))
+        );
+
+        types.forEach(type => {
+            const components = UNIFORM_COMPONENTS[type];
+            const value = components === 1 ? 1 : new Float32Array(components);
+            manager.registerUniformUpdater(PROGRAM_ID, `u_${type}`, type, () => value as never);
+        });
+
+        stub.reset();
+        manager.updateUniforms(PROGRAM_ID, 0);
+
+        types.forEach(type => {
+            expect(uploadCallsOf(stub, `u_${type}`)).toEqual([uploadCallFor(type)]);
+        });
+    });
+});
+
+describe('an updater for a uniform the program never declared', () => {
+    it('throws at registration instead of uploading nothing forever', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_swirl: 'float' }
+        });
+        const { manager } = build(config, { u_time: 'float', u_resolution: 'vec2', u_swirl: 'float' });
+
+        const updaters = realUpdaters({ swirl: { type: 'float', value: 1 } }, true);
+        expect(() => { register(manager, updaters) }).not.toThrow();
+
+        const undeclared = realUpdaters({ glow: { type: 'float', value: 1 } }, true);
+        expect(() => { register(manager, undeclared) })
+            .toThrow(/Uniform "u_glow".*never declared.*createShaderConfig/s);
+    });
+
+    it('names the audio band uniform when useAudioUniforms is wired to an undeclared name', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_audioLevel: 'float' }
+        });
+        const { manager } = build(config, {
+            u_time: 'float',
+            u_resolution: 'vec2',
+            u_audioLevel: 'float'
+        });
+
+        const updaters = realUpdaters({
+            u_audioBands: { type: 'vec4', value: () => new Float32Array([0, 0, 0, 0]) as never },
+            u_audioLevel: { type: 'float', value: 0 }
+        }, true);
+
+        expect(() => { register(manager, updaters) }).toThrow(/Uniform "u_audioBands"/);
+    });
+});
+
+describe('an updater whose type disagrees with the GLSL type', () => {
+    it('throws at registration, naming the GLSL type and the uploaded type', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_audioBands: 'vec3' }
+        });
+        const { manager } = build(config, {
+            u_time: 'float',
+            u_resolution: 'vec2',
+            u_audioBands: 'vec3'
+        });
+
+        const updaters = realUpdaters({
+            u_audioBands: { type: 'vec4', value: () => new Float32Array([0, 0, 0, 0]) as never }
+        }, true);
+
+        expect(() => { register(manager, updaters) })
+            .toThrow(/Uniform "u_audioBands".*is a vec3 in the shader source.*uploaded as a vec4/s);
+    });
+
+    it('accepts the same uniform once the uploaded type matches the GLSL type, and the value reaches GL', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_audioBands: 'vec3' }
+        });
+        const { manager, stub } = build(config, {
+            u_time: 'float',
+            u_resolution: 'vec2',
+            u_audioBands: 'vec3'
+        });
+
+        const updaters = realUpdaters({
+            u_audioBands: { type: 'vec3', value: vec3([0.25, 0.5, 0.75]) }
+        }, true);
+
+        expect(() => { register(manager, updaters) }).not.toThrow();
+
+        stub.reset();
+        manager.updateUniforms(PROGRAM_ID, 0);
+
+        expect(uploadsOf(stub, 'u_audioBands').map(readable)).toEqual([[0.25, 0.5, 0.75]]);
+    });
+
+    it('lets an int through to a sampler2D, because gl.uniform1i is how WebGL sets a sampler', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_texture0: 'int' }
+        });
+        const { manager, stub } = build(config, {
+            u_time: 'float',
+            u_texture0: 'sampler2D'
+        });
+
+        const updaters = realUpdaters({ u_texture0: { type: 'int', value: 0 } }, true);
+        expect(() => { register(manager, updaters) }).not.toThrow();
+
+        stub.reset();
+        manager.updateUniforms(PROGRAM_ID, 0);
+
+        expect(uploadCallsOf(stub, 'u_texture0')).toEqual(['uniform1i']);
+        expect(uploadsOf(stub, 'u_texture0')).toEqual([0]);
+    });
+});
+
+describe('a createShaderConfig type that disagrees with the shader source', () => {
+    it('throws when the program is created, before anything can be uploaded to it', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_audioBands: 'vec4' }
+        });
+
+        expect(() => build(config, { u_time: 'float', u_audioBands: 'vec3' }))
+            .toThrow(/Uniform "u_audioBands".*is a vec3 in the shader source.*declare it as a vec4/s);
+    });
+
+    it('is silent for a uniform the shader optimized out, which has no GLSL type to disagree with', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_unused: 'vec4' }
+        });
+
+        expect(() => build(config, { u_time: 'float' })).not.toThrow();
+    });
+});
+
+describe('a uniform the GLSL compiler optimized out', () => {
+    it('is still skipped silently, and every uniform the shader does keep still uploads its value', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_swirl: 'float', u_color: 'vec3', u_unused: 'float' }
+        });
+        const { manager, stub } = build(config, {
+            u_time: 'float',
+            u_swirl: 'float',
+            u_color: 'vec3'
+        });
+
+        const updaters = realUpdaters({
+            u_swirl: { type: 'float', value: 3 },
+            u_color: { type: 'vec3', value: vec3([1, 0, 0]) },
+            u_unused: { type: 'float', value: 9 }
+        }, false);
+
+        expect(updaters.map(updater => updater.name).sort())
+            .toEqual(['u_color', 'u_resolution', 'u_swirl', 'u_time', 'u_unused']);
+
+        expect(() => { register(manager, updaters) }).not.toThrow();
+
+        stub.reset();
+        manager.updateUniforms(PROGRAM_ID, 16);
+
+        expect(uploadsOf(stub, 'u_swirl')).toEqual([3]);
+        expect(uploadsOf(stub, 'u_color').map(readable)).toEqual([[1, 0, 0]]);
+        expect(uploadsOf(stub, 'u_time')).toEqual([0.016]);
+
+        expect(stub.uniformCalls.some(call => call.location === null)).toBe(false);
+        expect(stub.uniformCalls).toHaveLength(3);
+    });
+});
+
+describe('worker mode, where a throw from inside the rAF callback would kill the loop for the session', () => {
+    function initWorker(
+        config: ShaderProgramConfig,
+        activeUniforms: Record<string, UniformType>,
+        uniforms: Record<string, UniformParam>
+    ): { posted: WorkerToMain[]; framesRun: () => number; scheduled: () => number } {
+        const stub = createGLStub({ activeUniforms });
+        const canvas = {
+            width: WIDTH,
+            height: HEIGHT,
+            getContext: (): WebGLRenderingContext => stub.gl,
+            addEventListener: (): void => undefined,
+            removeEventListener: (): void => undefined
+        } as unknown as OffscreenCanvas;
+
+        const callbacks: ((now: number) => void)[] = [];
+        let framesRun = 0;
+        const posted: WorkerToMain[] = [];
+
+        const host: WorkerRuntimeHost = {
+            postMessage: message => { posted.push(message) },
+            requestAnimationFrame: callback => {
+                callbacks.push((now: number) => { framesRun += 1; callback(now) });
+                return callbacks.length;
+            },
+            cancelAnimationFrame: () => undefined,
+            now: () => 0
+        };
+
+        const descriptors = uniformDescriptors(uniforms);
+        const runtime = new WorkerRuntime(host);
+
+        runtime.handleMessage({
+            type: 'init',
+            canvas,
+            config: {
+                kind: 'single',
+                programConfigs: { [PROGRAM_ID]: config },
+                descriptors: { [PROGRAM_ID]: descriptors },
+                initialValues: {
+                    [PROGRAM_ID]: Object.fromEntries(
+                        descriptors.map(descriptor => [descriptor.name, descriptor.type === 'float' ? 1 : [0, 0, 0]])
+                    )
+                },
+                skipDefaultUniforms: false,
+                frameloop: 'always',
+                speed: 1,
+                active: true
+            }
+        });
+
+        return { posted, framesRun: () => framesRun, scheduled: () => callbacks.length };
+    }
+
+    it('reports an undeclared uniform from "init", before a single frame is ever scheduled', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_level: 'float' }
+        });
+
+        const worker = initWorker(
+            config,
+            { u_time: 'float', u_resolution: 'vec2', u_level: 'float' },
+            { u_glow: { type: 'float', value: 1 } }
+        );
+
+        const errors = worker.posted.filter(message => message.type === 'error');
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toMatchObject({
+            message: expect.stringMatching(/Uniform "u_glow".*never declared/s) as string
+        });
+
+        expect(worker.posted.some(message => message.type === 'ready')).toBe(false);
+        expect(worker.scheduled()).toBe(0);
+        expect(worker.framesRun()).toBe(0);
+    });
+
+    it('still reaches "ready" and schedules frames when every uniform is declared', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_level: 'float' }
+        });
+
+        const worker = initWorker(
+            config,
+            { u_time: 'float', u_resolution: 'vec2', u_level: 'float' },
+            { u_level: { type: 'float', value: 1 } }
+        );
+
+        expect(worker.posted.filter(message => message.type === 'error')).toEqual([]);
+        expect(worker.posted.some(message => message.type === 'ready')).toBe(true);
+        expect(worker.scheduled()).toBe(1);
+    });
+});
+
+describe('the main-thread ping-pong pass path, which uploads through setUniform and never registers an updater', () => {
+    function pingPongPasses(uniforms: Record<string, UniformParam>): ReturnType<typeof buildPasses> {
+        return buildPasses(
+            PROGRAM_ID,
+            undefined,
+            1,
+            { [PROGRAM_ID]: realUpdaters(uniforms, false) },
+            {},
+            DEFAULT_FRAMEBUFFER_OPTIONS,
+            DEFAULT_RENDER_OPTIONS,
+            undefined
+        );
+    }
+
+    function run(
+        config: ShaderProgramConfig,
+        activeUniforms: Record<string, UniformType>,
+        uniforms: Record<string, UniformParam>,
+        customPasses?: RenderPass[]
+    ): { execute: () => void; stub: GLStubHandle } {
+        const { manager, stub } = build(config, activeUniforms, FBO_CONFIG);
+        const built = pingPongPasses(uniforms);
+        const passes = customPasses ?? built.passes;
+
+        for (const [id, options] of Object.entries(built.framebuffers)) {
+            manager.fbo.createFramebuffer(id, { ...options, width: WIDTH, height: HEIGHT });
+        }
+
+        const passSystem = new Passes(manager);
+        for (const pass of passes) {
+            passSystem.addPass(pass);
+        }
+        passSystem.initializeResources();
+
+        return { execute: () => { passSystem.execute(0) }, stub };
+    }
+
+    const ACTIVE = {
+        u_time: 'float',
+        u_texture0: 'sampler2D',
+        u_intensity: 'float'
+    } as const;
+
+    it('throws when a pass uniform was never declared, at pass build time and not from inside the frame loop', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_texture0: 'sampler2D' }
+        });
+
+        expect(() => run(config, ACTIVE, { u_intensity: { type: 'float', value: 0.5 } }))
+            .toThrow(/Uniform "u_intensity".*never declared/s);
+    });
+
+    it('throws when a pass uniform is uploaded as the wrong type, at pass build time', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_texture0: 'sampler2D', u_intensity: 'float' }
+        });
+
+        expect(() => run(
+            config,
+            ACTIVE,
+            { u_intensity: { type: 'vec3', value: vec3([1, 0, 0]) } }
+        )).toThrow(/Uniform "u_intensity".*is a float in the shader source.*uploaded as a vec3/s);
+    });
+
+    it('throws for the sampler name of a custom pass the shader never declared, so a typo cannot ship dead', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_texture0: 'sampler2D', u_intensity: 'float' }
+        });
+
+        const custom: RenderPass[] = [{
+            programId: PROGRAM_ID,
+            inputTextures: [{
+                id: `${PROGRAM_ID}-fb-a`,
+                textureUnit: 0,
+                bindingType: 'read',
+                samplerName: 'u_pervious'
+            }],
+            outputFramebuffer: null,
+            uniforms: {}
+        }];
+
+        expect(() => run(config, ACTIVE, { u_intensity: { type: 'float', value: 0.5 } }, custom))
+            .toThrow(/Uniform "u_pervious".*never declared/s);
+    });
+
+    it('throws for a pass whose program was never created, instead of skipping the pass silently', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_texture0: 'sampler2D', u_intensity: 'float' }
+        });
+
+        const custom: RenderPass[] = [{
+            programId: 'never-created',
+            inputTextures: [],
+            outputFramebuffer: null,
+            uniforms: {}
+        }];
+
+        expect(() => run(config, ACTIVE, { u_intensity: { type: 'float', value: 0.5 } }, custom))
+            .toThrow(/Program with id never-created not found/);
+    });
+
+    it('throws for a sampler named after an Object.prototype member, which is a legal GLSL identifier', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_texture0: 'sampler2D', u_intensity: 'float' }
+        });
+
+        const custom: RenderPass[] = [{
+            programId: PROGRAM_ID,
+            inputTextures: [{
+                id: `${PROGRAM_ID}-fb-a`,
+                textureUnit: 0,
+                bindingType: 'read',
+                samplerName: 'valueOf'
+            }],
+            outputFramebuffer: null,
+            uniforms: {}
+        }];
+
+        expect(() => run(config, ACTIVE, { u_intensity: { type: 'float', value: 0.5 } }, custom))
+            .toThrow(/Uniform "valueOf".*never declared/s);
+    });
+
+    it('lets a fully declared chain through, including a u_resolution the shader optimized out', () => {
+        const config = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_texture0: 'sampler2D', u_intensity: 'float' }
+        });
+
+        const { execute, stub } = run(config, ACTIVE, { u_intensity: { type: 'float', value: 0.5 } });
+
+        stub.reset();
+        execute();
+
+        expect(stub.calls.filter(call => call.name === 'drawArrays')).toHaveLength(3);
+        expect(uploadsOf(stub, 'u_intensity')).toEqual([0.5, 0.5, 0.5]);
+        expect(uploadsOf(stub, 'u_texture0')).toEqual([0, 0]);
+        expect(uploadsOf(stub, 'u_time')).toEqual([0, 0, 0]);
+        expect(uploadsOf(stub, 'u_resolution')).toEqual([]);
+        expect(stub.uniformCalls.some(call => call.location === null)).toBe(false);
+    });
+
+    it('declares the sampler it invents itself, so a user shader config that never names it still uploads it', () => {
+        const userConfig = createShaderConfig({
+            vertexShader: 'void main() {}',
+            fragmentShader: 'void main() {}',
+            uniformNames: { u_intensity: 'float' }
+        });
+
+        expect(userConfig.uniforms.map(uniform => uniform.name)).not.toContain('u_texture0');
+
+        const [engineConfig] = Object.values(declarePingPongSampler({ [PROGRAM_ID]: userConfig }));
+
+        const { execute, stub } = run(engineConfig, ACTIVE, { u_intensity: { type: 'float', value: 0.5 } });
+
+        stub.reset();
+        execute();
+
+        expect(uploadCallsOf(stub, 'u_texture0')).toEqual(['uniform1i', 'uniform1i']);
+        expect(uploadsOf(stub, 'u_texture0')).toEqual([0, 0]);
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export {
     useUniformUpdaters
 } from './react';
 export type {
+    ActiveUniform,
+    ActiveUniformTypes,
     AttributeConfig,
     AttributeType,
     AudioSourceSpec,
@@ -96,6 +98,7 @@ export type {
     UniformTypeMap,
     UniformUpdateFn,
     UniformUpdaterDef,
+    UniformUploadCall,
     UniformValue,
     Vec2,
     Vec3,

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -31,6 +31,7 @@ import type { CapturesAreNonReproducible } from '@/react/lib/captureLiveness';
 import { nonReproducibleCaptureMessage } from '@/react/lib/captureLiveness';
 import { framebuffersContentKey, programConfigsContentKey } from '@/react/lib/contentKeys';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
+import { declarePingPongSampler } from '@/react/lib/pingPongPasses';
 import { createRecording } from '@/react/lib/record';
 import { RenderLoop } from '@/react/lib/renderLoop';
 import { runRenderSequence } from '@/react/lib/renderSequence';
@@ -436,7 +437,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             }
             return {
                 kind: 'pingpong',
-                programConfigs,
+                programConfigs: declarePingPongSampler(programConfigs),
                 uniforms: workerPrograms,
                 passes: workerPasses,
                 framebuffers,
@@ -485,76 +486,81 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
         const manager = new WebGLManager(canvasRef.current);
         managerRef.current = manager;
 
-        if (!manager.context.isContextLost()) {
-            const { programConfigs: configs, framebuffers: fbs, passes: initialPasses } = initPropsRef.current;
+        try {
+            if (!manager.context.isContextLost()) {
+                const { programConfigs: configs, framebuffers: fbs, passes: initialPasses } = initPropsRef.current;
 
-            Object.entries(configs).forEach(([id, config]) => {
-                manager.createProgram(id, config);
-            });
+                Object.entries(declarePingPongSampler(configs)).forEach(([id, config]) => {
+                    manager.createProgram(id, config);
+                });
 
-            Object.entries(fbs ?? {}).forEach(([id, options]) => {
-                manager.fbo.createFramebuffer(id, options);
-            });
+                Object.entries(fbs ?? {}).forEach(([id, options]) => {
+                    manager.fbo.createFramebuffer(id, options);
+                });
 
-            const passSystem = new Passes(manager);
-            passSystemRef.current = passSystem;
+                const passSystem = new Passes(manager);
+                passSystemRef.current = passSystem;
 
-            initialPasses.forEach(pass => {
-                passSystem.addPass(pass);
-            });
-            appliedPassesRef.current = initialPasses;
+                initialPasses.forEach(pass => {
+                    passSystem.addPass(pass);
+                });
+                appliedPassesRef.current = initialPasses;
 
-            passSystem.initializeResources();
+                passSystem.initializeResources();
 
-            readyRef.current = true;
-            applySizeRef.current();
-            controllerRef.current?.start();
+                readyRef.current = true;
+                applySizeRef.current();
+                controllerRef.current?.start();
 
-            const managerWeak = new WeakRef(manager);
-            const engineId = engineIdRef.current;
-            let lastKnownState: EngineDebugState | null = null;
+                const managerWeak = new WeakRef(manager);
+                const engineId = engineIdRef.current;
+                let lastKnownState: EngineDebugState | null = null;
 
-            const handle: EngineHandle = {
-                id: engineId,
-                kind: 'pingpong',
-                getManager: () => managerWeak.deref() ?? null,
-                getState: () => {
-                    const currentManager = managerWeak.deref();
-                    if (!currentManager) {
-                        return lastKnownState ?? emptyDebugState(engineId);
-                    }
-                    try {
-                        const glCanvas = currentManager.context.canvas as HTMLCanvasElement;
-                        const state: EngineDebugState = {
-                            kind: 'pingpong',
-                            id: engineId,
-                            canvas: {
-                                renderWidth: glCanvas.width,
-                                renderHeight: glCanvas.height,
-                                displayWidth: glCanvas.clientWidth,
-                                displayHeight: glCanvas.clientHeight
-                            },
-                            programIds: Array.from(currentManager.resources.keys()),
-                            framebufferIds: currentManager.fbo.getFramebufferIds(),
-                            capabilities: currentManager.fbo.getCapabilities(),
-                            floatFilterDowngraded: currentManager.fbo.wasFloatFilterDowngraded(),
-                            frameloop: controllerRef.current?.getFrameloop(),
-                            paused: controllerRef.current?.isPaused(),
-                            speed: controllerRef.current?.getSpeed()
-                        };
-                        lastKnownState = state;
-                        return state;
-                    } catch {
-                        return lastKnownState ?? emptyDebugState(engineId);
-                    }
-                },
-                invalidate: () => { controllerRef.current?.invalidate() },
-                setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
-                getFrame: () => controllerRef.current?.getFrame() ?? 0,
-                setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) },
-                uniforms: debugPortRef?.current ?? undefined
-            };
-            emitEngineMount(handle);
+                const handle: EngineHandle = {
+                    id: engineId,
+                    kind: 'pingpong',
+                    getManager: () => managerWeak.deref() ?? null,
+                    getState: () => {
+                        const currentManager = managerWeak.deref();
+                        if (!currentManager) {
+                            return lastKnownState ?? emptyDebugState(engineId);
+                        }
+                        try {
+                            const glCanvas = currentManager.context.canvas as HTMLCanvasElement;
+                            const state: EngineDebugState = {
+                                kind: 'pingpong',
+                                id: engineId,
+                                canvas: {
+                                    renderWidth: glCanvas.width,
+                                    renderHeight: glCanvas.height,
+                                    displayWidth: glCanvas.clientWidth,
+                                    displayHeight: glCanvas.clientHeight
+                                },
+                                programIds: Array.from(currentManager.resources.keys()),
+                                framebufferIds: currentManager.fbo.getFramebufferIds(),
+                                capabilities: currentManager.fbo.getCapabilities(),
+                                floatFilterDowngraded: currentManager.fbo.wasFloatFilterDowngraded(),
+                                frameloop: controllerRef.current?.getFrameloop(),
+                                paused: controllerRef.current?.isPaused(),
+                                speed: controllerRef.current?.getSpeed()
+                            };
+                            lastKnownState = state;
+                            return state;
+                        } catch {
+                            return lastKnownState ?? emptyDebugState(engineId);
+                        }
+                    },
+                    invalidate: () => { controllerRef.current?.invalidate() },
+                    setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
+                    getFrame: () => controllerRef.current?.getFrame() ?? 0,
+                    setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) },
+                    uniforms: debugPortRef?.current ?? undefined
+                };
+                emitEngineMount(handle);
+            }
+        } catch (error) {
+            manager.destroyAll();
+            throw error;
         }
 
         return () => {

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -550,110 +550,115 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         const manager = new WebGLManager(canvasRef.current);
         managerRef.current = manager;
 
-        if (!manager.context.isContextLost()) {
-            const [pid, cfg] = singleProgramEntry(initPropsRef.current.programConfigs);
-            manager.createProgram(pid, cfg);
-            manager.createBuffer(pid, 'a_position', new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]));
-            manager.setAttributeOnce(pid, 'a_position', {
-                name: 'a_position', size: 2, type: 'FLOAT',
-                normalized: false, stride: 0, offset: 0
-            });
-            activeProgram.current = pid;
+        try {
+            if (!manager.context.isContextLost()) {
+                const [pid, cfg] = singleProgramEntry(initPropsRef.current.programConfigs);
+                manager.createProgram(pid, cfg);
+                manager.createBuffer(pid, 'a_position', new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]));
+                manager.setAttributeOnce(pid, 'a_position', {
+                    name: 'a_position', size: 2, type: 'FLOAT',
+                    normalized: false, stride: 0, offset: 0
+                });
+                activeProgram.current = pid;
 
-            const instancingConfig = initPropsRef.current.instancing;
-            if (instancingConfig) {
-                if (!renderConfigRef.current.useFastPath) {
-                    throw new Error('ShaderEngine: instancing requires useFastPath');
+                const instancingConfig = initPropsRef.current.instancing;
+                if (instancingConfig) {
+                    if (!renderConfigRef.current.useFastPath) {
+                        throw new Error('ShaderEngine: instancing requires useFastPath');
+                    }
+
+                    const instancedAttributeConfigs = new Map(
+                        (cfg.attributes ?? [])
+                            .filter(attribute => attribute.instanced)
+                            .map(attribute => [attribute.name, attribute] as const)
+                    );
+
+                    const instancingAttributeConfigs = Object.keys(instancingConfig.attributes).map(name => {
+                        const attributeConfig = instancedAttributeConfigs.get(name);
+                        if (!attributeConfig) {
+                            throw new Error(
+                                `ShaderEngine: instancing attribute "${name}" must be declared with instanced: true in the program's attributeConfigs`
+                            );
+                        }
+                        return [name, attributeConfig] as const;
+                    });
+
+                    const delegatingConfig = createDelegatingInstancingConfig(instancingConfig, () => {
+                        const latest = instancingRef.current;
+                        if (!latest) {
+                            throw new Error('ShaderEngine: instancing prop was removed while active');
+                        }
+                        return latest;
+                    });
+
+                    const uploader = new InstanceUploader(manager, pid, delegatingConfig);
+                    uploader.initialize();
+
+                    for (const [name, attributeConfig] of instancingAttributeConfigs) {
+                        manager.setAttributeOnce(pid, name, attributeConfig);
+                    }
+
+                    instanceUploaderRef.current = uploader;
                 }
 
-                const instancedAttributeConfigs = new Map(
-                    (cfg.attributes ?? [])
-                        .filter(attribute => attribute.instanced)
-                        .map(attribute => [attribute.name, attribute] as const)
-                );
-
-                const instancingAttributeConfigs = Object.keys(instancingConfig.attributes).map(name => {
-                    const attributeConfig = instancedAttributeConfigs.get(name);
-                    if (!attributeConfig) {
-                        throw new Error(
-                            `ShaderEngine: instancing attribute "${name}" must be declared with instanced: true in the program's attributeConfigs`
-                        );
-                    }
-                    return [name, attributeConfig] as const;
+                const ups = initPropsRef.current.uniformUpdaters[pid] as UniformUpdaterEntry[] | undefined;
+                ups?.forEach(u => {
+                    manager.registerUniformUpdater(pid, u.name, u.type, u.updateFn);
                 });
 
-                const delegatingConfig = createDelegatingInstancingConfig(instancingConfig, () => {
-                    const latest = instancingRef.current;
-                    if (!latest) {
-                        throw new Error('ShaderEngine: instancing prop was removed while active');
-                    }
-                    return latest;
-                });
+                readyRef.current = true;
+                applySizeRef.current();
+                controllerRef.current?.start();
 
-                const uploader = new InstanceUploader(manager, pid, delegatingConfig);
-                uploader.initialize();
+                const managerWeak = new WeakRef(manager);
+                const engineId = engineIdRef.current;
+                let lastKnownState: EngineDebugState | null = null;
 
-                for (const [name, attributeConfig] of instancingAttributeConfigs) {
-                    manager.setAttributeOnce(pid, name, attributeConfig);
-                }
-
-                instanceUploaderRef.current = uploader;
+                const handle: EngineHandle = {
+                    id: engineId,
+                    kind: 'shader',
+                    getManager: () => managerWeak.deref() ?? null,
+                    getState: () => {
+                        const currentManager = managerWeak.deref();
+                        if (!currentManager) {
+                            return lastKnownState ?? emptyDebugState(engineId);
+                        }
+                        try {
+                            const glCanvas = currentManager.context.canvas as HTMLCanvasElement;
+                            const state: EngineDebugState = {
+                                kind: 'shader',
+                                id: engineId,
+                                canvas: {
+                                    renderWidth: glCanvas.width,
+                                    renderHeight: glCanvas.height,
+                                    displayWidth: glCanvas.clientWidth,
+                                    displayHeight: glCanvas.clientHeight
+                                },
+                                programIds: Array.from(currentManager.resources.keys()),
+                                framebufferIds: currentManager.fbo.getFramebufferIds(),
+                                capabilities: currentManager.fbo.getCapabilities(),
+                                floatFilterDowngraded: currentManager.fbo.wasFloatFilterDowngraded(),
+                                frameloop: controllerRef.current?.getFrameloop(),
+                                paused: controllerRef.current?.isPaused(),
+                                speed: controllerRef.current?.getSpeed()
+                            };
+                            lastKnownState = state;
+                            return state;
+                        } catch {
+                            return lastKnownState ?? emptyDebugState(engineId);
+                        }
+                    },
+                    invalidate: () => { controllerRef.current?.invalidate() },
+                    setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
+                    getFrame: () => controllerRef.current?.getFrame() ?? 0,
+                    setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) },
+                    uniforms: debugPortRef?.current ?? undefined
+                };
+                emitEngineMount(handle);
             }
-
-            const ups = initPropsRef.current.uniformUpdaters[pid] as UniformUpdaterEntry[] | undefined;
-            ups?.forEach(u => {
-                manager.registerUniformUpdater(pid, u.name, u.type, u.updateFn);
-            });
-
-            readyRef.current = true;
-            applySizeRef.current();
-            controllerRef.current?.start();
-
-            const managerWeak = new WeakRef(manager);
-            const engineId = engineIdRef.current;
-            let lastKnownState: EngineDebugState | null = null;
-
-            const handle: EngineHandle = {
-                id: engineId,
-                kind: 'shader',
-                getManager: () => managerWeak.deref() ?? null,
-                getState: () => {
-                    const currentManager = managerWeak.deref();
-                    if (!currentManager) {
-                        return lastKnownState ?? emptyDebugState(engineId);
-                    }
-                    try {
-                        const glCanvas = currentManager.context.canvas as HTMLCanvasElement;
-                        const state: EngineDebugState = {
-                            kind: 'shader',
-                            id: engineId,
-                            canvas: {
-                                renderWidth: glCanvas.width,
-                                renderHeight: glCanvas.height,
-                                displayWidth: glCanvas.clientWidth,
-                                displayHeight: glCanvas.clientHeight
-                            },
-                            programIds: Array.from(currentManager.resources.keys()),
-                            framebufferIds: currentManager.fbo.getFramebufferIds(),
-                            capabilities: currentManager.fbo.getCapabilities(),
-                            floatFilterDowngraded: currentManager.fbo.wasFloatFilterDowngraded(),
-                            frameloop: controllerRef.current?.getFrameloop(),
-                            paused: controllerRef.current?.isPaused(),
-                            speed: controllerRef.current?.getSpeed()
-                        };
-                        lastKnownState = state;
-                        return state;
-                    } catch {
-                        return lastKnownState ?? emptyDebugState(engineId);
-                    }
-                },
-                invalidate: () => { controllerRef.current?.invalidate() },
-                setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
-                getFrame: () => controllerRef.current?.getFrame() ?? 0,
-                setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) },
-                uniforms: debugPortRef?.current ?? undefined
-            };
-            emitEngineMount(handle);
+        } catch (error) {
+            manager.destroyAll();
+            throw error;
         }
 
         return () => {

--- a/src/react/components/engine/engineMountFailure.test.tsx
+++ b/src/react/components/engine/engineMountFailure.test.tsx
@@ -1,0 +1,108 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { GL_NEAREST, GL_UNSIGNED_BYTE } from '@/core/lib/glConstants';
+import { BasePingPongShaderComponent } from '@/react/components/base/BasePingPongShaderComponent';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FramebufferOptions } from '@/types';
+
+const PROGRAM_ID = 'mount-failure';
+const WIDTH = 64;
+const HEIGHT = 32;
+
+const BYTE_FRAMEBUFFERS: FramebufferOptions = {
+    width: 0,
+    height: 0,
+    textureCount: 1,
+    textureOptions: { type: GL_UNSIGNED_BYTE, minFilter: GL_NEAREST, magFilter: GL_NEAREST }
+};
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_swirl: 'float' }
+});
+
+let stub: GLStubHandle;
+let container: HTMLDivElement;
+let root: Root;
+let originalGetContext: unknown;
+
+beforeEach(() => {
+    stub = createGLStub({ activeUniforms: { u_time: 'float', u_resolution: 'vec2', u_swirl: 'float' } });
+
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown };
+    originalGetContext = canvasProto.getContext;
+    canvasProto.getContext = function stubGetContext(): unknown {
+        return stub.gl;
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    container.remove();
+
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown };
+    canvasProto.getContext = originalGetContext;
+});
+
+function createdPrograms(handle: GLStubHandle): unknown[] {
+    return handle.calls.filter(call => call.name === 'linkProgram').map(call => call.args[0]);
+}
+
+function deletedPrograms(handle: GLStubHandle): unknown[] {
+    return handle.calls.filter(call => call.name === 'deleteProgram').map(call => call.args[0]);
+}
+
+describe('an engine whose mount effect throws', () => {
+    it('destroys the programs and buffers it already created, instead of leaking the context', () => {
+        expect(() => {
+            act(() => {
+                root.render(
+                    <BaseShaderComponent
+                        programId={PROGRAM_ID}
+                        shaderConfig={CONFIG}
+                        uniforms={{ glow: { type: 'float', value: 1 } }}
+                        width={WIDTH}
+                        height={HEIGHT}
+                        useDevicePixelRatio={false}
+                        frameloop='demand'
+                    />
+                );
+            });
+        }).toThrow(/Uniform "u_glow".*never declared/s);
+
+        expect(createdPrograms(stub)).toHaveLength(1);
+        expect(deletedPrograms(stub)).toEqual(createdPrograms(stub));
+    });
+
+    it('destroys every program of a ping-pong chain when a later pass fails to build', () => {
+        expect(() => {
+            act(() => {
+                root.render(
+                    <BasePingPongShaderComponent
+                        programId={PROGRAM_ID}
+                        shaderConfig={CONFIG}
+                        uniforms={{ glow: { type: 'float', value: 1 } }}
+                        framebufferOptions={BYTE_FRAMEBUFFERS}
+                        width={WIDTH}
+                        height={HEIGHT}
+                        useDevicePixelRatio={false}
+                        frameloop='demand'
+                    />
+                );
+            });
+        }).toThrow(/Uniform "u_glow".*never declared/s);
+
+        expect(createdPrograms(stub)).toHaveLength(1);
+        expect(deletedPrograms(stub)).toEqual(createdPrograms(stub));
+    });
+});

--- a/src/react/lib/pingPongPasses.ts
+++ b/src/react/lib/pingPongPasses.ts
@@ -3,9 +3,26 @@ import type {
     FramebufferOptions,
     RenderPass,
     RenderPassUniformValue,
+    ShaderProgramConfig,
+    UniformConfig,
     UniformType,
     UniformUpdaterDef
 } from '@/types';
+
+export const PING_PONG_SAMPLER: UniformConfig = { name: 'u_texture0', type: 'sampler2D' };
+
+export function declarePingPongSampler(
+    configs: Record<string, ShaderProgramConfig>
+): Record<string, ShaderProgramConfig> {
+    return Object.fromEntries(
+        Object.entries(configs).map(([id, config]) => {
+            if (config.uniforms.some(uniform => uniform.name === PING_PONG_SAMPLER.name)) {
+                return [id, config];
+            }
+            return [id, { ...config, uniforms: [...config.uniforms, PING_PONG_SAMPLER] }];
+        })
+    );
+}
 
 export interface PingPongRenderOptions {
     clear?: boolean;
@@ -102,7 +119,7 @@ export function buildPasses(
 
         passes.push({
             programId: currentProgramId,
-            inputTextures: [{ id: sourceId, textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
+            inputTextures: [{ id: sourceId, textureUnit: 0, bindingType: 'read', samplerName: PING_PONG_SAMPLER.name }],
             outputFramebuffer: targetId,
             uniforms: passUniformsFrom(updaters),
             renderOptions
@@ -118,7 +135,7 @@ export function buildPasses(
 
     passes.push({
         programId: finalProgramId,
-        inputTextures: [{ id: lastTarget, textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
+        inputTextures: [{ id: lastTarget, textureUnit: 0, bindingType: 'read', samplerName: PING_PONG_SAMPLER.name }],
         outputFramebuffer: null,
         uniforms: passUniformsFrom(finalUpdaters),
         renderOptions

--- a/src/react/lib/transitionPipeline.test.ts
+++ b/src/react/lib/transitionPipeline.test.ts
@@ -36,7 +36,7 @@ const GL_STUB_CONFIG: GLStubConfig = {
 const CONFIG = createShaderConfig({
     vertexShader: 'void main() {}',
     fragmentShader: 'void main() {}',
-    uniformNames: { u_swirl: 'float', u_color: 'vec3' }
+    uniformNames: { u_swirl: 'float', u_color: 'vec3', u_texture0: 'sampler2D' }
 });
 
 function uploadsOf(stub: GLStubHandle, name: string): unknown[] {

--- a/src/testing/glStub.ts
+++ b/src/testing/glStub.ts
@@ -7,8 +7,10 @@ import {
     GL_RGBA,
     GL_UNSIGNED_BYTE
 } from '@/core/lib/glConstants';
-import type { WebGLExtensionName } from '@/types';
+import { GL_UNIFORM_TYPES } from '@/core/lib/uniformReflection';
+import type { UniformType, WebGLExtensionName } from '@/types';
 
+const GL_ACTIVE_UNIFORMS = 0x8b86;
 const GL_ARRAY_BUFFER = 0x8892;
 const GL_BYTE = 0x1400;
 const GL_COLOR_ATTACHMENT0 = 0x8ce0;
@@ -37,6 +39,7 @@ const GL_VERTEX_SHADER = 0x8b31;
 const GL_VIEWPORT = 0x0ba2;
 
 const ENUM_CONSTANTS = {
+    ACTIVE_UNIFORMS: GL_ACTIVE_UNIFORMS,
     ARRAY_BUFFER: GL_ARRAY_BUFFER,
     BYTE: GL_BYTE,
     CLAMP_TO_EDGE: GL_CLAMP_TO_EDGE,
@@ -119,6 +122,7 @@ export interface GLStubConfig {
     canvas?: { width: number; height: number };
     compileFails?: boolean;
     linkFails?: boolean;
+    activeUniforms?: Record<string, UniformType>;
     missingAttributes?: string[];
     colorReadType?: number;
     colorReadFormat?: number;
@@ -175,6 +179,11 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
     const uniformLocations = new Map<string, WebGLUniformLocation>();
     const attributeLocations = new Map<string, number>();
     let nextAttributeLocation = 0;
+
+    const declaredActiveUniforms = config.activeUniforms;
+    const activeUniformEntries = Object.entries(declaredActiveUniforms ?? {});
+    const isActiveUniform = (name: string): boolean =>
+        declaredActiveUniforms === undefined || name in declaredActiveUniforms;
 
     const record = (name: string, args: unknown[]): void => {
         calls.push({ name, args });
@@ -351,9 +360,23 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
             record('getShaderParameter', [shader, pname]);
             return pname === GL_COMPILE_STATUS ? !config.compileFails : true;
         },
-        getProgramParameter: (program: WebGLProgram, pname: number): boolean => {
+        getProgramParameter: (program: WebGLProgram, pname: number): boolean | number => {
             record('getProgramParameter', [program, pname]);
-            return pname === GL_LINK_STATUS ? !config.linkFails : true;
+            if (pname === GL_LINK_STATUS) {
+                return !config.linkFails;
+            }
+            if (pname === GL_ACTIVE_UNIFORMS) {
+                return activeUniformEntries.length;
+            }
+            return true;
+        },
+        getActiveUniform: (program: WebGLProgram, index: number): WebGLActiveInfo | null => {
+            record('getActiveUniform', [program, index]);
+            const entry = activeUniformEntries[index] as [string, UniformType] | undefined;
+            if (!entry) {
+                return null;
+            }
+            return { name: entry[0], type: GL_UNIFORM_TYPES[entry[1]], size: 1 };
         },
         getShaderInfoLog: (shader: WebGLShader): string => {
             record('getShaderInfoLog', [shader]);
@@ -363,8 +386,11 @@ export function createGLStub(config: GLStubConfig = {}): GLStubHandle {
             record('getProgramInfoLog', [program]);
             return config.linkFails ? 'micugl test stub: simulated program link failure' : '';
         },
-        getUniformLocation: (program: WebGLProgram, name: string): WebGLUniformLocation => {
+        getUniformLocation: (program: WebGLProgram, name: string): WebGLUniformLocation | null => {
             record('getUniformLocation', [program, name]);
+            if (!isActiveUniform(name)) {
+                return null;
+            }
             let location = uniformLocations.get(name);
             if (!location) {
                 location = {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export interface RenderOptions {
   clearColor?: Vec4;
 }
 
-export type ShaderUniformLocations = Record<string, WebGLUniformLocation | null>;
+export type ShaderUniformLocations = Partial<Record<string, WebGLUniformLocation | null>>;
 export type ShaderAttributeLocations = Record<string, number>;
 
 export interface UniformConfig {
@@ -73,9 +73,30 @@ export interface InstancingConfig {
   attributes: Record<string, InstanceAttribute>;
 }
 
+export type UniformUploadCall =
+  'uniform1f'
+  | 'uniform1i'
+  | 'uniform2fv'
+  | 'uniform3fv'
+  | 'uniform4fv'
+  | 'uniform2iv'
+  | 'uniform3iv'
+  | 'uniform4iv'
+  | 'uniformMatrix2fv'
+  | 'uniformMatrix3fv'
+  | 'uniformMatrix4fv';
+
+export interface ActiveUniform {
+  glslType: string;
+  uploadCall: UniformUploadCall;
+}
+
+export type ActiveUniformTypes = Partial<Record<string, ActiveUniform>>;
+
 export interface ShaderResources {
   program: WebGLProgram;
   uniforms: ShaderUniformLocations;
+  activeUniforms: ActiveUniformTypes;
   attributes: ShaderAttributeLocations;
   buffers: Record<string, BufferData>;
 }
@@ -243,7 +264,7 @@ export interface TextureBinding {
   id: string;
   textureUnit: number;
   bindingType: 'read' | 'write' | 'readwrite';
-  samplerName?: string;
+  samplerName: string;
 }
 
 export type RenderPassUniformUpdateFn = (

--- a/src/worker/WorkerBridge.test.ts
+++ b/src/worker/WorkerBridge.test.ts
@@ -417,7 +417,7 @@ describe('WorkerBridge setPasses', () => {
 
         bridge.setPasses([{
             programId: 'blur',
-            inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+            inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
             outputFramebuffer: null,
             uniforms: {
                 u_time: { type: 'float', value: (time: number) => time },
@@ -429,7 +429,7 @@ describe('WorkerBridge setPasses', () => {
             type: 'setPasses',
             passes: [{
                 programId: 'blur',
-                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read' }],
+                inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
                 outputFramebuffer: null,
                 uniforms: {
                     u_time: { kind: 'builtin', type: 'float' },

--- a/src/worker/workerPipeline.test.ts
+++ b/src/worker/workerPipeline.test.ts
@@ -35,7 +35,7 @@ const HEIGHT = 200;
 const CONFIG = createShaderConfig({
     vertexShader: 'void main() {}',
     fragmentShader: 'void main() {}',
-    uniformNames: { u_intensity: 'float', u_color1: 'vec3' }
+    uniformNames: { u_intensity: 'float', u_color1: 'vec3', u_texture0: 'sampler2D' }
 });
 
 const UNIFORM_NAMES = ['u_time', 'u_resolution', 'u_intensity', 'u_color1', 'u_texture0'];
@@ -270,8 +270,8 @@ describe('worker ping-pong pipeline, driven by the real pass and uniform builder
             u_intensity: 0.5,
             u_color1: [1, 0, 0]
         });
-        expect(worker.map(draw => ({ ...draw, u_texture0: undefined })))
-            .toEqual(main.map(draw => ({ ...draw, u_texture0: undefined })));
+        expect(main.slice(1).map(draw => draw.u_texture0)).toEqual([0, 0]);
+        expect(worker).toEqual(main);
     });
 
     it('keeps worker and main thread in step as the clock advances', () => {
@@ -283,7 +283,6 @@ describe('worker ping-pong pipeline, driven by the real pass and uniform builder
             renderInWorker(built.passes, built.framebuffers, uniforms, [0, 1000, 2000]).gl
         );
 
-        expect(worker.map(draw => ({ ...draw, u_texture0: undefined })))
-            .toEqual(main.map(draw => ({ ...draw, u_texture0: undefined })));
+        expect(worker).toEqual(main);
     });
 });


### PR DESCRIPTION
Closes the **undeclared-uniform silence** filed as a follow-up by T4 (#56). It is this codebase's signature failure in its purest form, sitting in the hottest path in the library.

### The bug

`WebGLManager.createProgram` populates `resources.uniforms` **only** from the names passed to `createShaderConfig`. `ShaderUniformLocations` was typed `Record<string, WebGLUniformLocation | null>`, so at the type level indexing it can never yield `undefined` — and the guard was written to match:

```ts
const location = resources.uniforms[uniformName];
if (location === null) return;
```

`noUncheckedIndexedAccess` is off, so **the index signature lies**. A name that was never declared reads back as `undefined`, sails through a `=== null` check, and calls `gl.uniform4fv(undefined, buffer)` — a **spec no-op**. The value never reaches GL. Nothing throws. Nothing logs. A declared type that disagrees with the GLSL type is equally silent: `INVALID_OPERATION` lands on the error queue and no exception is raised.

T4 made this the likeliest mistake in the library, because `useAudioUniforms`'s `u_audioBands` has a **type that is a runtime option** (`bands`) the user must mirror by hand into the shader. Get it wrong and the bars just do not move.

### The fix

`createProgram` walks `ACTIVE_UNIFORMS`/`getActiveUniform` **once** and hangs the reflection on `ShaderResources`. A single checked-location helper serves both call sites and distinguishes three cases:

- **`undefined`** (never declared) → **throw**, naming the uniform and pointing at `createShaderConfig`'s `uniformNames`.
- **`null`** (declared, but the GLSL compiler optimized it out because it is unused) → **skip silently**. Legitimate, and it must keep working. Tested in the negative direction, hard: making this case throw turns 5 tests red.
- **type mismatch** → **throw**, naming the GLSL type and the uploaded type.

`ShaderUniformLocations` is now `Partial<Record<...>>` — the type that caused the bug is the type that fixes it. The `undefined` state is representable, the cast is gone, and `=== null` can no longer *look* exhaustive.

### What review changed

**`int` and `sampler2D` are the same upload.** The first version compared type strings — but both types dispatch to `gl.uniform1i`, and per the ES 2.0 spec `uniform1i` is the only legal way to set a sampler. Declaring a sampler as `{ type: 'int' }` is a **correct, working upload**, and the guard would have hard-thrown on it with a message claiming the value never reaches the shader. It does. Comparison is now on the **upload call**, not the type name. *A fail-loud guard that kills a working program with a false explanation is worse than no guard.*

**The guard was incomplete exactly where it claimed to be complete.** A GLSL `uniform bool` or `ivec2` has no `micugl` `UniformType`, so the reflection omitted it and the type check was **skipped** — `gl.uniform1f` on a `bool` location is `INVALID_OPERATION`, silent, value never lands. Now an acceptance table keyed by GL enum covers all 17 GLSL ES 1.00 uniform types; anything a `UniformType` cannot legally upload to throws.

**`Postprocessing` is a public export, not dead code.** It was left unguarded on the claim that it was unwired. It is exported from both `src/index.ts` and `src/core/index.ts`, calls `setUniform` directly, and **its own fixture had the same dead-sampler shape** this PR was sweeping out elsewhere. Guarded at `generatePasses()` — once per chain shape, off the frame loop — and its test rebuilt on the real `WebGLManager` instead of a hand-rolled stub.

### Every ping-pong test in the repo had a dead sampler upload

Four fixtures built passes with `samplerName: 'u_texture0'` on programs that never declared it, so the sampler upload was **a no-op in all of them** — invisible because a GL sampler's default value *is* 0, and `buildPasses` always binds unit 0. `workerPipeline.test.ts` had even masked `u_texture0` out of its parity assertions to work around the symptom. Those masks are gone; worker-vs-main parity now compares the sampler that this PR brought back to life.

### No breaking change, because the framework declares what the framework uploads

`u_texture0` is **invented by `buildPasses`** — the user never chose that name. Forcing them to re-declare a framework-generated uniform would be exactly asymmetric with `u_time`/`u_resolution`, which `createShaderConfig` injects *because the framework uploads them*. So the ping-pong path now declares its own sampler, and an existing ping-pong shader keeps working untouched.

This cannot mask the bug it is meant to catch: if the shader does not sample `u_texture0`, the location is `null`, the upload is skipped, and the chain visibly cannot feed back — a black canvas, which is loud. The typo hazard lives on a **different, user-owned** name (`RenderPass.inputTextures[].samplerName` on custom passes), which still throws — and `samplerName` is now **required**, killing two `?? u_${id}` fallbacks that could only ever generate illegal GLSL identifiers like `u_sim-fb-a`.

### Also fixed

- **The fail-loud path leaked a WebGL context.** The throw fires inside the mount effect *after* `new WebGLManager(canvas)`, and React does not run the cleanup of an effect that threw. Both engines now `destroyAll()` and rethrow. (Same shape as T3's leaked microphone: a resource acquired where the `catch` cannot see it.)
- **Prototype-chain bypass.** `constructor`, `toString` and `valueOf` are legal GLSL identifiers, and reading them off a plain object literal returns an inherited *function*, not `undefined` — bypassing the whole guard. Both uniform records are now `Object.create(null)`.
- `Passes.initializeResources` failed loud and failed *open* on the same condition in the same method.
- `createProgram` now also checks the `createShaderConfig` type against the reflected type, so `UniformConfig.type` stops being a field that can lie.

871 tests, 19/19 bench counters, 9/9 worker e2e — the browser suites matter here, because they are the only thing that exercises a real `getActiveUniform` against a real driver.

### Follow-up filed
`WorkerRuntime`'s init `catch` does not destroy its GL context — the same leak class, on the worker side. Far less severe (the worker dies with its thread on a failed init) and out of scope here.
