### PR TITLE
motion: discrete vs continuous invalidation - the gate learns to tell a live input from a changed value

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,31 @@ deterministic frame instead of animating continuously.
   `setFrame`/`ShaderHandle`. Pick a frame that looks good as a static image for shaders
   that are dull at frame 0.
 
+### What repaints the poster, and what freezes
+
+Under a `static-frame` or `pause` gate the render loop is off, so the canvas only repaints
+when something asks for a **discrete** repaint — a "one thing changed, show it once" event:
+a changed plain uniform value (theme, resize, a prop-driven `u_color`), a snapped transition,
+a devtools override. A per-frame **continuous** stream — a live audio level, a webcam frame,
+anything that wants the *next* frame of an ongoing animation — is suppressed by the gate; it
+never schedules a frame while gated.
+
+That distinction is carried by `InvalidationKind` on the `FrameInvalidation` you connect to a
+custom uniform (see [Waking a `demand` engine from your own value
+producer](#waking-a-demand-engine-from-your-own-value-producer)):
+
+- `request()` (or `request('discrete')`) — "a value changed, repaint the poster." Fires under
+  a gate. Use it for producers that emit on discrete state changes.
+- `request('continuous')` — "I want the next frame of a stream." Suppressed under a gate. Use
+  it for a source you sample every frame (a `requestVideoFrameCallback` webcam, an rAF loop).
+
+A gated audio visualizer follows the same rule: while a source is running the poster **freezes
+at the last sampled values** (the driver keeps analysing for any un-gated engine sharing it,
+but this engine will not schedule frames), and `stop()` drains the bands to zero and repaints
+that drained poster once, because stopping is a discrete state change. If the visualizer *is*
+the point of the page and should animate for everyone, opt the component out with
+`reducedMotion="ignore"` / `saveData="ignore"` — there is no per-source override.
+
 ## Uniform transitions
 
 Give a uniform param a `transition` and a change to its `value` animates to the new value
@@ -478,6 +503,15 @@ identity, so an inline `createFrameInvalidation()` or `combineFrameInvalidation(
 during render would connect and dispose on every render. Memoize it (or hold it in a ref), as
 above. `combineFrameInvalidation` merges several producers into one when a uniform is woken by
 more than one source.
+
+`request()` takes an optional `InvalidationKind`. A producer that emits when a discrete thing
+changed — a pointer moved, a websocket message arrived — calls `request()` (its default,
+`'discrete'`), and its repaint reaches the canvas even under a reduced-motion gate. A producer
+that samples a continuous stream every frame — a `requestVideoFrameCallback` webcam, an rAF
+loop — calls `request('continuous')`, which drives `frameloop='demand'` at full rate but is
+suppressed while the component is motion-gated, so a reduced-motion user gets the poster instead
+of a live stream. When in doubt, `request()`: repainting a poster once is the safe default. See
+[What repaints the poster, and what freezes](#what-repaints-the-poster-and-what-freezes).
 
 ## Worker rendering (OffscreenCanvas)
 

--- a/demo/scenes/ReducedMotion.tsx
+++ b/demo/scenes/ReducedMotion.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
 import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
@@ -6,7 +6,25 @@ import { useReducedMotion } from '../../src/react/hooks/useReducedMotion';
 import { useSaveData } from '../../src/react/hooks/useSaveData';
 import type { MotionPolicy, ShaderHandle, UniformParam } from '../../src/types';
 import { getIntQuery, getQueryString } from './query';
-import { QUAD_VERTEX, WAVE_FRAGMENT } from './shaders';
+import { QUAD_VERTEX } from './shaders';
+
+const TINT_FRAGMENT = `
+    precision highp float;
+    uniform float u_time;
+    uniform vec2 u_resolution;
+    uniform float u_tint;
+    varying vec2 v_uv;
+    void main() {
+        vec2 uv = v_uv;
+        float w = 0.5 + 0.5 * sin(uv.x * 10.0 + u_time);
+        float g = 0.5 + 0.5 * cos(uv.y * 10.0 - u_time);
+        vec3 base = vec3(w, g, 1.0 - w * g);
+        vec3 tint = vec3(u_tint, 1.0 - u_tint, 0.5);
+        gl_FragColor = vec4(mix(base, tint, 0.5), 1.0);
+    }
+`;
+
+const TINTS = [0, 0.25, 0.5, 0.75, 1];
 
 declare global {
     interface Window {
@@ -16,10 +34,9 @@ declare global {
 
 const config = createShaderConfig({
     vertexShader: QUAD_VERTEX,
-    fragmentShader: WAVE_FRAGMENT
+    fragmentShader: TINT_FRAGMENT,
+    uniformNames: { u_tint: 'float' }
 });
-
-const uniforms: Record<string, UniformParam> = {};
 
 const MOTION_POLICIES: MotionPolicy[] = ['static-frame', 'pause', 'ignore'];
 
@@ -37,6 +54,11 @@ export const ReducedMotion = () => {
     const policy = readPolicy();
     const staticFrame = getIntQuery('staticFrame', 0);
     const handleRef = useRef<ShaderHandle>(null);
+    const [tintIndex, setTintIndex] = useState(0);
+
+    const uniforms: Record<string, UniformParam> = {
+        u_tint: { type: 'float', value: TINTS[tintIndex] }
+    };
 
     useEffect(() => {
         window.__reducedMotionHandle = handleRef.current ?? undefined;
@@ -74,6 +96,14 @@ export const ReducedMotion = () => {
                 <div>useSaveData(): {String(saveDataActive)}</div>
                 <div>reducedMotion policy: {policy}</div>
                 <div>staticFrame: {staticFrame}</div>
+                <div>u_tint: {TINTS[tintIndex].toFixed(2)}</div>
+                <button
+                    type='button'
+                    onClick={() => { setTintIndex(index => (index + 1) % TINTS.length) }}
+                    style={{ marginTop: '6px', fontFamily: 'monospace', fontSize: '12px' }}
+                >
+                    cycle u_tint
+                </button>
             </div>
         </div>
     );

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,6 @@
 export { createTypedFloat32Array,mat2, mat3, mat4, vec2, vec3, vec4 } from './lib/vectorUtils';
 export { createShaderConfig } from '@/core/lib/createShaderConfig';
-export type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+export type { FrameInvalidation, InvalidationKind } from '@/core/lib/frameInvalidation';
 export { combineFrameInvalidation, createFrameInvalidation } from '@/core/lib/frameInvalidation';
 export {
     GL_CLAMP_TO_EDGE,

--- a/src/core/lib/frameInvalidation.test.ts
+++ b/src/core/lib/frameInvalidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { InvalidationKind } from '@/core/lib/frameInvalidation';
 import { combineFrameInvalidation, createFrameInvalidation } from '@/core/lib/frameInvalidation';
 
 describe('createFrameInvalidation', () => {
@@ -42,6 +43,27 @@ describe('createFrameInvalidation', () => {
         const invalidation = createFrameInvalidation();
         expect(() => { invalidation.request() }).not.toThrow();
     });
+
+    it('fans the requested kind out to listeners', () => {
+        const invalidation = createFrameInvalidation();
+        const kinds: InvalidationKind[] = [];
+        invalidation.connect(kind => { kinds.push(kind) });
+
+        invalidation.request('continuous');
+        invalidation.request('discrete');
+
+        expect(kinds).toEqual(['continuous', 'discrete']);
+    });
+
+    it('a bare request() resolves to discrete at the listener', () => {
+        const invalidation = createFrameInvalidation();
+        const kinds: InvalidationKind[] = [];
+        invalidation.connect(kind => { kinds.push(kind) });
+
+        invalidation.request();
+
+        expect(kinds).toEqual(['discrete']);
+    });
 });
 
 describe('combineFrameInvalidation', () => {
@@ -71,6 +93,36 @@ describe('combineFrameInvalidation', () => {
         combined.request();
 
         expect(calls).toEqual(['a', 'b']);
+    });
+
+    it('forwards a source request kind through to a combined listener', () => {
+        const sourceA = createFrameInvalidation();
+        const sourceB = createFrameInvalidation();
+        const combined = combineFrameInvalidation([sourceA, sourceB]);
+
+        const kinds: InvalidationKind[] = [];
+        combined.connect(kind => { kinds.push(kind) });
+
+        sourceA.request('continuous');
+        sourceB.request('discrete');
+        sourceB.request();
+
+        expect(kinds).toEqual(['continuous', 'discrete', 'discrete']);
+    });
+
+    it('forwards a combined request kind down to every source listener', () => {
+        const sourceA = createFrameInvalidation();
+        const sourceB = createFrameInvalidation();
+        const combined = combineFrameInvalidation([sourceA, sourceB]);
+
+        const kinds: InvalidationKind[] = [];
+        sourceA.connect(kind => { kinds.push(kind) });
+        sourceB.connect(kind => { kinds.push(kind) });
+
+        combined.request('continuous');
+        combined.request();
+
+        expect(kinds).toEqual(['continuous', 'continuous', 'discrete', 'discrete']);
     });
 
     it('the disposer from connect() disconnects from every source', () => {

--- a/src/core/lib/frameInvalidation.ts
+++ b/src/core/lib/frameInvalidation.ts
@@ -1,18 +1,20 @@
+export type InvalidationKind = 'discrete' | 'continuous';
+
 export interface FrameInvalidation {
-    connect(invalidate: () => void): () => void;
-    request(): void;
+    connect(invalidate: (kind: InvalidationKind) => void): () => void;
+    request(kind?: InvalidationKind): void;
 }
 
 export function createFrameInvalidation(): FrameInvalidation {
-    const listeners = new Set<() => void>();
+    const listeners = new Set<(kind: InvalidationKind) => void>();
 
     return {
         connect(invalidate) {
             listeners.add(invalidate);
             return () => { listeners.delete(invalidate) };
         },
-        request() {
-            listeners.forEach(listener => { listener() });
+        request(kind = 'discrete') {
+            listeners.forEach(listener => { listener(kind) });
         }
     };
 }
@@ -23,8 +25,8 @@ export function combineFrameInvalidation(sources: FrameInvalidation[]): FrameInv
             const disposers = sources.map(source => source.connect(invalidate));
             return () => { disposers.forEach(dispose => { dispose() }) };
         },
-        request() {
-            sources.forEach(source => { source.request() });
+        request(kind) {
+            sources.forEach(source => { source.request(kind) });
         }
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { FrameInvalidation } from './core';
+export type { FrameInvalidation, InvalidationKind } from './core';
 export {
     combineFrameInvalidation,
     createFrameInvalidation,

--- a/src/react/components/base/BaseShaderComponent.gatedAudio.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.gatedAudio.test.tsx
@@ -1,0 +1,262 @@
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { BandCount } from '@/core/lib/audioBands';
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { AudioUniformsResult } from '@/react/hooks/useAudioUniforms';
+import { useAudioUniforms } from '@/react/hooks/useAudioUniforms';
+import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
+import { asContext, createFakeStream, FakeContext, latestAnalyser, LOW_HALF } from '@/react/lib/fakeWebAudio';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type { AudioSourceSpec, AudioUniformsOptions, ShaderProgramConfig } from '@/types';
+
+const PROGRAM_ID = 'audio-bars';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+const MIC: AudioSourceSpec = { type: 'mic' };
+const BAND_TYPES = { 1: 'float', 2: 'vec2', 3: 'vec3', 4: 'vec4' } as const;
+
+const configFor = (bands: BandCount): ShaderProgramConfig => createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_audioBands: BAND_TYPES[bands], u_audioLevel: 'float' }
+});
+
+const optionsFor = (bands: BandCount): AudioUniformsOptions => ({
+    bands,
+    fftSize: 64,
+    bandLayout: 'linear',
+    attack: 0.05,
+    release: 0.4
+});
+
+interface Fixture {
+    deps: AudioAnalyserDriverDeps;
+    hear: () => void;
+}
+
+function createFixture(): Fixture {
+    const context = new FakeContext();
+    const { stream } = createFakeStream();
+    return {
+        deps: {
+            createContext: () => asContext(context),
+            getUserMedia: () => Promise.resolve(stream)
+        },
+        hear: () => { latestAnalyser(context).spectrum = LOW_HALF }
+    };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stubs: GLStubHandle[];
+let byCanvas: WeakMap<object, GLStubHandle>;
+let originalGetContext: unknown;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stubs = [];
+    byCanvas = new WeakMap<object, GLStubHandle>();
+    originalGetContext = (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext;
+    (HTMLCanvasElement.prototype as unknown as { getContext: () => WebGLRenderingContext }).getContext =
+        function stubGetContext(this: object) {
+            const existing = byCanvas.get(this);
+            if (existing) {
+                return existing.gl;
+            }
+            const created = createGLStub();
+            byCanvas.set(this, created);
+            stubs.push(created);
+            return created.gl;
+        };
+
+    originalMatchMedia = window.matchMedia;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext = originalGetContext;
+    if (originalMatchMedia) {
+        window.matchMedia = originalMatchMedia;
+    }
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+function mockReducedMotionActive(): void {
+    window.matchMedia = ((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false
+    })) as unknown as typeof window.matchMedia;
+}
+
+function levelUploads(stub: GLStubHandle): number[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, 'u_audioLevel');
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value as number);
+}
+
+function probeRef(): { current: AudioUniformsResult | null } {
+    return { current: null };
+}
+
+function current(probe: { current: AudioUniformsResult | null }): AudioUniformsResult {
+    const value = probe.current;
+    if (!value) {
+        throw new Error('the scene has not rendered yet');
+    }
+    return value;
+}
+
+interface GatedSceneProps {
+    probe: { current: AudioUniformsResult | null };
+    deps: AudioAnalyserDriverDeps;
+}
+
+const GatedScene = ({ probe, deps }: GatedSceneProps) => {
+    const audio = useAudioUniforms(MIC, optionsFor(2), deps);
+    probe.current = audio;
+    return (
+        <BaseShaderComponent
+            programId={PROGRAM_ID}
+            shaderConfig={configFor(2)}
+            uniforms={audio.uniforms}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            saveData='ignore'
+        />
+    );
+};
+
+describe('a gated audio visualizer end-to-end (relay integrity)', () => {
+    it('freezes the poster while a running mic streams, then repaints a drained zero on stop', async () => {
+        mockReducedMotionActive();
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        await mount(<GatedScene probe={probe} deps={fixture.deps} />);
+        act(() => { frames.tick(0) });
+        const stub = stubs[0];
+        expect(levelUploads(stub)).toEqual([0]);
+        expect(frames.pending()).toBe(0);
+
+        await act(async () => { await current(probe).start() });
+        expect(frames.pending()).toBe(1);
+        fixture.hear();
+
+        act(() => { frames.tick(16) });
+        expect(frames.pending()).toBe(0);
+
+        for (let time = 32; time <= 320; time += 16) {
+            act(() => { frames.tick(time) });
+            expect(frames.pending()).toBe(0);
+        }
+        expect(levelUploads(stub).every(value => value === 0)).toBe(true);
+
+        act(() => { current(probe).stop() });
+        expect(frames.pending()).toBe(1);
+        act(() => { frames.tick(336) });
+
+        expect(levelUploads(stub).every(value => value === 0)).toBe(true);
+        expect(frames.pending()).toBe(0);
+    });
+});
+
+interface TwoEngineSceneProps {
+    probe: { current: AudioUniformsResult | null };
+    deps: AudioAnalyserDriverDeps;
+}
+
+const TwoEngineScene = ({ probe, deps }: TwoEngineSceneProps) => {
+    const audio = useAudioUniforms(MIC, optionsFor(2), deps);
+    probe.current = audio;
+    return (
+        <>
+            <BaseShaderComponent
+                programId={PROGRAM_ID}
+                shaderConfig={configFor(2)}
+                uniforms={audio.uniforms}
+                width={WIDTH}
+                height={HEIGHT}
+                useDevicePixelRatio={false}
+                reducedMotion='ignore'
+                saveData='ignore'
+            />
+            <BaseShaderComponent
+                programId={PROGRAM_ID}
+                shaderConfig={configFor(2)}
+                uniforms={audio.uniforms}
+                width={WIDTH}
+                height={HEIGHT}
+                useDevicePixelRatio={false}
+                saveData='ignore'
+            />
+        </>
+    );
+};
+
+describe('two engines sharing one audio driver, one gated and one not', () => {
+    it('animates the ungated engine while the gated engine freezes its poster', async () => {
+        mockReducedMotionActive();
+        const probe = probeRef();
+        const fixture = createFixture();
+
+        await mount(<TwoEngineScene probe={probe} deps={fixture.deps} />);
+        act(() => { frames.tick(0) });
+
+        expect(stubs).toHaveLength(2);
+        const animated = stubs[0];
+        const gated = stubs[1];
+
+        await act(async () => { await current(probe).start() });
+        fixture.hear();
+
+        for (let time = 16; time <= 96; time += 16) {
+            act(() => { frames.tick(time) });
+        }
+        const gatedFrozen = levelUploads(gated).length;
+        const animatedAtSettle = levelUploads(animated).length;
+
+        for (let time = 112; time <= 400; time += 16) {
+            act(() => { frames.tick(time) });
+        }
+
+        const animatedLevels = levelUploads(animated);
+        expect(animatedLevels.length).toBeGreaterThan(animatedAtSettle);
+        expect(animatedLevels[animatedLevels.length - 1]).toBeGreaterThan(0.4);
+        for (let i = 1; i < animatedLevels.length; i++) {
+            expect(animatedLevels[i]).toBeGreaterThanOrEqual(animatedLevels[i - 1]);
+        }
+
+        expect(levelUploads(gated).length).toBe(gatedFrozen);
+    });
+});

--- a/src/react/components/base/BaseShaderComponent.motionGate.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.motionGate.test.tsx
@@ -1,0 +1,313 @@
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { ShaderRenderCallback } from '@/core';
+import { vec2 } from '@/core';
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import { ShaderEngine } from '@/react/components/engine/ShaderEngine';
+import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
+import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type { Frameloop, MotionPolicy, UniformParam } from '@/types';
+
+const PROGRAM_ID = 'gate-demo';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let originalGetContext: unknown;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stub = createGLStub();
+    originalGetContext = (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext;
+    (HTMLCanvasElement.prototype as unknown as { getContext: () => WebGLRenderingContext }).getContext =
+        function stubGetContext() { return stub.gl };
+
+    originalMatchMedia = window.matchMedia;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext = originalGetContext;
+    if (originalMatchMedia) {
+        window.matchMedia = originalMatchMedia;
+    }
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+function uploads(name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+function latestVec(name: string): number[] {
+    const calls = uploads(name);
+    if (calls.length === 0) {
+        throw new Error(`${name} has never been uploaded`);
+    }
+    return Array.from(calls[calls.length - 1] as Float32Array);
+}
+
+function mockReducedMotionActive(): void {
+    window.matchMedia = ((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false
+    })) as unknown as typeof window.matchMedia;
+}
+
+const CAM_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_cam: 'float' }
+});
+
+interface CamSceneProps {
+    counter: { value: number };
+    invalidation: ReturnType<typeof createFrameInvalidation>;
+    reducedMotion?: MotionPolicy;
+    frameloop?: Frameloop;
+}
+
+const CamScene = ({ counter, invalidation, reducedMotion, frameloop = 'demand' }: CamSceneProps) => {
+    const uniforms: Record<string, UniformParam> = {
+        u_cam: { type: 'float', value: () => counter.value, invalidation }
+    };
+    return (
+        <BaseShaderComponent
+            programId={PROGRAM_ID}
+            shaderConfig={CAM_CONFIG}
+            uniforms={uniforms}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop={frameloop}
+            reducedMotion={reducedMotion}
+            saveData='ignore'
+        />
+    );
+};
+
+describe('a motion gate and a per-frame continuous producer (P2 inverted)', () => {
+    it('suppresses a gated continuous producer while the ungated control advances', async () => {
+        mockReducedMotionActive();
+        const counter = { value: 0 };
+        const invalidation = createFrameInvalidation();
+
+        await mount(<CamScene counter={counter} invalidation={invalidation} />);
+        act(() => { frames.tick(0) });
+
+        const afterPoster = uploads('u_cam').length;
+        expect(afterPoster).toBeGreaterThan(0);
+
+        for (let i = 1; i <= 10; i++) {
+            counter.value = i;
+            act(() => { invalidation.request('continuous') });
+            expect(frames.pending()).toBe(0);
+            act(() => { frames.tick(16 * i) });
+        }
+
+        expect(uploads('u_cam').length).toBe(afterPoster);
+    });
+
+    it('the same continuous producer advances when the component opts out with reducedMotion="ignore"', async () => {
+        mockReducedMotionActive();
+        const counter = { value: 0 };
+        const invalidation = createFrameInvalidation();
+
+        await mount(<CamScene counter={counter} invalidation={invalidation} reducedMotion='ignore' />);
+        act(() => { frames.tick(0) });
+
+        const seen: number[] = [];
+        for (let i = 1; i <= 10; i++) {
+            counter.value = i;
+            act(() => { invalidation.request('continuous') });
+            expect(frames.pending()).toBe(1);
+            act(() => { frames.tick(16 * i) });
+            seen.push(uploads('u_cam')[uploads('u_cam').length - 1] as number);
+        }
+
+        expect(seen).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+});
+
+const COLOR_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_color: 'float' }
+});
+
+interface ColorSceneProps {
+    value: number;
+    reducedMotion?: MotionPolicy;
+    frameloop?: Frameloop;
+}
+
+const ColorScene = ({ value, reducedMotion, frameloop }: ColorSceneProps) => (
+    <BaseShaderComponent
+        programId={PROGRAM_ID}
+        shaderConfig={COLOR_CONFIG}
+        uniforms={{ u_color: { type: 'float', value } }}
+        width={WIDTH}
+        height={HEIGHT}
+        useDevicePixelRatio={false}
+        frameloop={frameloop}
+        reducedMotion={reducedMotion}
+        saveData='ignore'
+    />
+);
+
+const renderQuad: ShaderRenderCallback = (_time, _resources, gl) => {
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+};
+
+const OverrideScene = ({ portRef }: { portRef: { current: UniformDebugPort | null } }) => {
+    const { updaters, port, invalidation, capturesAreNonReproducible } = useUniformUpdaters(
+        PROGRAM_ID,
+        { u_color: { type: 'float', value: 1 } },
+        { saveData: 'ignore' }
+    );
+    portRef.current = port;
+
+    return (
+        <ShaderEngine
+            programConfigs={{ [PROGRAM_ID]: COLOR_CONFIG }}
+            renderCallback={renderQuad}
+            uniformUpdaters={updaters}
+            invalidation={invalidation}
+            capturesAreNonReproducible={capturesAreNonReproducible}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            saveData='ignore'
+            useFastPath
+        />
+    );
+};
+
+describe('a plain uniform change under a motion gate (P3 inverted)', () => {
+    it('repaints the poster exactly once with the new value under a static gate', async () => {
+        mockReducedMotionActive();
+
+        await mount(<ColorScene value={1} />);
+        act(() => { frames.tick(0) });
+        expect(uploads('u_color')).toEqual([1]);
+
+        await mount(<ColorScene value={2} />);
+        expect(frames.pending()).toBe(1);
+        act(() => { frames.tick(16) });
+
+        expect(uploads('u_color')).toEqual([1, 2]);
+        expect(frames.pending()).toBe(0);
+    });
+
+    it('repaints the poster under a pause gate too', async () => {
+        mockReducedMotionActive();
+
+        await mount(<ColorScene value={1} reducedMotion='pause' />);
+        act(() => { frames.tick(0) });
+        expect(uploads('u_color')).toEqual([1]);
+
+        await mount(<ColorScene value={2} reducedMotion='pause' />);
+        expect(frames.pending()).toBe(1);
+        act(() => { frames.tick(16) });
+
+        expect(uploads('u_color')).toEqual([1, 2]);
+    });
+
+    it('does NOT repaint a plain change under frameloop="demand" with no gate', async () => {
+        await mount(<ColorScene value={1} reducedMotion='ignore' frameloop='demand' />);
+        act(() => { frames.tick(0) });
+        expect(uploads('u_color')).toEqual([1]);
+        expect(frames.pending()).toBe(0);
+
+        await mount(<ColorScene value={2} reducedMotion='ignore' frameloop='demand' />);
+        expect(frames.pending()).toBe(0);
+        act(() => { frames.tick(16) });
+
+        expect(uploads('u_color')).toEqual([1]);
+        expect(frames.pending()).toBe(0);
+    });
+});
+
+const VEC_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_vec: 'vec2' }
+});
+
+const VecScene = ({ value }: { value: [number, number] }) => (
+    <BaseShaderComponent
+        programId={PROGRAM_ID}
+        shaderConfig={VEC_CONFIG}
+        uniforms={{ u_vec: { type: 'vec2', value: vec2(value) } }}
+        width={WIDTH}
+        height={HEIGHT}
+        useDevicePixelRatio={false}
+        saveData='ignore'
+    />
+);
+
+describe('a gated mount with a vec uniform (P0)', () => {
+    it('does not crash at mount and paints the real vec values on the first frame', async () => {
+        mockReducedMotionActive();
+
+        await mount(<VecScene value={[0.25, 0.5]} />);
+        act(() => { frames.tick(0) });
+
+        expect(latestVec('u_vec')).toEqual([0.25, 0.5]);
+    });
+});
+
+describe('a devtools override under a motion gate', () => {
+    it('repaints the poster with the override value', async () => {
+        mockReducedMotionActive();
+        const portRef: { current: UniformDebugPort | null } = { current: null };
+
+        await mount(<OverrideScene portRef={portRef} />);
+        act(() => { frames.tick(0) });
+        expect(uploads('u_color')).toEqual([1]);
+
+        const port = portRef.current;
+        if (!port) {
+            throw new Error('debug port was never mounted');
+        }
+        act(() => { port.setOverride('u_color', 7) });
+        expect(frames.pending()).toBe(1);
+        act(() => { frames.tick(16) });
+
+        expect(uploads('u_color')).toEqual([1, 7]);
+    });
+});

--- a/src/react/components/base/BaseShaderComponent.workerGateOrder.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.workerGateOrder.test.tsx
@@ -1,0 +1,202 @@
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type { UniformParam } from '@/types';
+import type { MainToWorker, WorkerToMain } from '@/worker/protocol';
+import type { WorkerRuntimeHost } from '@/worker/WorkerRuntime';
+import { WorkerRuntime } from '@/worker/WorkerRuntime';
+
+const PROGRAM_ID = 'blob';
+const WIDTH = 320;
+const HEIGHT = 200;
+const LIVE_VALUE = 0.75;
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_level: 'float' }
+});
+
+interface WorkerHarness {
+    createWorker: () => Worker;
+    gl: GLStubHandle;
+    frames: FrameQueue;
+    posted: MainToWorker[];
+}
+
+function createWorkerHarness(): WorkerHarness {
+    const offscreenCanvas = {
+        width: 0,
+        height: 0,
+        getContext: (): WebGLRenderingContext => stub.gl,
+        addEventListener: (): void => undefined,
+        removeEventListener: (): void => undefined
+    };
+    const offscreen = offscreenCanvas as unknown as OffscreenCanvas;
+    const stub = createGLStub({ overrides: { canvas: offscreen } });
+
+    const frames = createFrameQueue();
+    const posted: MainToWorker[] = [];
+    const listeners: ((event: MessageEvent<WorkerToMain>) => void)[] = [];
+
+    const host: WorkerRuntimeHost = {
+        postMessage: message => {
+            listeners.forEach(listener => { listener({ data: message } as MessageEvent<WorkerToMain>) });
+        },
+        requestAnimationFrame: frames.schedule,
+        cancelAnimationFrame: frames.cancel,
+        now: () => 0
+    };
+
+    const runtime = new WorkerRuntime(host);
+
+    const worker = {
+        postMessage: (message: MainToWorker) => {
+            posted.push(message);
+            runtime.handleMessage(message);
+        },
+        addEventListener: (type: string, listener: (event: never) => void) => {
+            if (type === 'error') return;
+            listeners.push(listener as (event: MessageEvent<WorkerToMain>) => void);
+        },
+        removeEventListener: () => undefined,
+        terminate: () => undefined
+    };
+
+    (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas = {};
+    (globalThis as { Worker?: unknown }).Worker = {};
+    (HTMLCanvasElement.prototype as unknown as {
+        transferControlToOffscreen: () => OffscreenCanvas;
+    }).transferControlToOffscreen = function transferControlToOffscreen(this: HTMLCanvasElement) {
+        offscreenCanvas.width = this.width;
+        offscreenCanvas.height = this.height;
+        return offscreen;
+    };
+    (HTMLCanvasElement.prototype as unknown as {
+        getContext: () => WebGLRenderingContext;
+    }).getContext = function getContext() {
+        return stub.gl;
+    };
+
+    return {
+        createWorker: () => worker as unknown as Worker,
+        gl: stub,
+        frames,
+        posted
+    };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let mainFrames: FrameQueue;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    mainFrames = createFrameQueue();
+    globalThis.requestAnimationFrame = mainFrames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = mainFrames.cancel;
+
+    originalMatchMedia = window.matchMedia;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    if (originalMatchMedia) {
+        window.matchMedia = originalMatchMedia;
+    }
+});
+
+function mockReducedMotionActive(): void {
+    window.matchMedia = ((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false
+    })) as unknown as typeof window.matchMedia;
+}
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+interface SceneProps {
+    worker: WorkerHarness;
+    uniforms: Record<string, UniformParam>;
+    liveUniforms: string[];
+}
+
+const Scene = ({ worker, uniforms, liveUniforms }: SceneProps) => (
+    <BaseShaderComponent
+        worker={true}
+        createWorker={worker.createWorker}
+        programId={PROGRAM_ID}
+        shaderConfig={CONFIG}
+        uniforms={uniforms}
+        liveUniforms={liveUniforms}
+        width={WIDTH}
+        height={HEIGHT}
+        useDevicePixelRatio={false}
+        frameloop='demand'
+        saveData='ignore'
+    />
+);
+
+function firstIndexOf(posted: MainToWorker[], predicate: (message: MainToWorker) => boolean): number {
+    return posted.findIndex(predicate);
+}
+
+describe('a gated worker mount posts its poster renderFrame after the first live values', () => {
+    it('posts renderFrame only after setMotionGate and the setUniformValues carrying the live sample', async () => {
+        mockReducedMotionActive();
+        const worker = createWorkerHarness();
+
+        await mount(
+            <Scene
+                worker={worker}
+                uniforms={{ level: { type: 'float', value: () => LIVE_VALUE } }}
+                liveUniforms={['level']}
+            />
+        );
+
+        const gateIndex = firstIndexOf(worker.posted, message => message.type === 'setMotionGate');
+        const liveValuesIndex = firstIndexOf(
+            worker.posted,
+            message => message.type === 'setUniformValues' && message.values.u_level === LIVE_VALUE
+        );
+        const renderFrameIndex = firstIndexOf(worker.posted, message => message.type === 'renderFrame');
+
+        expect(gateIndex).toBeGreaterThanOrEqual(0);
+        expect(liveValuesIndex).toBeGreaterThanOrEqual(0);
+        expect(renderFrameIndex).toBeGreaterThanOrEqual(0);
+
+        const gate = worker.posted[gateIndex];
+        if (gate.type !== 'setMotionGate') {
+            throw new Error('expected a setMotionGate message at gateIndex');
+        }
+        expect(gate.gate).toBe('static');
+
+        expect(renderFrameIndex).toBeGreaterThan(liveValuesIndex);
+        expect(renderFrameIndex).toBeGreaterThan(gateIndex);
+    });
+});

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -18,7 +18,7 @@ import type {
 } from '@/core';
 import { CAPTURE_SCRATCH_FRAMEBUFFER_ID, captureFrame } from '@/core/lib/captureFrame';
 import { resolveExportDimensions, validateRenderToBlobOptions } from '@/core/lib/captureOptions';
-import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+import type { FrameInvalidation, InvalidationKind } from '@/core/lib/frameInvalidation';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import { Passes } from '@/core/systems/Passes';
 import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
@@ -405,12 +405,12 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
 
     const applySizeRef = useRef(applySize);
 
-    const invalidateAll = useCallback(() => {
+    const invalidateAll = useCallback((kind: InvalidationKind = 'discrete') => {
         if (workerActiveRef.current) {
-            bridgeRef.current?.invalidate();
+            bridgeRef.current?.invalidate(undefined, kind);
             return;
         }
-        controllerRef.current?.invalidate();
+        controllerRef.current?.invalidate(kind);
     }, []);
 
     const session = useWorkerBridge({
@@ -697,7 +697,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
 
         controller.setMotionGate(motionGate);
         if (motionGate === 'static') {
-            controller.setFrame(staticFrame);
+            controller.pinFrame(staticFrame);
         }
     }, [motionGate, staticFrame]);
 

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -19,7 +19,7 @@ import type {
 } from '@/core';
 import { captureFrame } from '@/core/lib/captureFrame';
 import { resolveExportDimensions, validateRenderToBlobOptions } from '@/core/lib/captureOptions';
-import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+import type { FrameInvalidation, InvalidationKind } from '@/core/lib/frameInvalidation';
 import { InstanceUploader } from '@/core/lib/instanceBuffers';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
@@ -451,14 +451,14 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
         renderFrame(elapsed);
     }, [postLiveUniforms, renderFrame]);
 
-    const invalidateAll = useCallback(() => {
+    const invalidateAll = useCallback((kind: InvalidationKind = 'discrete') => {
         if (workerActiveRef.current) {
             postLiveUniforms(frameToMs(controllerRef.current?.getFrame() ?? 0));
-            controllerRef.current?.invalidate();
-            bridgeRef.current?.invalidate();
+            controllerRef.current?.invalidate(kind);
+            bridgeRef.current?.invalidate(undefined, kind);
             return;
         }
-        controllerRef.current?.invalidate();
+        controllerRef.current?.invalidate(kind);
     }, [postLiveUniforms]);
 
     const startSamplerLoop = useCallback(() => {
@@ -770,7 +770,7 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
 
         controller.setMotionGate(motionGate);
         if (motionGate === 'static') {
-            controller.setFrame(staticFrame);
+            controller.pinFrame(staticFrame);
         }
     }, [motionGate, staticFrame]);
 

--- a/src/react/hooks/useUniformUpdaters.ts
+++ b/src/react/hooks/useUniformUpdaters.ts
@@ -8,10 +8,13 @@ import {
     collectInvalidations,
     collectLiveValues,
     collectNonReproducible,
+    collectPosterValues,
     createUniformDebugPort,
     type LiveValues,
     mergeOverrides,
     parseUniformStructureKey,
+    type PosterSnapshot,
+    posterValuesChanged,
     type UniformDebugPort,
     type UniformDescriptor,
     uniformDescriptors,
@@ -60,19 +63,32 @@ export const useUniformUpdaters = (
     const runtime = runtimeRef.current;
 
     const relayedRef = useRef(new Map<FrameInvalidation, () => void>());
+    const posterRef = useRef<PosterSnapshot | null>(null);
 
     useEffect(() => {
         const base = collectLiveValues(uniforms);
+        const nextPoster = collectPosterValues(uniforms);
+        const previousPoster = posterRef.current;
+        posterRef.current = nextPoster;
+
         baseValuesRef.current = base;
         valuesRef.current = mergeOverrides(base, overridesRef.current);
         runtime.applyTargets(uniforms, motionGate);
+
+        if (
+            motionGate !== 'none'
+            && previousPoster !== null
+            && posterValuesChanged(previousPoster, nextPoster)
+        ) {
+            runtime.invalidation.request();
+        }
 
         const relayed = relayedRef.current;
         const sources = collectInvalidations(uniforms);
 
         for (const source of sources) {
             if (!relayed.has(source)) {
-                relayed.set(source, source.connect(() => { runtime.invalidation.request() }));
+                relayed.set(source, source.connect(kind => { runtime.invalidation.request(kind) }));
             }
         }
         for (const [source, dispose] of relayed) {

--- a/src/react/hooks/useWorkerBridge.ts
+++ b/src/react/hooks/useWorkerBridge.ts
@@ -152,11 +152,12 @@ export function useWorkerBridge(options: UseWorkerBridgeOptions): WorkerBridgeSe
             current.bridgeRef.current = bridge;
 
             bridge.setMotionGate(current.motionGate);
+
+            current.onConnected?.();
+
             if (current.motionGate === 'static') {
                 bridge.renderFrame(frameToMs(current.staticFrame));
             }
-
-            current.onConnected?.();
         };
 
         void connect().catch((cause: unknown) => {

--- a/src/react/lib/audioAnalyserDriver.test.ts
+++ b/src/react/lib/audioAnalyserDriver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { validateAudioOptions } from '@/core/lib/audioBands';
+import type { InvalidationKind } from '@/core/lib/frameInvalidation';
 import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
 import { createAudioAnalyserDriver } from '@/react/lib/audioAnalyserDriver';
 import type { FakeAnalyser, FakeStream, FakeTrack } from '@/react/lib/fakeWebAudio';
@@ -825,5 +826,51 @@ describe('audio driver reconfigure', () => {
         expect(harness.driver.bandsScratch).toHaveLength(2);
         expect(harness.driver.status).toBe('idle');
         expect(harness.context.analysers).toHaveLength(0);
+    });
+});
+
+describe('audio driver invalidation kind', () => {
+    function kindHarness(): { driver: ReturnType<typeof createAudioAnalyserDriver>; kinds: InvalidationKind[]; context: FakeContext } {
+        const context = new FakeContext();
+        const { stream } = createFakeStream();
+        const driver = createAudioAnalyserDriver({ type: 'mic' }, validateAudioOptions(TWO_BAND_LINEAR), {
+            createContext: () => asContext(context),
+            getUserMedia: () => Promise.resolve(stream)
+        });
+        const kinds: InvalidationKind[] = [];
+        driver.invalidation.connect(kind => { kinds.push(kind) });
+        return { driver, kinds, context };
+    }
+
+    it('analyseIfNeeded emits continuous while start, stop and reconfigure emit discrete', async () => {
+        const harness = kindHarness();
+
+        await harness.driver.start();
+        expect(harness.kinds).toEqual(['discrete']);
+
+        latestAnalyser(harness.context).spectrum = LOW_HALF;
+        harness.driver.analyseIfNeeded(16);
+        harness.driver.analyseIfNeeded(32);
+        expect(harness.kinds).toEqual(['discrete', 'continuous', 'continuous']);
+
+        harness.driver.reconfigure(validateAudioOptions({ ...TWO_BAND_LINEAR, fftSize: 128 }));
+        expect(harness.kinds[harness.kinds.length - 1]).toBe('discrete');
+
+        harness.driver.stop();
+        expect(harness.kinds[harness.kinds.length - 1]).toBe('discrete');
+    });
+
+    it('a start failure emits discrete so the poster shows the error state', async () => {
+        const context = new FakeContext();
+        const driver = createAudioAnalyserDriver({ type: 'mic' }, validateAudioOptions(TWO_BAND_LINEAR), {
+            createContext: () => asContext(context),
+            getUserMedia: () => Promise.reject(new Error('denied'))
+        });
+        const kinds: InvalidationKind[] = [];
+        driver.invalidation.connect(kind => { kinds.push(kind) });
+
+        await driver.start().catch(() => undefined);
+
+        expect(kinds).toEqual(['discrete']);
     });
 });

--- a/src/react/lib/audioAnalyserDriver.ts
+++ b/src/react/lib/audioAnalyserDriver.ts
@@ -363,7 +363,7 @@ export function createAudioAnalyserDriver(
         level = sum / bands.length;
 
         lastAnalysedTime = timeMs;
-        invalidation.request();
+        invalidation.request('continuous');
     }
 
     function adoptOptions(next: ResolvedAnalyserOptions): void {

--- a/src/react/lib/liveUniformUpdaters.ts
+++ b/src/react/lib/liveUniformUpdaters.ts
@@ -169,6 +169,63 @@ export function collectLiveValues(uniforms: Record<string, UniformParam>): LiveV
     return values;
 }
 
+export type PosterSnapshot = Record<string, number | number[]>;
+
+function copyPosterValue(value: UniformValue<UniformType>): number | number[] {
+    if (typeof value === 'number') {
+        return value;
+    }
+    return Array.from(value as ArrayLike<number>);
+}
+
+export function collectPosterValues(uniforms: Record<string, UniformParam>): PosterSnapshot {
+    const snapshot: PosterSnapshot = {};
+    for (const [name, param] of Object.entries(uniforms)) {
+        if (typeof param.value === 'function' || param.transition) {
+            continue;
+        }
+        snapshot[normalizeUniformName(name)] = copyPosterValue(param.value);
+    }
+    return snapshot;
+}
+
+function posterValueChanged(a: number | number[], b: number | number[]): boolean {
+    const aArray = Array.isArray(a);
+    const bArray = Array.isArray(b);
+    if (aArray !== bArray) {
+        return true;
+    }
+    if (!aArray || !bArray) {
+        return !Object.is(a, b);
+    }
+    if (a.length !== b.length) {
+        return true;
+    }
+    for (let i = 0; i < a.length; i++) {
+        if (!Object.is(a[i], b[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function posterValuesChanged(prev: PosterSnapshot, next: PosterSnapshot): boolean {
+    const prevKeys = Object.keys(prev);
+    const nextKeys = Object.keys(next);
+    if (prevKeys.length !== nextKeys.length) {
+        return true;
+    }
+    for (const key of nextKeys) {
+        if (!Object.prototype.hasOwnProperty.call(prev, key)) {
+            return true;
+        }
+        if (posterValueChanged(prev[key], next[key])) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export function collectInvalidations(uniforms: Record<string, UniformParam>): FrameInvalidation[] {
     const sources: FrameInvalidation[] = [];
     for (const param of Object.values(uniforms)) {

--- a/src/react/lib/renderLoop.test.ts
+++ b/src/react/lib/renderLoop.test.ts
@@ -376,6 +376,86 @@ describe('RenderLoop motion gate', () => {
     });
 });
 
+describe('RenderLoop invalidation kind under a gate', () => {
+    it('schedules for a discrete request but never for a continuous one while gated', () => {
+        const h = harness({ frameloop: 'always' });
+        h.loop.start();
+        h.flush(16);
+        h.loop.setMotionGate('static');
+        expect(h.pending).toBe(0);
+
+        h.loop.invalidate('continuous');
+        expect(h.pending).toBe(0);
+
+        h.loop.invalidate('discrete');
+        expect(h.pending).toBe(1);
+        h.flush(500);
+        expect(h.renders).toEqual([0, 0]);
+        expect(h.pending).toBe(0);
+    });
+
+    it('a continuous and a discrete request in the same window both clear when the frame fires', () => {
+        const h = harness({ frameloop: 'demand' });
+        h.loop.start();
+        h.flush(16);
+        expect(h.pending).toBe(0);
+
+        h.loop.invalidate('continuous');
+        h.loop.invalidate('discrete');
+        expect(h.pending).toBe(1);
+
+        h.flush(32);
+        expect(h.renders).toHaveLength(2);
+        expect(h.pending).toBe(0);
+    });
+
+    it('without a gate a continuous request schedules a demand frame', () => {
+        const h = harness({ frameloop: 'demand' });
+        h.loop.start();
+        h.flush(16);
+        expect(h.pending).toBe(0);
+
+        h.loop.invalidate('continuous');
+        expect(h.pending).toBe(1);
+        h.flush(32);
+        expect(h.renders).toHaveLength(2);
+    });
+});
+
+describe('RenderLoop pinFrame', () => {
+    it('pins the clock and schedules a frame without rendering synchronously', () => {
+        const h = harness({ frameloop: 'always' });
+        h.loop.start();
+        h.flush(16);
+        h.loop.setMotionGate('static');
+        expect(h.renders).toEqual([0]);
+        expect(h.pending).toBe(0);
+
+        h.loop.pinFrame(120);
+        expect(h.renders).toEqual([0]);
+        expect(h.loop.getFrame()).toBe(120);
+        expect(h.pending).toBe(1);
+
+        h.flush(999999);
+        expect(h.renders).toEqual([0, 2000]);
+        expect(h.pending).toBe(0);
+    });
+
+    it('unlike setFrame, pinFrame does not paint before the scheduled frame', () => {
+        const h = harness({ frameloop: 'always' });
+        h.loop.start();
+        h.flush(16);
+        h.loop.setMotionGate('static');
+
+        const before = h.renders.length;
+        h.loop.pinFrame(60);
+        expect(h.renders.length).toBe(before);
+
+        h.loop.setFrame(60);
+        expect(h.renders.length).toBe(before + 1);
+    });
+});
+
 describe('RenderLoop introspection getters', () => {
     it('reports the configured frameloop mode and reacts to setFrameloop', () => {
         const h = harness({ frameloop: 'demand' });

--- a/src/react/lib/renderLoop.ts
+++ b/src/react/lib/renderLoop.ts
@@ -1,3 +1,4 @@
+import type { InvalidationKind } from '@/core/lib/frameInvalidation';
 import type { MotionGate } from '@/react/lib/motionPolicy';
 import { shouldSchedule } from '@/react/lib/shouldSchedule';
 import {
@@ -29,7 +30,8 @@ export class RenderLoop {
     private pauseWhenHidden: boolean;
     private documentVisible = true;
     private intersecting = true;
-    private pendingInvalidate = false;
+    private pendingDiscrete = false;
+    private pendingContinuous = false;
     private running = false;
     private handle: number | null = null;
     private cold = true;
@@ -69,7 +71,8 @@ export class RenderLoop {
             documentVisible: this.documentVisible,
             intersecting: this.intersecting,
             pauseWhenHidden: this.pauseWhenHidden,
-            pendingInvalidate: this.pendingInvalidate,
+            pendingDiscrete: this.pendingDiscrete,
+            pendingContinuous: this.pendingContinuous,
             motionGate: this.motionGate
         });
 
@@ -83,7 +86,8 @@ export class RenderLoop {
 
     private frame = (now: number): void => {
         this.handle = null;
-        this.pendingInvalidate = false;
+        this.pendingDiscrete = false;
+        this.pendingContinuous = false;
 
         if (this.motionGate !== 'none') {
             this.time = syncTime(this.time, now);
@@ -116,8 +120,12 @@ export class RenderLoop {
         this.evaluate();
     }
 
-    invalidate(): void {
-        this.pendingInvalidate = true;
+    invalidate(kind: InvalidationKind = 'discrete'): void {
+        if (kind === 'continuous') {
+            this.pendingContinuous = true;
+        } else {
+            this.pendingDiscrete = true;
+        }
         this.evaluate();
     }
 
@@ -126,6 +134,12 @@ export class RenderLoop {
         this.cold = true;
         this.deps.render(elapsedMs(this.time));
         this.evaluate();
+    }
+
+    pinFrame(frame: number): void {
+        this.time = setTimeFrame(this.time, frame, this.deps.now());
+        this.cold = true;
+        this.invalidate();
     }
 
     getFrame(): number {

--- a/src/react/lib/shouldSchedule.test.ts
+++ b/src/react/lib/shouldSchedule.test.ts
@@ -18,12 +18,12 @@ function expected(inputs: ScheduleInputs): boolean {
         return false;
     }
     if (inputs.motionGate !== 'none') {
-        return inputs.pendingInvalidate;
+        return inputs.pendingDiscrete;
     }
     if (inputs.frameloop === 'always') {
         return true;
     }
-    return inputs.pendingInvalidate;
+    return inputs.pendingDiscrete || inputs.pendingContinuous;
 }
 
 describe('shouldSchedule truth table', () => {
@@ -33,14 +33,17 @@ describe('shouldSchedule truth table', () => {
                 for (const documentVisible of BOOLS) {
                     for (const intersecting of BOOLS) {
                         for (const pauseWhenHidden of BOOLS) {
-                            for (const pendingInvalidate of BOOLS) {
-                                for (const motionGate of MOTION_GATES) {
-                                    const inputs: ScheduleInputs = {
-                                        frameloop, speed, documentVisible,
-                                        intersecting, pauseWhenHidden, pendingInvalidate,
-                                        motionGate
-                                    };
-                                    expect(shouldSchedule(inputs)).toBe(expected(inputs));
+                            for (const pendingDiscrete of BOOLS) {
+                                for (const pendingContinuous of BOOLS) {
+                                    for (const motionGate of MOTION_GATES) {
+                                        const inputs: ScheduleInputs = {
+                                            frameloop, speed, documentVisible,
+                                            intersecting, pauseWhenHidden,
+                                            pendingDiscrete, pendingContinuous,
+                                            motionGate
+                                        };
+                                        expect(shouldSchedule(inputs)).toBe(expected(inputs));
+                                    }
                                 }
                             }
                         }
@@ -57,7 +60,8 @@ const base: ScheduleInputs = {
     documentVisible: true,
     intersecting: true,
     pauseWhenHidden: true,
-    pendingInvalidate: false,
+    pendingDiscrete: false,
+    pendingContinuous: false,
     motionGate: 'none'
 };
 
@@ -88,19 +92,21 @@ describe('shouldSchedule precedence', () => {
         expect(shouldSchedule({ ...base, speed: -1 })).toBe(true);
     });
 
-    it('demand mode schedules only when an invalidate is pending', () => {
-        expect(shouldSchedule({ ...base, frameloop: 'demand', pendingInvalidate: false })).toBe(false);
-        expect(shouldSchedule({ ...base, frameloop: 'demand', pendingInvalidate: true })).toBe(true);
+    it('demand mode schedules on a pending discrete or continuous request', () => {
+        expect(shouldSchedule({ ...base, frameloop: 'demand' })).toBe(false);
+        expect(shouldSchedule({ ...base, frameloop: 'demand', pendingDiscrete: true })).toBe(true);
+        expect(shouldSchedule({ ...base, frameloop: 'demand', pendingContinuous: true })).toBe(true);
     });
 
-    it('never mode schedules only when an invalidate is pending', () => {
-        expect(shouldSchedule({ ...base, frameloop: 'never', pendingInvalidate: false })).toBe(false);
-        expect(shouldSchedule({ ...base, frameloop: 'never', pendingInvalidate: true })).toBe(true);
+    it('never mode schedules on a pending discrete or continuous request', () => {
+        expect(shouldSchedule({ ...base, frameloop: 'never' })).toBe(false);
+        expect(shouldSchedule({ ...base, frameloop: 'never', pendingDiscrete: true })).toBe(true);
+        expect(shouldSchedule({ ...base, frameloop: 'never', pendingContinuous: true })).toBe(true);
     });
 
-    it('hidden overrides a pending invalidate in demand mode', () => {
+    it('hidden overrides a pending request in demand mode', () => {
         expect(shouldSchedule({
-            ...base, frameloop: 'demand', pendingInvalidate: true, documentVisible: false
+            ...base, frameloop: 'demand', pendingDiscrete: true, documentVisible: false
         })).toBe(false);
     });
 
@@ -109,26 +115,35 @@ describe('shouldSchedule precedence', () => {
         expect(shouldSchedule({ ...base, motionGate: 'pause' })).toBe(false);
     });
 
-    it('a motion gate still allows one coalesced repaint per invalidate', () => {
-        expect(shouldSchedule({ ...base, motionGate: 'static', pendingInvalidate: true })).toBe(true);
-        expect(shouldSchedule({ ...base, motionGate: 'pause', pendingInvalidate: true })).toBe(true);
+    it('a motion gate schedules on a pending discrete request but never on a continuous one', () => {
+        expect(shouldSchedule({ ...base, motionGate: 'static', pendingDiscrete: true })).toBe(true);
+        expect(shouldSchedule({ ...base, motionGate: 'pause', pendingDiscrete: true })).toBe(true);
+        expect(shouldSchedule({ ...base, motionGate: 'static', pendingContinuous: true })).toBe(false);
+        expect(shouldSchedule({ ...base, motionGate: 'pause', pendingContinuous: true })).toBe(false);
     });
 
-    it('hidden still wins over a motion gate with a pending invalidate', () => {
+    it('a continuous request alongside a discrete one still schedules under a gate', () => {
         expect(shouldSchedule({
-            ...base, motionGate: 'static', pendingInvalidate: true, documentVisible: false
+            ...base, motionGate: 'static', pendingDiscrete: true, pendingContinuous: true
+        })).toBe(true);
+    });
+
+    it('hidden still wins over a motion gate with a pending discrete request', () => {
+        expect(shouldSchedule({
+            ...base, motionGate: 'static', pendingDiscrete: true, documentVisible: false
         })).toBe(false);
     });
 
-    it('speed zero still wins over a motion gate with a pending invalidate', () => {
+    it('speed zero still wins over a motion gate with a pending discrete request', () => {
         expect(shouldSchedule({
-            ...base, motionGate: 'static', pendingInvalidate: true, speed: 0
+            ...base, motionGate: 'static', pendingDiscrete: true, speed: 0
         })).toBe(false);
     });
 
     it('motionGate none preserves the pre-gate always/demand/never behavior', () => {
         expect(shouldSchedule({ ...base, motionGate: 'none' })).toBe(true);
-        expect(shouldSchedule({ ...base, frameloop: 'demand', motionGate: 'none', pendingInvalidate: false })).toBe(false);
-        expect(shouldSchedule({ ...base, frameloop: 'demand', motionGate: 'none', pendingInvalidate: true })).toBe(true);
+        expect(shouldSchedule({ ...base, frameloop: 'demand', motionGate: 'none' })).toBe(false);
+        expect(shouldSchedule({ ...base, frameloop: 'demand', motionGate: 'none', pendingContinuous: true })).toBe(true);
+        expect(shouldSchedule({ ...base, frameloop: 'demand', motionGate: 'none', pendingDiscrete: true })).toBe(true);
     });
 });

--- a/src/react/lib/shouldSchedule.ts
+++ b/src/react/lib/shouldSchedule.ts
@@ -7,7 +7,8 @@ export interface ScheduleInputs {
     documentVisible: boolean;
     intersecting: boolean;
     pauseWhenHidden: boolean;
-    pendingInvalidate: boolean;
+    pendingDiscrete: boolean;
+    pendingContinuous: boolean;
     motionGate: MotionGate;
 }
 
@@ -21,12 +22,12 @@ export function shouldSchedule(inputs: ScheduleInputs): boolean {
     }
 
     if (inputs.motionGate !== 'none') {
-        return inputs.pendingInvalidate;
+        return inputs.pendingDiscrete;
     }
 
     if (inputs.frameloop === 'always') {
         return true;
     }
 
-    return inputs.pendingInvalidate;
+    return inputs.pendingDiscrete || inputs.pendingContinuous;
 }

--- a/src/worker/WorkerBridge.test.ts
+++ b/src/worker/WorkerBridge.test.ts
@@ -463,7 +463,40 @@ describe('WorkerBridge invalidate coalescing', () => {
         await Promise.resolve();
 
         expect(fake.postMessage).toHaveBeenCalledTimes(1);
-        expect(fake.postMessage).toHaveBeenCalledWith({ type: 'invalidate', frames: 3 }, undefined);
+        expect(fake.postMessage).toHaveBeenCalledWith(
+            { type: 'invalidate', frames: 3, kind: 'discrete' },
+            undefined
+        );
+    });
+
+    it('coalesces a mixed discrete and continuous window into a discrete message', async () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.invalidate(undefined, 'continuous');
+        bridge.invalidate(undefined, 'discrete');
+        await Promise.resolve();
+
+        expect(fake.postMessage).toHaveBeenCalledWith(
+            { type: 'invalidate', frames: 1, kind: 'discrete' },
+            undefined
+        );
+    });
+
+    it('keeps a purely continuous window continuous across the boundary', async () => {
+        const fake = createFakeTransport();
+        const bridge = new WorkerBridge(fake.transport, baseInit());
+        fake.postMessage.mockClear();
+
+        bridge.invalidate(undefined, 'continuous');
+        bridge.invalidate(undefined, 'continuous');
+        await Promise.resolve();
+
+        expect(fake.postMessage).toHaveBeenCalledWith(
+            { type: 'invalidate', frames: 1, kind: 'continuous' },
+            undefined
+        );
     });
 
     it('throws instead of posting a garbage frame count across the boundary', () => {
@@ -490,7 +523,10 @@ describe('WorkerBridge invalidate coalescing', () => {
         bridge.invalidate(5);
         await Promise.resolve();
         expect(fake.postMessage).toHaveBeenCalledTimes(2);
-        expect(fake.postMessage).toHaveBeenLastCalledWith({ type: 'invalidate', frames: 5 }, undefined);
+        expect(fake.postMessage).toHaveBeenLastCalledWith(
+            { type: 'invalidate', frames: 5, kind: 'discrete' },
+            undefined
+        );
     });
 });
 

--- a/src/worker/WorkerBridge.ts
+++ b/src/worker/WorkerBridge.ts
@@ -1,3 +1,4 @@
+import type { InvalidationKind } from '@/core/lib/frameInvalidation';
 import type { MotionGate } from '@/react/lib/motionPolicy';
 import type {
     FramebufferOptions,
@@ -200,6 +201,7 @@ export class WorkerBridge {
     private lastActive: boolean;
     private pendingResize: { renderWidth: number; renderHeight: number } | null = null;
     private pendingInvalidateFrames: number | null = null;
+    private pendingInvalidateKind: InvalidationKind | null = null;
     private invalidateScheduled = false;
     private readonly lastPostedValues = new Map<string, UniformValueMap>();
 
@@ -337,7 +339,7 @@ export class WorkerBridge {
         this.post({ type: 'setActive', active });
     }
 
-    invalidate(frames?: number): void {
+    invalidate(frames?: number, kind: InvalidationKind = 'discrete'): void {
         if (this.disposed) {
             return;
         }
@@ -350,6 +352,8 @@ export class WorkerBridge {
             );
         }
         this.pendingInvalidateFrames = Math.max(this.pendingInvalidateFrames ?? 0, requested);
+        this.pendingInvalidateKind =
+            kind === 'discrete' || this.pendingInvalidateKind === 'discrete' ? 'discrete' : 'continuous';
 
         if (this.invalidateScheduled) {
             return;
@@ -359,11 +363,13 @@ export class WorkerBridge {
         queueMicrotask(() => {
             this.invalidateScheduled = false;
             const framesToSend = this.pendingInvalidateFrames;
+            const kindToSend = this.pendingInvalidateKind ?? 'discrete';
             this.pendingInvalidateFrames = null;
+            this.pendingInvalidateKind = null;
             if (framesToSend === null || this.disposed) {
                 return;
             }
-            this.post({ type: 'invalidate', frames: framesToSend });
+            this.post({ type: 'invalidate', frames: framesToSend, kind: kindToSend });
         });
     }
 

--- a/src/worker/WorkerRuntime.ts
+++ b/src/worker/WorkerRuntime.ts
@@ -1,3 +1,4 @@
+import type { InvalidationKind } from '@/core/lib/frameInvalidation';
 import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import { Passes } from '@/core/systems/Passes';
@@ -97,6 +98,7 @@ export class WorkerRuntime {
     private renderWidth = 0;
     private renderHeight = 0;
     private pendingFrames = 0;
+    private pendingFrameKind: InvalidationKind = 'discrete';
     private active = false;
     private contextLost = false;
     private failed = false;
@@ -147,7 +149,7 @@ export class WorkerRuntime {
                 this.setActive(loop, message.active);
                 break;
             case 'invalidate':
-                this.invalidate(loop, message.frames);
+                this.invalidate(loop, message.frames, message.kind);
                 break;
             case 'setFrameloop':
                 loop.setFrameloop(message.mode);
@@ -481,7 +483,7 @@ export class WorkerRuntime {
         }
     }
 
-    private invalidate(loop: RenderLoop, frames: number | undefined): void {
+    private invalidate(loop: RenderLoop, frames: number | undefined, kind: InvalidationKind = 'discrete'): void {
         const requested = frames ?? 1;
         if (!Number.isInteger(requested) || requested < 1) {
             throw new Error(
@@ -491,7 +493,8 @@ export class WorkerRuntime {
         }
 
         this.pendingFrames = Math.max(this.pendingFrames, requested);
-        loop.invalidate();
+        this.pendingFrameKind = kind;
+        loop.invalidate(kind);
     }
 
     private readonly renderTick = (elapsed: number): void => {
@@ -511,7 +514,7 @@ export class WorkerRuntime {
 
         this.pendingFrames -= 1;
         if (this.pendingFrames > 0) {
-            this.loop?.invalidate();
+            this.loop?.invalidate(this.pendingFrameKind);
         }
     }
 

--- a/src/worker/protocol.ts
+++ b/src/worker/protocol.ts
@@ -1,3 +1,4 @@
+import type { InvalidationKind } from '@/core/lib/frameInvalidation';
 import type { MotionGate } from '@/react/lib/motionPolicy';
 import type {
     FramebufferOptions,
@@ -97,7 +98,7 @@ export type MainToWorker =
     | { type: 'setPasses'; passes: SerializableRenderPass[] }
     | { type: 'resize'; renderWidth: number; renderHeight: number }
     | { type: 'setActive'; active: boolean }
-    | { type: 'invalidate'; frames?: number }
+    | { type: 'invalidate'; frames?: number; kind?: InvalidationKind }
     | { type: 'setFrameloop'; mode: Frameloop }
     | { type: 'setSpeed'; speed: number }
     | { type: 'setMotionGate'; gate: MotionGate }

--- a/src/worker/workerPipeline.test.ts
+++ b/src/worker/workerPipeline.test.ts
@@ -286,3 +286,120 @@ describe('worker ping-pong pipeline, driven by the real pass and uniform builder
         expect(worker).toEqual(main);
     });
 });
+
+interface SingleWorkerHarness {
+    bridge: WorkerBridge;
+    gl: GLStubHandle;
+    tick: (now: number) => void;
+    pending: () => number;
+    errors: string[];
+}
+
+function createSingleWorker(uniforms: Record<string, UniformParam>): SingleWorkerHarness {
+    const canvas = {
+        width: WIDTH,
+        height: HEIGHT,
+        getContext: (): WebGLRenderingContext => stub.gl,
+        addEventListener: (): void => undefined,
+        removeEventListener: (): void => undefined
+    };
+    const offscreen = canvas as unknown as OffscreenCanvas;
+    const stub = createGLStub({ ...GL_STUB_CONFIG, overrides: { canvas: offscreen } });
+
+    const scheduled = new Map<number, (now: number) => void>();
+    let nextHandle = 1;
+    const errors: string[] = [];
+    const listeners: ((event: WorkerBridgeMessageEvent<WorkerToMain>) => void)[] = [];
+
+    const host: WorkerRuntimeHost = {
+        postMessage: message => { listeners.forEach(listener => { listener({ data: message }) }) },
+        requestAnimationFrame: callback => {
+            const handle = nextHandle;
+            nextHandle += 1;
+            scheduled.set(handle, callback);
+            return handle;
+        },
+        cancelAnimationFrame: handle => { scheduled.delete(handle) },
+        now: () => 0
+    };
+
+    const runtime = new WorkerRuntime(host);
+    const transport: WorkerTransport = {
+        postMessage: (message: MainToWorker) => { runtime.handleMessage(message) },
+        addEventListener: (_type, listener) => { listeners.push(listener) }
+    };
+
+    const bridge = new WorkerBridge(
+        transport,
+        {
+            canvas: offscreen,
+            kind: 'single',
+            programConfigs: { [PROGRAM_ID]: CONFIG },
+            uniforms: normalizeWorkerPrograms({ [PROGRAM_ID]: uniforms }),
+            skipDefaultUniforms: false,
+            frameloop: 'always',
+            speed: 1,
+            active: true
+        },
+        { onError: message => { errors.push(message) } }
+    );
+
+    const tick = (now: number): void => {
+        const callbacks = Array.from(scheduled.values());
+        scheduled.clear();
+        callbacks.forEach(callback => { callback(now) });
+    };
+
+    stub.reset();
+    return { bridge, gl: stub, tick, pending: () => scheduled.size, errors };
+}
+
+describe('a motion-gated single-mode worker', () => {
+    it('a continuous invalidate under a static gate draws nothing', async () => {
+        const worker = createSingleWorker(simUniforms());
+
+        worker.bridge.setMotionGate('static');
+        worker.tick(0);
+        worker.gl.reset();
+
+        worker.bridge.invalidate(undefined, 'continuous');
+        await Promise.resolve();
+        expect(worker.pending()).toBe(0);
+        worker.tick(16);
+
+        expect(worker.errors).toEqual([]);
+        expect(uniformStateAtEachDraw(worker.gl)).toHaveLength(0);
+    });
+
+    it('a discrete invalidate after new values draws once with the new values', async () => {
+        const worker = createSingleWorker(simUniforms());
+
+        worker.bridge.setMotionGate('static');
+        worker.tick(0);
+        worker.gl.reset();
+
+        worker.bridge.setUniformValues(PROGRAM_ID, { u_intensity: 0.9 });
+        worker.bridge.invalidate(undefined, 'discrete');
+        await Promise.resolve();
+        expect(worker.pending()).toBe(1);
+        worker.tick(16);
+
+        expect(worker.errors).toEqual([]);
+        const draws = uniformStateAtEachDraw(worker.gl);
+        expect(draws).toHaveLength(1);
+        expect(draws[0].u_intensity).toBe(0.9);
+    });
+
+    it('a static poster drawn after the values are posted paints the posted values, not the init default', () => {
+        const worker = createSingleWorker(simUniforms());
+
+        worker.bridge.setMotionGate('static');
+        worker.bridge.setUniformValues(PROGRAM_ID, { u_intensity: 0.9 });
+        worker.bridge.renderFrame(0);
+
+        expect(worker.errors).toEqual([]);
+        const draws = uniformStateAtEachDraw(worker.gl);
+        expect(draws).toHaveLength(1);
+        expect(draws[0].u_intensity).toBe(0.9);
+    });
+});


### PR DESCRIPTION
Closes the reduced-motion follow-ups filed by #53 and #59: the motion gate could not tell "a live input wants the next frame of a stream" from "something changed, repaint the poster", so it failed in both directions at once.

## The verified diagnosis (probes against master, not code-reading)

- **A gated mount with any vec uniform crashed React's commit.** The gate effect's synchronous `setFrame(staticFrame)` render runs in a child effect, before the parent hook's post-commit effect populates `valuesRef` — the vec dirty-check read `undefined[0]` and threw. `?scene=audio-bars` with OS reduced-motion on (bands >= 2) crashed at mount. Scalars silently uploaded `undefined` in that poster frame instead.
- **Any invalidation producer with its own clock drove gated frames at full rate.** Probe: a function-valued uniform plus an external `FrameInvalidation` requesting per tick (the webcam/rVFC shape, and the shape of a second non-gated engine sharing one audio driver) uploaded `[0,1,2,...,10]` under the gate — full-rate animation with `u_time` frozen, against an OS accessibility setting.
- **Single-engine gated audio did not animate — it starved by accident.** The frozen gate clock plus `analyseIfNeeded`'s monotonic memo killed the chain after one frame. The "suppression" was a coincidence of a re-entrancy guard, not a design; the multi-engine and webcam shapes sailed straight past it.
- **A plain, non-transitioned uniform change never repainted a gated poster.** Set `u_color` to red, the reduced-motion user kept seeing blue, forever. Also true in worker mode, where `setUniformValues` stores values without invalidating — and the worker poster was drawn from `connect()` before the first live values were even posted.

## The fix

`FrameInvalidation` now carries a kind:

```ts
export type InvalidationKind = 'discrete' | 'continuous';
export interface FrameInvalidation {
    connect(invalidate: (kind: InvalidationKind) => void): () => void;
    request(kind?: InvalidationKind): void;
}
```

`request()` defaults to `'discrete'` — the safe direction: an unaware producer wakes the poster, which cannot re-create #53's "reduced-motion user sees nothing at all" bug. `RenderLoop` keeps two pending flags and, under a gate, schedules only on the discrete one; with no gate, scheduling is byte-identical to before. The same `RenderLoop` runs in the worker, so the worker gets the same behavior by carrying the kind through the `invalidate` protocol message (bridge coalescing keeps discrete when kinds mix in one microtask window).

- The audio driver's per-frame sampler request is the one `'continuous'` call site; start/stop/reconfigure/error stay discrete — so `stop()`'s drain-to-0 repaints the poster, and a stopped mic never blocks anything.
- A plain uniform change now diffs against a poster snapshot in the hook's post-commit effect and requests a discrete repaint **only when a gate is active** — the `frameloop='demand'` no-repaint contract is untouched (asserted in the negative direction).
- The gate effect uses a new internal `RenderLoop.pinFrame()` (pin clock + discrete invalidate, no synchronous render), fixing the mount crash; `setFrame` keeps its synchronous contract for handles and capture paths.
- `useWorkerBridge.connect()` posts the gated poster `renderFrame` after `onConnected` posts the first live values, so a gated worker poster paints real values instead of init defaults.
- Gated posters freeze a running audio source at its last sampled values (the gate never reaches into the driver — one driver can feed engines with different gates). The documented opt-in for deliberately motion-ful scenes is component-level `reducedMotion='ignore'`; `useAudioUniforms` deliberately gains no per-source escape hatch.

Input-textures T3 (webcam) inherits the contract for free: a per-decoded-frame producer requests `'continuous'` and the gate holds.

## Tests

984 vitest tests (was 957). New coverage, each verified to fail with its specific fix reverted (reverts spot-checked by two independent review passes): continuous suppression under the gate with an `'ignore'` control proving the suppression is the gate; plain-change poster repaint under `'static'` and `'pause'` plus the demand-contract negative; the gated vec mount (asserts the painted values, not survival); gated audio end-to-end through the real driver/relay/engine/loop chain (catches kind-laundering at any link); **two engines sharing one driver — fails on master, the shipped full-rate case**; devtools override under the gate; kind fan-out/combine, two-flag loop and `pinFrame` units; driver kind classification; worker pipeline gate semantics, bridge coalescing, and the `connect()` message-order test. Playwright counters 19/19, worker e2e 9/9.

## Manual checklist (reduced-motion pass — extends the #56 audio checklist)

With OS reduced-motion ON:
- [ ] `?scene=audio-bars` mounts without crashing and shows a static poster (previously crashed at mount with bands >= 2)
- [ ] starting the mic does NOT animate the poster; the OS mic indicator lights (expected — the user asked for the mic)
- [ ] stopping the mic repaints a drained (zero) poster and clears the OS mic indicator
- [ ] `?scene=reduced-motion`: the new "cycle u_tint" button visibly updates the static poster (plain-uniform repaint)
- [ ] with OS reduced-motion OFF, every scene animates exactly as before

Follow-ups filed (not fixed here): `WorkerRuntime`'s frame-pump stores one kind for a whole multi-frame pump — unreachable today (nothing sends `frames > 1` with a continuous kind), but a future multi-frame producer must carry the kind per frame; the engine's eager `postLiveUniforms` in worker-mode `invalidateAll` stays unconditional (dirty-checked, cheap under a frozen clock) — revisit with input-textures T3 if a webcam makes it measurable.
