### PR TITLE
textures: T3 video + webcam inputs - useVideoTexture, useWebcamTexture, a pump that keeps its kinds honest, and a capture guard that names the culprit

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,8 +592,9 @@ const cam = useWebcamTexture();                                 // never auto-st
   `status: 'idle' | 'loading' | 'ready' | 'error'`. A URL or `MediaStream` input is adopted into a
   hidden element micugl creates `muted` and `playsInline` and auto-plays (browsers only autoplay
   muted video). Pass an `HTMLVideoElement` you own and micugl **never** touches its playback — it
-  only pumps and samples what you play. `crossOrigin` (URL inputs, default `'anonymous'`) and `loop`
-  (owned elements) mirror the image hook.
+  only pumps and samples what you play. `crossOrigin` (default `'anonymous'`) and `loop` (default
+  `false`) apply only to a hidden element micugl creates, so in practice only to URL inputs: `loop`
+  is meaningless on a live `MediaStream` and is never touched on an element you own and play yourself.
 - **`useWebcamTexture(options?)`** returns `{ texture, status, error, start, stop, stream }` with
   `status: 'idle' | 'starting' | 'running' | 'stopped' | 'error'`. It is **explicit start/stop** and
   never auto-starts: opening a camera is a permission moment, so it waits for `start()`. `stop()` and

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ animate everything else from `u_time` inside the shader.
 
 - **useUniformUpdaters(programId, uniforms)** → React memoized uniform updaters
 - **useImageTexture(input, options?)** → { texture, status, error } for the `textures` prop
+- **useVideoTexture(input, options?)** → { texture, status, error, video } for the `textures` prop
+- **useWebcamTexture(options?)** → { texture, status, error, start, stop, stream } for the `textures` prop
 - **usePingPongPasses(options)** → { passes, framebuffers } for engine
 - **useDarkMode()** → boolean dark‑mode flag
 - **useReducedMotion()** → boolean, live `prefers-reduced-motion: reduce` state
@@ -560,6 +562,64 @@ const overlay = useImageTexture(file);
 - **Worker mode.** `textures` under `worker` throws at mount: texture frames decode on the main
   thread and cannot cross to the worker, so it fails loud instead of sampling a blank placeholder.
   Turn worker mode off on that component, or drop `textures`.
+
+### Video and webcam textures
+
+`useVideoTexture` samples a playing `<video>` (a file URL, a `MediaStream`, or an element you own)
+into a `sampler2D`; `useWebcamTexture` opens the camera and feeds it the same way. Both hand back
+the same stable `TextureSource` the `textures` prop expects, and both pump one upload per decoded
+frame — driven by the video's own clock through `requestVideoFrameCallback` (an internal
+`requestAnimationFrame` loop where that is missing), so a paused tab or a `demand` engine costs
+nothing between frames.
+
+```tsx
+const clip = useVideoTexture('https://example.com/clip.mp4');   // URL | MediaStream | HTMLVideoElement | null
+const cam = useWebcamTexture();                                 // never auto-starts
+
+<button onClick={() => cam.start()}>Enable camera</button>
+<button onClick={cam.stop}>Disable camera</button>
+
+<BaseShaderComponent
+  programId="scene"
+  shaderConfig={config}
+  uniforms={{}}
+  textures={{ cam: cam.texture }}                               // -> u_cam (unit 0)
+  frameloop="demand"
+/>
+```
+
+- **`useVideoTexture(input, options?)`** returns `{ texture, status, error, video }` with
+  `status: 'idle' | 'loading' | 'ready' | 'error'`. A URL or `MediaStream` input is adopted into a
+  hidden element micugl creates `muted` and `playsInline` and auto-plays (browsers only autoplay
+  muted video). Pass an `HTMLVideoElement` you own and micugl **never** touches its playback — it
+  only pumps and samples what you play. `crossOrigin` (URL inputs, default `'anonymous'`) and `loop`
+  (owned elements) mirror the image hook.
+- **`useWebcamTexture(options?)`** returns `{ texture, status, error, start, stop, stream }` with
+  `status: 'idle' | 'starting' | 'running' | 'stopped' | 'error'`. It is **explicit start/stop** and
+  never auto-starts: opening a camera is a permission moment, so it waits for `start()`. `stop()` and
+  unmount end every track, so the OS camera indicator clears. `deviceId`, `facingMode`, `width` and
+  `height` pass straight through to the constraints; the constraints always set `audio: false` (there
+  is no option to record audio). Changing those constraints on a live hook throws — give the
+  component a `key` that changes with them so React remounts it and stops the old camera.
+- **Permissions and secure context.** `getUserMedia` only exists in a secure context: serve over
+  `https`, or from `localhost`. A denied or unavailable camera reaches `status: 'error'` and, with no
+  `onError`, re-throws during render to your nearest error boundary — same convention as the image
+  hook.
+- **Reduced motion.** The first decoded frame requests a *discrete* repaint and every frame after it
+  a *continuous* one, so a motion-gated scene paints one frozen poster of the opening frame and then
+  stays still, instead of either animating or showing black.
+- **Capture semantics.** A playing video or a running webcam is wall-clock-dependent, so
+  `renderToBlob({ frame })` and `renderSequence` **throw** — a synthesized frame number cannot
+  reproduce a live picture. Pause the video or `stop()` the camera first for a deterministic export.
+  The live-clock paths — `renderToBlob()` with no frame, `record()`, `captureStream()` — capture the
+  live picture and stay available (the "capture button on a webcam filter" case).
+- **`resizeToPOT`.** Supported, and lazy: the power-of-two copy is drawn at most once per decoded
+  frame, reusing one canvas until the video's dimensions change. It legalizes `REPEAT` wrap and
+  mipmap min-filters, but a mipmapped video regenerates mipmaps on every upload — that is a per-frame
+  cost on top of the per-frame copy, so leave the default `LINEAR` filter unless you need it.
+- **SSR.** Importing the hooks touches no browser global, and `getUserMedia` / the element are read
+  lazily inside `start()` / the mount effect, so the hooks render on the server and only reach for the
+  camera in the browser.
 
 ## Worker rendering (OffscreenCanvas)
 

--- a/demo/scenes/Webcam.tsx
+++ b/demo/scenes/Webcam.tsx
@@ -1,0 +1,96 @@
+import { useRef, useState } from 'react';
+
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '../../src/react/components/base/BaseShaderComponent';
+import { useWebcamTexture } from '../../src/react/hooks/useWebcamTexture';
+import type { ShaderHandle } from '../../src/types';
+import { QUAD_VERTEX } from './shaders';
+
+const FRAGMENT = `
+    precision highp float;
+    uniform sampler2D u_cam;
+    varying vec2 v_uv;
+    void main() {
+        vec2 uv = vec2(1.0 - v_uv.x, v_uv.y);
+        vec3 cam = texture2D(u_cam, uv).rgb;
+        float luma = dot(cam, vec3(0.299, 0.587, 0.114));
+        float bands = step(0.5, fract(uv.y * 24.0));
+        vec3 tint = mix(vec3(0.1, 0.4, 0.9), vec3(1.0, 0.6, 0.2), luma);
+        vec3 filtered = mix(cam, cam * tint * 1.6, 0.6);
+        gl_FragColor = vec4(mix(filtered, filtered * 0.7, bands), 1.0);
+    }
+`;
+
+const config = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: FRAGMENT
+});
+
+const downloadBlob = (blob: Blob, filename: string): void => {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+    URL.revokeObjectURL(url);
+};
+
+export const Webcam = () => {
+    const handleRef = useRef<ShaderHandle>(null);
+    const [error, setError] = useState<string | null>(null);
+    const cam = useWebcamTexture({
+        onError: caught => { setError(caught instanceof Error ? caught.message : String(caught)) }
+    });
+
+    const enable = (): void => {
+        setError(null);
+        void cam.start();
+    };
+
+    const capture = async (): Promise<void> => {
+        const blob = await handleRef.current?.renderToBlob();
+        if (blob) {
+            downloadBlob(blob, 'webcam.png');
+        }
+    };
+
+    return (
+        <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
+            <BaseShaderComponent
+                ref={handleRef}
+                programId='webcam'
+                shaderConfig={config}
+                uniforms={{}}
+                textures={{ cam: cam.texture }}
+                frameloop='demand'
+                style={{ width: '100%', height: '100%', display: 'block' }}
+            />
+            <div
+                style={{
+                    position: 'absolute',
+                    top: '12px',
+                    left: '12px',
+                    padding: '8px 12px',
+                    background: 'rgba(0, 0, 0, 0.6)',
+                    color: '#fff',
+                    fontFamily: 'monospace',
+                    fontSize: '12px',
+                    borderRadius: '4px',
+                    lineHeight: 1.6,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '6px',
+                    alignItems: 'flex-start'
+                }}
+            >
+                <div>camera status: {cam.status}</div>
+                {error !== null && <div>error: {error}</div>}
+                <div style={{ display: 'flex', gap: '6px' }}>
+                    <button type='button' onClick={enable}>Enable camera</button>
+                    <button type='button' onClick={() => { cam.stop() }}>Disable camera</button>
+                </div>
+                <button type='button' onClick={() => { void capture() }}>Capture PNG</button>
+            </div>
+        </div>
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -16,6 +16,7 @@ import { RerenderStorm } from './RerenderStorm';
 import { StaticIdle } from './StaticIdle';
 import { Transitions } from './Transitions';
 import { VisualFixed } from './VisualFixed';
+import { Webcam } from './Webcam';
 import { WorkerContextLoss } from './WorkerContextLoss';
 import { WorkerJank } from './WorkerJank';
 
@@ -33,6 +34,7 @@ export const scenes: Record<string, ComponentType> = {
     'visual-fixed': VisualFixed,
     'export-demo': ExportDemo,
     'image-texture': ImageTexture,
+    'webcam': Webcam,
     'instanced-particles': InstancedParticles,
     'particles-components': ParticlesComponents,
     'worker-jank': WorkerJank,

--- a/e2e/webcam.spec.ts
+++ b/e2e/webcam.spec.ts
@@ -1,0 +1,76 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import type { GlCountersData } from '../src/testing/glCounters';
+import { instrumentationInitScript } from '../src/testing/glCounters';
+import { differingPixelFraction } from './pixels';
+import { DEV_URL } from './servers';
+
+const NOISE_TOLERANCE = 24;
+const SETTLE_MS = 250;
+
+test.use({
+    launchOptions: {
+        args: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream']
+    }
+});
+
+interface PageWatch {
+    pageErrors: string[];
+    consoleErrors: string[];
+}
+
+const watchPage = (page: Page): PageWatch => {
+    const watch: PageWatch = { pageErrors: [], consoleErrors: [] };
+    page.on('pageerror', error => watch.pageErrors.push(error.message));
+    page.on('console', message => {
+        if (message.type() === 'error') {
+            watch.consoleErrors.push(message.text());
+        }
+    });
+    return watch;
+};
+
+const uploadCount = async (page: Page): Promise<number> => {
+    const counters: GlCountersData = await page.evaluate(
+        () => window.__micuglInstrumentation.counters.snapshot()
+    );
+    return counters.texImage2D;
+};
+
+test('the webcam scene renders a live camera and freezes when disabled', async ({ page }) => {
+    const watch = watchPage(page);
+    await page.addInitScript({ content: instrumentationInitScript });
+    await page.goto(`${DEV_URL}/?scene=webcam`, { waitUntil: 'domcontentloaded' });
+
+    const canvas = page.locator('canvas').first();
+    await canvas.waitFor({ state: 'attached' });
+
+    await page.getByRole('button', { name: 'Enable camera' }).click();
+    await expect(page.getByText('camera status: running')).toBeVisible({ timeout: 10_000 });
+
+    const uploadsBeforeMotion = await uploadCount(page);
+
+    await expect
+        .poll(async () => {
+            const first = await canvas.screenshot();
+            await page.waitForTimeout(120);
+            const second = await canvas.screenshot();
+            return differingPixelFraction(first, second, NOISE_TOLERANCE);
+        }, { message: 'the enabled webcam canvas never changed across two samples', timeout: 10_000 })
+        .toBeGreaterThan(0);
+
+    const uploadsAfterMotion = await uploadCount(page);
+    expect(uploadsAfterMotion).toBeGreaterThan(uploadsBeforeMotion);
+
+    await page.getByRole('button', { name: 'Disable camera' }).click();
+    await expect(page.getByText('camera status: stopped')).toBeVisible({ timeout: 10_000 });
+
+    await page.waitForTimeout(SETTLE_MS);
+    const frozenBefore = await canvas.screenshot();
+    await page.waitForTimeout(SETTLE_MS);
+    const frozenAfter = await canvas.screenshot();
+
+    expect(differingPixelFraction(frozenBefore, frozenAfter, NOISE_TOLERANCE)).toBe(0);
+
+    expect(watch.pageErrors).toEqual([]);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,15 @@ export type {
     AudioUniformsResult,
     ImageTextureDeps,
     ImageTextureOptions,
-    ImageTextureResult
+    ImageTextureResult,
+    VideoInput,
+    VideoTextureDeps,
+    VideoTextureOptions,
+    VideoTextureResult,
+    WebcamStatus,
+    WebcamTextureDeps,
+    WebcamTextureOptions,
+    WebcamTextureResult
 } from './react';
 export {
     BaseInstancedShaderComponent,
@@ -47,7 +55,9 @@ export {
     usePingPongPasses,
     useReducedMotion,
     useSaveData,
-    useUniformUpdaters
+    useUniformUpdaters,
+    useVideoTexture,
+    useWebcamTexture
 } from './react';
 export type {
     ActiveUniform,

--- a/src/react/components/base/BaseInstancedShaderComponent.tsx
+++ b/src/react/components/base/BaseInstancedShaderComponent.tsx
@@ -1,11 +1,12 @@
 import type { CSSProperties } from 'react';
-import { forwardRef, memo, useMemo, useRef } from 'react';
+import { forwardRef, memo, useCallback, useMemo, useRef } from 'react';
 
 import type { RenderOptions, ShaderProgramConfig, ShaderRenderCallback } from '@/core';
 import { combineFrameInvalidation } from '@/core';
 import { ShaderEngine } from '@/react';
 import { useTextureBindings } from '@/react/hooks/useTextureBindings';
 import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
+import type { CapturesAreNonReproducible } from '@/react/lib/captureLiveness';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import type {
     InstanceAttribute,
@@ -68,7 +69,7 @@ const BaseInstancedShaderComponentImpl = forwardRef<ShaderHandle, BaseInstancedS
     style,
     renderOptions = RENDER_OPTIONS
 }, ref) => {
-    const { updaters, port, invalidation, capturesAreNonReproducible } = useUniformUpdaters(
+    const { updaters, port, invalidation, capturesAreNonReproducible: uniformsAreNonReproducible } = useUniformUpdaters(
         programId,
         uniforms,
         { skipDefaultUniforms, reducedMotion, saveData }
@@ -76,12 +77,17 @@ const BaseInstancedShaderComponentImpl = forwardRef<ShaderHandle, BaseInstancedS
     const {
         bindings,
         invalidation: textureInvalidation,
-        config: augmentedConfig
+        config: augmentedConfig,
+        texturesAreNonReproducible
     } = useTextureBindings(textures, shaderConfig);
     const programConfigs = { [programId]: augmentedConfig };
     const combinedInvalidation = useMemo(
         () => (textureInvalidation ? combineFrameInvalidation([invalidation, textureInvalidation]) : invalidation),
         [invalidation, textureInvalidation]
+    );
+    const capturesAreNonReproducible = useCallback<CapturesAreNonReproducible>(
+        () => uniformsAreNonReproducible() ?? (texturesAreNonReproducible() ? 'texture' : null),
+        [uniformsAreNonReproducible, texturesAreNonReproducible]
     );
     const debugPortRef = useRef<UniformDebugPort | null>(null);
     debugPortRef.current = port;

--- a/src/react/components/base/BaseShaderComponent.tsx
+++ b/src/react/components/base/BaseShaderComponent.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from 'react';
-import { forwardRef, memo, useMemo, useRef } from 'react';
+import { forwardRef, memo, useCallback, useMemo, useRef } from 'react';
 
 import type { RenderOptions, ShaderProgramConfig, ShaderRenderCallback } from '@/core';
 import { combineFrameInvalidation } from '@/core';
@@ -7,6 +7,7 @@ import { ShaderEngine } from '@/react';
 import type { ShaderEngineWorkerProps } from '@/react/components/engine/ShaderEngine';
 import { useTextureBindings } from '@/react/hooks/useTextureBindings';
 import { useUniformUpdaters } from '@/react/hooks/useUniformUpdaters';
+import type { CapturesAreNonReproducible } from '@/react/lib/captureLiveness';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import type { RenderControlProps, ShaderHandle, TextureSource, UniformParam } from '@/types';
 
@@ -62,7 +63,7 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     style,
     renderOptions = RENDER_OPTIONS
 }, ref) => {
-    const { updaters, port, invalidation, capturesAreNonReproducible } = useUniformUpdaters(
+    const { updaters, port, invalidation, capturesAreNonReproducible: uniformsAreNonReproducible } = useUniformUpdaters(
         programId,
         uniforms,
         { skipDefaultUniforms, reducedMotion, saveData }
@@ -70,12 +71,17 @@ const BaseShaderComponentImpl = forwardRef<ShaderHandle, BaseShaderProps>(({
     const {
         bindings,
         invalidation: textureInvalidation,
-        config: augmentedConfig
+        config: augmentedConfig,
+        texturesAreNonReproducible
     } = useTextureBindings(textures, shaderConfig);
     const programConfigs = { [programId]: augmentedConfig };
     const combinedInvalidation = useMemo(
         () => (textureInvalidation ? combineFrameInvalidation([invalidation, textureInvalidation]) : invalidation),
         [invalidation, textureInvalidation]
+    );
+    const capturesAreNonReproducible = useCallback<CapturesAreNonReproducible>(
+        () => uniformsAreNonReproducible() ?? (texturesAreNonReproducible() ? 'texture' : null),
+        [uniformsAreNonReproducible, texturesAreNonReproducible]
     );
     const debugPortRef = useRef<UniformDebugPort | null>(null);
     debugPortRef.current = port;

--- a/src/react/hooks/index.ts
+++ b/src/react/hooks/index.ts
@@ -6,3 +6,17 @@ export { usePingPongPasses } from './usePingPongPasses';
 export { useReducedMotion } from './useReducedMotion';
 export { useSaveData } from './useSaveData';
 export { useUniformUpdaters } from './useUniformUpdaters';
+export type {
+    VideoInput,
+    VideoTextureDeps,
+    VideoTextureOptions,
+    VideoTextureResult
+} from './useVideoTexture';
+export { useVideoTexture } from './useVideoTexture';
+export type {
+    WebcamStatus,
+    WebcamTextureDeps,
+    WebcamTextureOptions,
+    WebcamTextureResult
+} from './useWebcamTexture';
+export { useWebcamTexture } from './useWebcamTexture';

--- a/src/react/hooks/useTextureBindings.ts
+++ b/src/react/hooks/useTextureBindings.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
+import type { NonReproducible } from '@/react/lib/captureLiveness';
 import { augmentConfigWithSamplers, buildTextureBindings } from '@/react/lib/textureBindings';
 import type { ShaderProgramConfig, TextureBindingSpec, TextureSource } from '@/types';
 
@@ -9,6 +10,20 @@ export interface TextureBindingsResult {
     bindings: TextureBindingSpec[] | undefined;
     invalidation: FrameInvalidation | null;
     config: ShaderProgramConfig;
+    texturesAreNonReproducible: () => boolean;
+}
+
+function collectNonReproducible(bindings: TextureBindingSpec[] | undefined): NonReproducible[] {
+    if (!bindings) {
+        return [];
+    }
+    const predicates: NonReproducible[] = [];
+    for (const binding of bindings) {
+        if (binding.source.nonReproducible) {
+            predicates.push(binding.source.nonReproducible);
+        }
+    }
+    return predicates;
 }
 
 export function useTextureBindings(
@@ -20,6 +35,14 @@ export function useTextureBindings(
     const relayedRef = useRef(new Map<FrameInvalidation, () => void>());
 
     const bindings = textures ? buildTextureBindings(textures) : undefined;
+
+    const nonReproducibleRef = useRef<NonReproducible[]>([]);
+    nonReproducibleRef.current = collectNonReproducible(bindings);
+
+    const texturesAreNonReproducible = useCallback(
+        () => nonReproducibleRef.current.some(isLive => isLive()),
+        []
+    );
 
     useEffect(() => {
         const relayed = relayedRef.current;
@@ -49,6 +72,7 @@ export function useTextureBindings(
     return {
         bindings,
         invalidation: textures ? fanIn : null,
-        config: bindings ? augmentConfigWithSamplers(config, bindings) : config
+        config: bindings ? augmentConfigWithSamplers(config, bindings) : config,
+        texturesAreNonReproducible
     };
 }

--- a/src/react/hooks/useVideoTexture.test.tsx
+++ b/src/react/hooks/useVideoTexture.test.tsx
@@ -1,0 +1,306 @@
+import { act, Component, type ReactElement, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { VideoInput, VideoTextureDeps } from '@/react/hooks/useVideoTexture';
+import { useVideoTexture } from '@/react/hooks/useVideoTexture';
+import type { FakeVideo } from '@/react/lib/fakeVideo';
+import { asVideoElement, makeFakeVideo, makeRvfcScheduler } from '@/react/lib/fakeVideo';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+
+const PROGRAM_ID = 'video-demo';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let originalGetContext: unknown;
+let originalToBlob: unknown;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stub = createGLStub({ extensions: { ANGLE_instanced_arrays: true } });
+
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown; toBlob: unknown };
+    originalGetContext = canvasProto.getContext;
+    originalToBlob = canvasProto.toBlob;
+    canvasProto.getContext = function stubGetContext(type: string): unknown {
+        return type === '2d' ? { putImageData: () => undefined, drawImage: () => undefined } : stub.gl;
+    };
+    canvasProto.toBlob = function stubToBlob(callback: (blob: Blob) => void, type?: string): void {
+        callback(new Blob([], { type: type ?? 'image/png' }));
+    };
+
+    originalMatchMedia = window.matchMedia;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown; toBlob: unknown };
+    canvasProto.getContext = originalGetContext;
+    canvasProto.toBlob = originalToBlob;
+    if (originalMatchMedia) {
+        window.matchMedia = originalMatchMedia;
+    }
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+function mockReducedMotionActive(): void {
+    window.matchMedia = ((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false
+    })) as unknown as typeof window.matchMedia;
+}
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_color: 'float' }
+});
+
+function fullUploads(): { width: number; height: number }[] {
+    return stub.texImage2DCalls
+        .filter(call => call.width !== 1 || call.height !== 1)
+        .map(call => ({ width: call.width, height: call.height }));
+}
+
+function count(name: string): number {
+    return stub.calls.filter(call => call.name === name).length;
+}
+
+function uploadCount(): number {
+    return fullUploads().length + stub.texSubImage2DCalls.length;
+}
+
+interface SceneProps {
+    input: VideoInput | null;
+    deps: VideoTextureDeps;
+    onError?: (error: unknown) => void;
+    statuses?: string[];
+    reducedMotion?: 'static-frame' | 'pause' | 'ignore';
+    frameloop?: 'always' | 'demand' | 'never';
+}
+
+const VideoScene = ({ input, deps, onError, statuses, reducedMotion, frameloop }: SceneProps) => {
+    const video = useVideoTexture(input, { deps, onError });
+    statuses?.push(video.status);
+    return (
+        <BaseShaderComponent
+            programId={PROGRAM_ID}
+            shaderConfig={CONFIG}
+            uniforms={{ u_color: { type: 'float', value: 0.5 } }}
+            textures={{ cam: video.texture }}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop={frameloop}
+            reducedMotion={reducedMotion}
+            saveData='ignore'
+        />
+    );
+};
+
+class ErrorBoundary extends Component<{ children: ReactNode; onError: (error: unknown) => void }, { failed: boolean }> {
+    state = { failed: false };
+
+    static getDerivedStateFromError(): { failed: boolean } {
+        return { failed: true };
+    }
+
+    componentDidCatch(error: unknown): void {
+        this.props.onError(error);
+    }
+
+    render(): ReactNode {
+        return this.state.failed ? null : this.props.children;
+    }
+}
+
+describe('useVideoTexture: kind honesty under a reduced-motion gate (H4)', () => {
+    it('paints one poster on the first decoded frame and suppresses the continuous frames after it', async () => {
+        mockReducedMotionActive();
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo();
+        const deps: VideoTextureDeps = {
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        };
+
+        await mount(<VideoScene input={asVideoElement(video)} deps={deps} />);
+
+        act(() => { frames.tick(0) });
+        const posters = count('drawArrays');
+        expect(posters).toBeGreaterThan(0);
+
+        act(() => { rvfc.fire() });
+        expect(frames.pending()).toBe(1);
+        act(() => { frames.tick(16) });
+        expect(count('drawArrays')).toBe(posters + 1);
+        expect(fullUploads()).toEqual([{ width: 640, height: 480 }]);
+
+        for (let i = 0; i < 4; i++) {
+            act(() => { rvfc.fire() });
+            expect(frames.pending()).toBe(0);
+        }
+        expect(fullUploads()).toEqual([{ width: 640, height: 480 }]);
+    });
+
+    it('uploads every decoded frame when reduced motion is ignored', async () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo();
+        const deps: VideoTextureDeps = {
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        };
+
+        await mount(<VideoScene input={asVideoElement(video)} deps={deps} reducedMotion='ignore' frameloop='demand' />);
+        act(() => { frames.tick(0) });
+        const base = uploadCount();
+
+        for (let i = 1; i <= 3; i++) {
+            act(() => { rvfc.fire() });
+            expect(frames.pending()).toBe(1);
+            act(() => { frames.tick(16 * i) });
+        }
+
+        expect(uploadCount()).toBe(base + 3);
+    });
+});
+
+describe('useVideoTexture: demand mode (H5)', () => {
+    it('wakes exactly one render and one upload per decoded frame, and skips a tick with no new frame', async () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo();
+        const deps: VideoTextureDeps = {
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        };
+
+        await mount(<VideoScene input={asVideoElement(video)} deps={deps} reducedMotion='ignore' frameloop='demand' />);
+        act(() => { frames.tick(0) });
+
+        act(() => { rvfc.fire() });
+        expect(frames.pending()).toBe(1);
+        act(() => { frames.tick(16) });
+        expect(fullUploads()).toHaveLength(1);
+        const draws = count('drawArrays');
+
+        act(() => { frames.tick(32) });
+        expect(fullUploads()).toHaveLength(1);
+        expect(count('drawArrays')).toBe(draws);
+    });
+});
+
+describe('useVideoTexture: the adopted-element contract (H10)', () => {
+    it('never plays or pauses a caller-owned video, yet still pumps and uploads its frames', async () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo();
+        const deps: VideoTextureDeps = {
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel,
+            createVideo: () => { throw new Error('an adopted element must never be re-created') }
+        };
+
+        await mount(<VideoScene input={asVideoElement(video)} deps={deps} reducedMotion='ignore' frameloop='demand' />);
+        act(() => { frames.tick(0) });
+
+        act(() => { rvfc.fire() });
+        act(() => { frames.tick(16) });
+
+        expect(fullUploads()).toHaveLength(1);
+        expect(video.playCalls).toBe(0);
+        expect(video.pauseCalls).toBe(0);
+    });
+});
+
+describe('useVideoTexture: the error surface (H9)', () => {
+    it('re-throws a URL video error during render when no onError is supplied', async () => {
+        const rvfc = makeRvfcScheduler();
+        let created: FakeVideo | null = null;
+        const deps: VideoTextureDeps = {
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel,
+            createVideo: () => { created = makeFakeVideo({ readyState: 0, videoWidth: 0, videoHeight: 0 }); return asVideoElement(created) }
+        };
+        let boundaryError: unknown = null;
+
+        await mount(
+            <ErrorBoundary onError={error => { boundaryError = error }}>
+                <VideoScene input='https://example.test/clip.mp4' deps={deps} reducedMotion='ignore' frameloop='demand' />
+            </ErrorBoundary>
+        );
+
+        expect(created).not.toBeNull();
+        await act(async () => {
+            (created as unknown as FakeVideo).error = { code: 4 };
+            (created as unknown as FakeVideo).emitError();
+            await Promise.resolve();
+        });
+
+        expect(boundaryError).toBeInstanceOf(Error);
+        expect((boundaryError as Error).message).toContain('failed to load');
+    });
+
+    it('reports a URL video error through onError without throwing when one is supplied', async () => {
+        const rvfc = makeRvfcScheduler();
+        let created: FakeVideo | null = null;
+        const deps: VideoTextureDeps = {
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel,
+            createVideo: () => { created = makeFakeVideo({ readyState: 0, videoWidth: 0, videoHeight: 0 }); return asVideoElement(created) }
+        };
+        const reports: unknown[] = [];
+        let boundaryError: unknown = null;
+
+        await mount(
+            <ErrorBoundary onError={error => { boundaryError = error }}>
+                <VideoScene
+                    input='https://example.test/clip.mp4'
+                    deps={deps}
+                    onError={error => { reports.push(error) }}
+                    reducedMotion='ignore'
+                    frameloop='demand'
+                />
+            </ErrorBoundary>
+        );
+
+        await act(async () => {
+            (created as unknown as FakeVideo).emitError();
+            await Promise.resolve();
+        });
+
+        expect(boundaryError).toBeNull();
+        expect(reports).toHaveLength(1);
+        expect(reports[0]).toBeInstanceOf(Error);
+    });
+});

--- a/src/react/hooks/useVideoTexture.test.tsx
+++ b/src/react/hooks/useVideoTexture.test.tsx
@@ -169,11 +169,12 @@ describe('useVideoTexture: kind honesty under a reduced-motion gate (H4)', () =>
         expect(count('drawArrays')).toBe(posters + 1);
         expect(fullUploads()).toEqual([{ width: 640, height: 480 }]);
 
+        const uploadsBefore = uploadCount();
         for (let i = 0; i < 4; i++) {
             act(() => { rvfc.fire() });
             expect(frames.pending()).toBe(0);
         }
-        expect(fullUploads()).toEqual([{ width: 640, height: 480 }]);
+        expect(uploadCount()).toBe(uploadsBefore);
     });
 
     it('uploads every decoded frame when reduced motion is ignored', async () => {
@@ -274,6 +275,35 @@ describe('useVideoTexture: the adopted-element contract (H10)', () => {
         expect(fullUploads()).toHaveLength(1);
         expect(video.playCalls).toBe(0);
         expect(video.pauseCalls).toBe(0);
+    });
+});
+
+describe('useVideoTexture: the placeholder-then-first-frame path through the real component', () => {
+    it('uploads only the placeholder while the element has no decoded frame, then the real frame once it decodes', async () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo({ readyState: 0, videoWidth: 0, videoHeight: 0 });
+        const deps: VideoTextureDeps = {
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        };
+
+        await mount(<VideoScene input={asVideoElement(video)} deps={deps} reducedMotion='ignore' frameloop='demand' />);
+        act(() => { frames.tick(0) });
+
+        act(() => { rvfc.fire() });
+        expect(frames.pending()).toBe(0);
+        expect(fullUploads()).toEqual([]);
+
+        act(() => {
+            video.readyState = 2;
+            video.videoWidth = 640;
+            video.videoHeight = 480;
+            rvfc.fire();
+        });
+        expect(frames.pending()).toBe(1);
+        act(() => { frames.tick(16) });
+
+        expect(fullUploads()).toEqual([{ width: 640, height: 480 }]);
     });
 });
 

--- a/src/react/hooks/useVideoTexture.test.tsx
+++ b/src/react/hooks/useVideoTexture.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
 import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
 import type { VideoInput, VideoTextureDeps } from '@/react/hooks/useVideoTexture';
 import { useVideoTexture } from '@/react/hooks/useVideoTexture';
@@ -197,27 +198,60 @@ describe('useVideoTexture: kind honesty under a reduced-motion gate (H4)', () =>
     });
 });
 
+const WAKE_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_color: 'float', u_wake: 'float' }
+});
+
 describe('useVideoTexture: demand mode (H5)', () => {
-    it('wakes exactly one render and one upload per decoded frame, and skips a tick with no new frame', async () => {
+    it('wakes one render and one upload per decoded frame, and does not re-upload on a render woken with no new frame', async () => {
         const rvfc = makeRvfcScheduler();
         const video = makeFakeVideo();
+        const element = asVideoElement(video);
+        const wake = createFrameInvalidation();
         const deps: VideoTextureDeps = {
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         };
 
-        await mount(<VideoScene input={asVideoElement(video)} deps={deps} reducedMotion='ignore' frameloop='demand' />);
+        const Scene = () => {
+            const source = useVideoTexture(element, { deps });
+            return (
+                <BaseShaderComponent
+                    programId={PROGRAM_ID}
+                    shaderConfig={WAKE_CONFIG}
+                    uniforms={{
+                        u_color: { type: 'float', value: 0.5 },
+                        u_wake: { type: 'float', value: 0.5, invalidation: wake }
+                    }}
+                    textures={{ cam: source.texture }}
+                    width={WIDTH}
+                    height={HEIGHT}
+                    useDevicePixelRatio={false}
+                    frameloop='demand'
+                    reducedMotion='ignore'
+                    saveData='ignore'
+                />
+            );
+        };
+
+        await mount(<Scene />);
         act(() => { frames.tick(0) });
 
         act(() => { rvfc.fire() });
         expect(frames.pending()).toBe(1);
         act(() => { frames.tick(16) });
-        expect(fullUploads()).toHaveLength(1);
+        const uploadsBefore = uploadCount();
+        expect(uploadsBefore).toBeGreaterThan(0);
         const draws = count('drawArrays');
 
+        act(() => { wake.request('discrete') });
+        expect(frames.pending()).toBe(1);
         act(() => { frames.tick(32) });
-        expect(fullUploads()).toHaveLength(1);
-        expect(count('drawArrays')).toBe(draws);
+
+        expect(count('drawArrays')).toBe(draws + 1);
+        expect(uploadCount()).toBe(uploadsBefore);
     });
 });
 

--- a/src/react/hooks/useVideoTexture.ts
+++ b/src/react/hooks/useVideoTexture.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+
+import { resolveSourceTextureOptions } from '@/core/lib/sourceTextureOptions';
+import type {
+    VideoInput,
+    VideoTextureDriver,
+    VideoTextureDriverConfig,
+    VideoTextureDriverDeps
+} from '@/react/lib/videoTextureDriver';
+import { createVideoTextureDriver } from '@/react/lib/videoTextureDriver';
+import type { SourceTextureOptions, TextureSource, TextureStatus } from '@/types';
+
+export type { VideoInput } from '@/react/lib/videoTextureDriver';
+
+export type VideoTextureDeps = VideoTextureDriverDeps;
+
+export interface VideoTextureOptions extends SourceTextureOptions {
+    resizeToPOT?: boolean;
+    crossOrigin?: string;
+    loop?: boolean;
+    onError?: (error: unknown) => void;
+    deps?: VideoTextureDeps;
+}
+
+export interface VideoTextureResult {
+    texture: TextureSource;
+    status: TextureStatus;
+    error: unknown;
+    video: HTMLVideoElement | null;
+}
+
+let videoTextureCounter = 0;
+
+const getServerStatus = (): TextureStatus => 'idle';
+const getServerError = (): unknown => null;
+const getServerVideo = (): HTMLVideoElement | null => null;
+
+export function useVideoTexture(input: VideoInput | null, options?: VideoTextureOptions): VideoTextureResult {
+    const resolved = resolveSourceTextureOptions(options);
+    const resizeToPOT = options?.resizeToPOT ?? false;
+    const optionsKey = `${JSON.stringify(resolved)}|${String(resizeToPOT)}`;
+
+    const idRef = useRef('');
+    if (idRef.current === '') {
+        videoTextureCounter += 1;
+        idRef.current = `video-texture-${String(videoTextureCounter)}`;
+    }
+
+    const configRef = useRef<VideoTextureDriverConfig>({
+        crossOrigin: options?.crossOrigin ?? 'anonymous',
+        loop: options?.loop ?? false,
+        resizeToPOT,
+        onError: options?.onError
+    });
+    configRef.current.crossOrigin = options?.crossOrigin ?? 'anonymous';
+    configRef.current.loop = options?.loop ?? false;
+    configRef.current.resizeToPOT = resizeToPOT;
+    configRef.current.onError = options?.onError;
+
+    const driverRef = useRef<VideoTextureDriver | null>(null);
+    driverRef.current ??= createVideoTextureDriver(configRef.current, options?.deps);
+    const driver = driverRef.current;
+
+    const nonReproducible = useCallback(() => driver.playing(), [driver]);
+
+    const sourceRef = useRef<TextureSource | null>(null);
+    const mintedOptionsKeyRef = useRef('');
+    if (sourceRef.current === null || mintedOptionsKeyRef.current !== optionsKey) {
+        mintedOptionsKeyRef.current = optionsKey;
+        sourceRef.current = {
+            id: idRef.current,
+            get version() { return driver.version },
+            options: resolved,
+            getFrame: () => driver.getFrame(),
+            invalidation: driver.invalidation,
+            nonReproducible
+        };
+    }
+    const source = sourceRef.current;
+
+    useEffect(() => {
+        if (input === null) {
+            driver.stop();
+            return;
+        }
+        driver.start(input);
+        return () => { driver.stop() };
+    }, [driver, input, optionsKey]);
+
+    const status = useSyncExternalStore(driver.subscribe, () => driver.status, getServerStatus);
+    const error = useSyncExternalStore(driver.subscribe, () => driver.error, getServerError);
+    const video = useSyncExternalStore(driver.subscribe, () => driver.video, getServerVideo);
+
+    if (status === 'error' && options?.onError === undefined) {
+        throw error;
+    }
+
+    return { texture: source, status, error, video };
+}

--- a/src/react/hooks/useVideoTexture.ts
+++ b/src/react/hooks/useVideoTexture.ts
@@ -38,7 +38,9 @@ const getServerVideo = (): HTMLVideoElement | null => null;
 export function useVideoTexture(input: VideoInput | null, options?: VideoTextureOptions): VideoTextureResult {
     const resolved = resolveSourceTextureOptions(options);
     const resizeToPOT = options?.resizeToPOT ?? false;
-    const optionsKey = `${JSON.stringify(resolved)}|${String(resizeToPOT)}`;
+    const crossOrigin = options?.crossOrigin ?? 'anonymous';
+    const loop = options?.loop ?? false;
+    const optionsKey = `${JSON.stringify(resolved)}|${String(resizeToPOT)}|${crossOrigin}|${String(loop)}`;
 
     const idRef = useRef('');
     if (idRef.current === '') {
@@ -47,13 +49,13 @@ export function useVideoTexture(input: VideoInput | null, options?: VideoTexture
     }
 
     const configRef = useRef<VideoTextureDriverConfig>({
-        crossOrigin: options?.crossOrigin ?? 'anonymous',
-        loop: options?.loop ?? false,
+        crossOrigin,
+        loop,
         resizeToPOT,
         onError: options?.onError
     });
-    configRef.current.crossOrigin = options?.crossOrigin ?? 'anonymous';
-    configRef.current.loop = options?.loop ?? false;
+    configRef.current.crossOrigin = crossOrigin;
+    configRef.current.loop = loop;
     configRef.current.resizeToPOT = resizeToPOT;
     configRef.current.onError = options?.onError;
 

--- a/src/react/hooks/useWebcamTexture.test.tsx
+++ b/src/react/hooks/useWebcamTexture.test.tsx
@@ -270,7 +270,11 @@ describe('useWebcamTexture: StrictMode never double-prompts (H6)', () => {
         });
 
         await mount(<StrictMode><WebcamScene deps={deps} control={control} /></StrictMode>);
-        await act(async () => { await control.start?.() });
+        await act(async () => {
+            const first = control.start?.();
+            const second = control.start?.();
+            await Promise.all([first, second]);
+        });
 
         expect(calls).toBe(1);
         expect(control.status).toBe('running');

--- a/src/react/hooks/useWebcamTexture.test.tsx
+++ b/src/react/hooks/useWebcamTexture.test.tsx
@@ -1,0 +1,447 @@
+import { act, Component, type ReactElement, type ReactNode, StrictMode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import type { VideoTextureDeps } from '@/react/hooks/useVideoTexture';
+import { useVideoTexture } from '@/react/hooks/useVideoTexture';
+import type { WebcamTextureDeps } from '@/react/hooks/useWebcamTexture';
+import { useWebcamTexture } from '@/react/hooks/useWebcamTexture';
+import type { FakeStream, FakeTrack, RvfcScheduler } from '@/react/lib/fakeVideo';
+import { asVideoElement, makeFakeStream, makeFakeVideo, makeRvfcScheduler } from '@/react/lib/fakeVideo';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type { ShaderHandle } from '@/types';
+
+const PROGRAM_ID = 'webcam-demo';
+const WIDTH = 320;
+const HEIGHT = 200;
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let originalGetContext: unknown;
+let originalToBlob: unknown;
+
+class ImageDataStub {
+    constructor(
+        public data: Uint8ClampedArray,
+        public width: number,
+        public height: number
+    ) {}
+}
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stub = createGLStub({ extensions: { ANGLE_instanced_arrays: true } });
+
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown; toBlob: unknown };
+    originalGetContext = canvasProto.getContext;
+    originalToBlob = canvasProto.toBlob;
+    canvasProto.getContext = function stubGetContext(type: string): unknown {
+        return type === '2d' ? { putImageData: () => undefined, drawImage: () => undefined } : stub.gl;
+    };
+    canvasProto.toBlob = function stubToBlob(callback: (blob: Blob) => void, type?: string): void {
+        callback(new Blob([], { type: type ?? 'image/png' }));
+    };
+    (globalThis as { ImageData?: unknown }).ImageData = ImageDataStub;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown; toBlob: unknown };
+    canvasProto.getContext = originalGetContext;
+    canvasProto.toBlob = originalToBlob;
+    delete (globalThis as { ImageData?: unknown }).ImageData;
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+const CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_color: 'float' }
+});
+
+function fullUploads(): { width: number; height: number }[] {
+    return stub.texImage2DCalls
+        .filter(call => call.width !== 1 || call.height !== 1)
+        .map(call => ({ width: call.width, height: call.height }));
+}
+
+interface WebcamControl {
+    start: (() => Promise<void>) | null;
+    stop: (() => void) | null;
+    status: string;
+}
+
+interface WebcamSceneProps {
+    deps: WebcamTextureDeps;
+    onError?: (error: unknown) => void;
+    control: WebcamControl;
+    handleRef?: { current: ShaderHandle | null };
+}
+
+const WebcamScene = ({ deps, onError, control, handleRef }: WebcamSceneProps) => {
+    const cam = useWebcamTexture({ deps, onError });
+    control.start = cam.start;
+    control.stop = cam.stop;
+    control.status = cam.status;
+    return (
+        <BaseShaderComponent
+            ref={handleRef ?? undefined}
+            programId={PROGRAM_ID}
+            shaderConfig={CONFIG}
+            uniforms={{ u_color: { type: 'float', value: 0.5 } }}
+            textures={{ cam: cam.texture }}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop='demand'
+            reducedMotion='ignore'
+            saveData='ignore'
+        />
+    );
+};
+
+interface VideoCaptureSceneProps {
+    deps: VideoTextureDeps;
+    url: string;
+    handleRef: { current: ShaderHandle | null };
+}
+
+const VideoCaptureScene = ({ deps, url, handleRef }: VideoCaptureSceneProps) => {
+    const video = useVideoTexture(url, { deps });
+    return (
+        <BaseShaderComponent
+            ref={handleRef}
+            programId={PROGRAM_ID}
+            shaderConfig={CONFIG}
+            uniforms={{ u_color: { type: 'float', value: 0.5 } }}
+            textures={{ cam: video.texture }}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop='demand'
+            reducedMotion='ignore'
+            saveData='ignore'
+        />
+    );
+};
+
+class ErrorBoundary extends Component<{ children: ReactNode; onError: (error: unknown) => void }, { failed: boolean }> {
+    state = { failed: false };
+
+    static getDerivedStateFromError(): { failed: boolean } {
+        return { failed: true };
+    }
+
+    componentDidCatch(error: unknown): void {
+        this.props.onError(error);
+    }
+
+    render(): ReactNode {
+        return this.state.failed ? null : this.props.children;
+    }
+}
+
+function webcamDeps(stream: FakeStream, rvfc: RvfcScheduler, extra: Partial<WebcamTextureDeps> = {}): WebcamTextureDeps {
+    return {
+        getUserMedia: () => Promise.resolve(stream.stream),
+        createVideo: () => asVideoElement(makeFakeVideo()),
+        requestVideoFrameCallback: rvfc.request,
+        cancelVideoFrameCallback: rvfc.cancel,
+        ...extra
+    };
+}
+
+async function driveRunning(control: WebcamControl, rvfc: RvfcScheduler): Promise<void> {
+    await act(async () => {
+        await control.start?.();
+    });
+    act(() => { frames.tick(0) });
+    act(() => { rvfc.fire() });
+    act(() => { frames.tick(16) });
+}
+
+describe('useWebcamTexture: deterministic capture is blocked while the camera runs (H1, anchor)', () => {
+    it('rejects renderToBlob at an explicit frame and renderSequence, naming the texture blocker', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const handleRef: { current: ShaderHandle | null } = { current: null };
+
+        await mount(<WebcamScene deps={webcamDeps(stream, rvfc)} control={control} handleRef={handleRef} />);
+        await driveRunning(control, rvfc);
+
+        expect(control.status).toBe('running');
+        expect(fullUploads()).toEqual([{ width: 640, height: 480 }]);
+
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).rejects.toThrow(/texture/);
+        expect(() => handleRef.current?.renderSequence({ fps: 30, frames: 2, container: 'none' }))
+            .toThrow(/texture/);
+    });
+});
+
+describe('useWebcamTexture: a stopped camera captures fine (H2)', () => {
+    it('resolves renderToBlob at an explicit frame once the camera is stopped', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const handleRef: { current: ShaderHandle | null } = { current: null };
+
+        await mount(<WebcamScene deps={webcamDeps(stream, rvfc)} control={control} handleRef={handleRef} />);
+        await driveRunning(control, rvfc);
+
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).rejects.toThrow(/texture/);
+
+        act(() => { control.stop?.() });
+        expect(control.status).toBe('stopped');
+
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
+    });
+});
+
+describe('useVideoTexture: a paused video captures fine, a playing one does not (H2)', () => {
+    it('blocks the explicit-frame export while playing and allows it once paused', async () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo();
+        const deps: VideoTextureDeps = {
+            createVideo: () => asVideoElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        };
+        const handleRef: { current: ShaderHandle | null } = { current: null };
+
+        await mount(<VideoCaptureScene deps={deps} url='https://example.test/clip.mp4' handleRef={handleRef} />);
+        act(() => { frames.tick(0) });
+        act(() => { rvfc.fire() });
+        act(() => { frames.tick(16) });
+
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).rejects.toThrow(/texture/);
+
+        video.paused = true;
+        await expect(handleRef.current?.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
+    });
+});
+
+describe('useWebcamTexture: the live capture path stays honest (H3)', () => {
+    it('resolves renderToBlob with no frame while the camera is running', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const handleRef: { current: ShaderHandle | null } = { current: null };
+
+        await mount(<WebcamScene deps={webcamDeps(stream, rvfc)} control={control} handleRef={handleRef} />);
+        await driveRunning(control, rvfc);
+
+        expect(control.status).toBe('running');
+        await expect(handleRef.current?.renderToBlob()).resolves.toBeInstanceOf(Blob);
+    });
+});
+
+describe('useWebcamTexture: StrictMode never double-prompts (H6)', () => {
+    it('opens the camera exactly once after start() under a StrictMode mount', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        let calls = 0;
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const deps = webcamDeps(stream, rvfc, {
+            getUserMedia: () => { calls += 1; return Promise.resolve(stream.stream) }
+        });
+
+        await mount(<StrictMode><WebcamScene deps={deps} control={control} /></StrictMode>);
+        await act(async () => { await control.start?.() });
+
+        expect(calls).toBe(1);
+        expect(control.status).toBe('running');
+    });
+});
+
+describe('useVideoTexture: StrictMode leaves exactly one pump (H6)', () => {
+    it('cancels the first attachment so a double-invoked mount effect does not leak a second pump', async () => {
+        const rvfc = makeRvfcScheduler();
+        const created: ReturnType<typeof makeFakeVideo>[] = [];
+        const deps: VideoTextureDeps = {
+            createVideo: () => { const video = makeFakeVideo(); created.push(video); return asVideoElement(video) },
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        };
+        const handleRef: { current: ShaderHandle | null } = { current: null };
+
+        await mount(
+            <StrictMode>
+                <VideoCaptureScene deps={deps} url='https://example.test/clip.mp4' handleRef={handleRef} />
+            </StrictMode>
+        );
+
+        expect(created.length).toBeGreaterThan(1);
+        expect(created[0].pauseCalls).toBe(1);
+        expect(rvfc.activeCount).toBe(1);
+        expect(rvfc.pending).toBe(true);
+    });
+});
+
+describe('useWebcamTexture: unmount releases the camera (H7)', () => {
+    it('stops every track and cancels the pump when the component unmounts while running', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+
+        await mount(<WebcamScene deps={webcamDeps(stream, rvfc)} control={control} />);
+        await act(async () => { await control.start?.() });
+
+        expect(stream.tracks.every((track: FakeTrack) => track.stopped)).toBe(false);
+
+        act(() => { root.render(<div />) });
+
+        expect(stream.tracks.every((track: FakeTrack) => track.stopped)).toBe(true);
+        expect(rvfc.cancelled.length).toBeGreaterThan(0);
+    });
+
+    it('releases a grant that lands after the component unmounted mid-prompt', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        let grant: (value: MediaStream) => void = () => undefined;
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const deps = webcamDeps(stream, rvfc, {
+            getUserMedia: () => new Promise<MediaStream>(resolve => { grant = resolve })
+        });
+
+        await mount(<WebcamScene deps={deps} control={control} />);
+        let starting: Promise<void> | undefined;
+        act(() => { starting = control.start?.() });
+
+        act(() => { root.render(<div />) });
+
+        grant(stream.stream);
+        await act(async () => { await starting });
+
+        expect(stream.tracks.every((track: FakeTrack) => track.stopped)).toBe(true);
+    });
+});
+
+describe('useWebcamTexture: SSR safety and lazy acquisition (H8)', () => {
+    it('never opens the camera at mount and reads no camera global before start()', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        let calls = 0;
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const deps = webcamDeps(stream, rvfc, {
+            getUserMedia: () => { calls += 1; return Promise.resolve(stream.stream) }
+        });
+
+        const descriptor = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices');
+        Object.defineProperty(navigator, 'mediaDevices', { value: undefined, configurable: true });
+        try {
+            await mount(<WebcamScene deps={deps} control={control} />);
+            expect(calls).toBe(0);
+            expect(control.status).toBe('idle');
+        } finally {
+            if (descriptor) {
+                Object.defineProperty(navigator, 'mediaDevices', descriptor);
+            }
+        }
+
+        await act(async () => { await control.start?.() });
+        expect(calls).toBe(1);
+        expect(control.status).toBe('running');
+    });
+});
+
+describe('useWebcamTexture: the error surface (H9)', () => {
+    it('re-throws a getUserMedia rejection during render when no onError is supplied', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        const denied = new Error('NotAllowedError: permission denied');
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const deps = webcamDeps(stream, rvfc, { getUserMedia: () => Promise.reject(denied) });
+        let boundaryError: unknown = null;
+
+        await mount(
+            <ErrorBoundary onError={error => { boundaryError = error }}>
+                <WebcamScene deps={deps} control={control} />
+            </ErrorBoundary>
+        );
+        await act(async () => { await control.start?.().catch(() => undefined) });
+
+        expect(boundaryError).toBe(denied);
+    });
+
+    it('reports a getUserMedia rejection through onError without throwing when one is supplied', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        const denied = new Error('NotAllowedError: permission denied');
+        const reports: unknown[] = [];
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const deps = webcamDeps(stream, rvfc, { getUserMedia: () => Promise.reject(denied) });
+        let boundaryError: unknown = null;
+
+        await mount(
+            <ErrorBoundary onError={error => { boundaryError = error }}>
+                <WebcamScene deps={deps} onError={error => { reports.push(error) }} control={control} />
+            </ErrorBoundary>
+        );
+        await act(async () => { await control.start?.().catch(() => undefined) });
+
+        expect(boundaryError).toBeNull();
+        expect(control.status).toBe('error');
+    });
+});
+
+describe('useWebcamTexture: constraint identity is fixed for a hook instance (A6)', () => {
+    it('throws the give-it-a-key message when the camera constraints change after mount', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+
+        const Scene = ({ deviceId }: { deviceId: string }) => {
+            const cam = useWebcamTexture({ deviceId, deps: webcamDeps(stream, rvfc) });
+            return (
+                <BaseShaderComponent
+                    programId={PROGRAM_ID}
+                    shaderConfig={CONFIG}
+                    uniforms={{ u_color: { type: 'float', value: 0.5 } }}
+                    textures={{ cam: cam.texture }}
+                    width={WIDTH}
+                    height={HEIGHT}
+                    useDevicePixelRatio={false}
+                    frameloop='demand'
+                    reducedMotion='ignore'
+                    saveData='ignore'
+                />
+            );
+        };
+
+        let caught: unknown = null;
+        const tree = (deviceId: string): ReactElement => (
+            <ErrorBoundary onError={error => { caught = error }}>
+                <Scene deviceId={deviceId} />
+            </ErrorBoundary>
+        );
+
+        await mount(tree('cam-a'));
+        await mount(tree('cam-b'));
+
+        expect(caught).toBeInstanceOf(Error);
+        expect((caught as Error).message).toContain('Give the component a "key"');
+    });
+});

--- a/src/react/hooks/useWebcamTexture.test.tsx
+++ b/src/react/hooks/useWebcamTexture.test.tsx
@@ -259,8 +259,8 @@ describe('useWebcamTexture: the live capture path stays honest (H3)', () => {
     });
 });
 
-describe('useWebcamTexture: StrictMode never double-prompts (H6)', () => {
-    it('opens the camera exactly once after start() under a StrictMode mount', async () => {
+describe('useWebcamTexture: repeated start() opens the camera once (hook-level idempotency)', () => {
+    it('opens the camera exactly once when start() is called twice before the grant lands', async () => {
         const stream = makeFakeStream();
         const rvfc = makeRvfcScheduler();
         let calls = 0;
@@ -269,7 +269,7 @@ describe('useWebcamTexture: StrictMode never double-prompts (H6)', () => {
             getUserMedia: () => { calls += 1; return Promise.resolve(stream.stream) }
         });
 
-        await mount(<StrictMode><WebcamScene deps={deps} control={control} /></StrictMode>);
+        await mount(<WebcamScene deps={deps} control={control} />);
         await act(async () => {
             const first = control.start?.();
             const second = control.start?.();
@@ -409,6 +409,51 @@ describe('useWebcamTexture: the error surface (H9)', () => {
 
         expect(boundaryError).toBeNull();
         expect(control.status).toBe('error');
+        expect(reports).toHaveLength(1);
+        expect(reports[0]).toBeInstanceOf(Error);
+        expect(reports[0]).toBe(denied);
+    });
+
+    it('folds a play() rejection on the webcam path into the error surface exactly once', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        const denied = new Error('NotAllowedError: autoplay blocked');
+        const reports: unknown[] = [];
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const deps = webcamDeps(stream, rvfc, {
+            createVideo: () => asVideoElement(makeFakeVideo({ play: () => Promise.reject(denied) }))
+        });
+
+        await mount(<WebcamScene deps={deps} onError={error => { reports.push(error) }} control={control} />);
+        await act(async () => { await control.start?.() });
+        await act(async () => { await Promise.resolve() });
+
+        expect(control.status).toBe('error');
+        expect(stream.tracks.every((track: FakeTrack) => track.stopped)).toBe(true);
+        expect(reports).toHaveLength(1);
+        expect(reports[0]).toBe(denied);
+    });
+
+    it('re-throws a webcam-path play() rejection during render when no onError is supplied', async () => {
+        const stream = makeFakeStream();
+        const rvfc = makeRvfcScheduler();
+        const denied = new Error('NotAllowedError: autoplay blocked');
+        const control: WebcamControl = { start: null, stop: null, status: 'idle' };
+        const deps = webcamDeps(stream, rvfc, {
+            createVideo: () => asVideoElement(makeFakeVideo({ play: () => Promise.reject(denied) }))
+        });
+        let boundaryError: unknown = null;
+
+        await mount(
+            <ErrorBoundary onError={error => { boundaryError = error }}>
+                <WebcamScene deps={deps} control={control} />
+            </ErrorBoundary>
+        );
+        await act(async () => { await control.start?.() });
+        await act(async () => { await Promise.resolve() });
+
+        expect(boundaryError).toBe(denied);
+        expect(stream.tracks.every((track: FakeTrack) => track.stopped)).toBe(true);
     });
 });
 

--- a/src/react/hooks/useWebcamTexture.ts
+++ b/src/react/hooks/useWebcamTexture.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+
+import { resolveSourceTextureOptions } from '@/core/lib/sourceTextureOptions';
+import type { VideoTextureDriver, VideoTextureDriverConfig, VideoTextureDriverDeps } from '@/react/lib/videoTextureDriver';
+import { createVideoTextureDriver } from '@/react/lib/videoTextureDriver';
+import type { WebcamAcquisition, WebcamConstraintOptions } from '@/react/lib/webcamAcquisition';
+import { buildWebcamConstraints, createWebcamAcquisition } from '@/react/lib/webcamAcquisition';
+import type { SourceTextureOptions, TextureSource } from '@/types';
+
+export type WebcamStatus = 'idle' | 'starting' | 'running' | 'stopped' | 'error';
+
+export interface WebcamTextureDeps extends VideoTextureDriverDeps {
+    getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+}
+
+export interface WebcamTextureOptions extends SourceTextureOptions {
+    deviceId?: string;
+    facingMode?: 'user' | 'environment';
+    width?: number;
+    height?: number;
+    resizeToPOT?: boolean;
+    onError?: (error: unknown) => void;
+    deps?: WebcamTextureDeps;
+}
+
+export interface WebcamTextureResult {
+    texture: TextureSource;
+    status: WebcamStatus;
+    error: Error | null;
+    start: () => Promise<void>;
+    stop: () => void;
+    stream: MediaStream | null;
+}
+
+let webcamTextureCounter = 0;
+
+const getServerStatus = (): WebcamStatus => 'idle';
+const getServerError = (): Error | null => null;
+const getServerStream = (): MediaStream | null => null;
+
+function constraintOptions(options?: WebcamTextureOptions): WebcamConstraintOptions {
+    return {
+        deviceId: options?.deviceId,
+        facingMode: options?.facingMode,
+        width: options?.width,
+        height: options?.height
+    };
+}
+
+function constraintKey(options: WebcamConstraintOptions): string {
+    return JSON.stringify([options.deviceId, options.facingMode, options.width, options.height]);
+}
+
+function assertSameConstraints(previous: string, next: string): void {
+    if (previous === next) {
+        return;
+    }
+    throw new Error(
+        'micugl textures: useWebcamTexture was given different camera constraints (deviceId, facingMode, width or '
+        + 'height) after it first mounted, but a hook instance owns one camera acquisition for its whole life: the '
+        + 'MediaStream tracks were opened for the first constraints, and rebinding them under a live shader would '
+        + 'leave the old camera running with nobody stopping it. Give the component a "key" that changes with the '
+        + 'constraints, so React unmounts the old hook (stopping the camera) and mounts a new one.'
+    );
+}
+
+export function useWebcamTexture(options?: WebcamTextureOptions): WebcamTextureResult {
+    const resolved = resolveSourceTextureOptions(options);
+    const resizeToPOT = options?.resizeToPOT ?? false;
+    const optionsKey = `${JSON.stringify(resolved)}|${String(resizeToPOT)}`;
+
+    const constraints = constraintOptions(options);
+    const key = constraintKey(constraints);
+    const constraintKeyRef = useRef(key);
+    assertSameConstraints(constraintKeyRef.current, key);
+
+    const idRef = useRef('');
+    if (idRef.current === '') {
+        webcamTextureCounter += 1;
+        idRef.current = `webcam-texture-${String(webcamTextureCounter)}`;
+    }
+
+    const configRef = useRef<VideoTextureDriverConfig>({
+        crossOrigin: 'anonymous',
+        loop: false,
+        resizeToPOT,
+        onError: options?.onError
+    });
+    configRef.current.resizeToPOT = resizeToPOT;
+    configRef.current.onError = options?.onError;
+
+    const driverRef = useRef<VideoTextureDriver | null>(null);
+    driverRef.current ??= createVideoTextureDriver(configRef.current, options?.deps);
+    const driver = driverRef.current;
+
+    const acquisitionRef = useRef<WebcamAcquisition | null>(null);
+    acquisitionRef.current ??= createWebcamAcquisition(buildWebcamConstraints(constraints), {
+        getUserMedia: options?.deps?.getUserMedia,
+        attach: stream => { driver.start(stream) },
+        detach: () => { driver.stop() }
+    });
+    const acquisition = acquisitionRef.current;
+
+    const nonReproducible = useCallback(() => acquisition.status === 'running', [acquisition]);
+
+    const sourceRef = useRef<TextureSource | null>(null);
+    const mintedOptionsKeyRef = useRef('');
+    if (sourceRef.current === null || mintedOptionsKeyRef.current !== optionsKey) {
+        mintedOptionsKeyRef.current = optionsKey;
+        sourceRef.current = {
+            id: idRef.current,
+            get version() { return driver.version },
+            options: resolved,
+            getFrame: () => driver.getFrame(),
+            invalidation: driver.invalidation,
+            nonReproducible
+        };
+    }
+    const source = sourceRef.current;
+
+    useEffect(() => () => { acquisition.stop() }, [acquisition]);
+
+    const status = useSyncExternalStore(acquisition.subscribe, () => acquisition.status, getServerStatus);
+    const error = useSyncExternalStore(acquisition.subscribe, () => acquisition.error, getServerError);
+    const stream = useSyncExternalStore(acquisition.subscribe, () => acquisition.stream, getServerStream);
+
+    const start = useCallback(() => acquisition.start(), [acquisition]);
+    const stop = useCallback(() => { acquisition.stop() }, [acquisition]);
+
+    if (status === 'error' && options?.onError === undefined) {
+        throw error ?? new Error('micugl textures: the webcam failed to start.');
+    }
+
+    return { texture: source, status, error, start, stop, stream };
+}

--- a/src/react/hooks/useWebcamTexture.ts
+++ b/src/react/hooks/useWebcamTexture.ts
@@ -80,24 +80,28 @@ export function useWebcamTexture(options?: WebcamTextureOptions): WebcamTextureR
         idRef.current = `webcam-texture-${String(webcamTextureCounter)}`;
     }
 
+    const onErrorRef = useRef(options?.onError);
+    onErrorRef.current = options?.onError;
+
+    const acquisitionRef = useRef<WebcamAcquisition | null>(null);
+
     const configRef = useRef<VideoTextureDriverConfig>({
         crossOrigin: 'anonymous',
         loop: false,
         resizeToPOT,
-        onError: options?.onError
+        onError: cause => { acquisitionRef.current?.fail(cause) }
     });
     configRef.current.resizeToPOT = resizeToPOT;
-    configRef.current.onError = options?.onError;
 
     const driverRef = useRef<VideoTextureDriver | null>(null);
     driverRef.current ??= createVideoTextureDriver(configRef.current, options?.deps);
     const driver = driverRef.current;
 
-    const acquisitionRef = useRef<WebcamAcquisition | null>(null);
     acquisitionRef.current ??= createWebcamAcquisition(buildWebcamConstraints(constraints), {
         getUserMedia: options?.deps?.getUserMedia,
         attach: stream => { driver.start(stream) },
-        detach: () => { driver.stop() }
+        detach: () => { driver.stop() },
+        onError: cause => { onErrorRef.current?.(cause) }
     });
     const acquisition = acquisitionRef.current;
 

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -12,6 +12,20 @@ export { usePingPongPasses } from './hooks/usePingPongPasses';
 export { useReducedMotion } from './hooks/useReducedMotion';
 export { useSaveData } from './hooks/useSaveData';
 export { useUniformUpdaters } from './hooks/useUniformUpdaters';
+export type {
+    VideoInput,
+    VideoTextureDeps,
+    VideoTextureOptions,
+    VideoTextureResult
+} from './hooks/useVideoTexture';
+export { useVideoTexture } from './hooks/useVideoTexture';
+export type {
+    WebcamStatus,
+    WebcamTextureDeps,
+    WebcamTextureOptions,
+    WebcamTextureResult
+} from './hooks/useWebcamTexture';
+export { useWebcamTexture } from './hooks/useWebcamTexture';
 export type { AudioAnalyserDriverDeps } from './lib/audioAnalyserDriver';
 export { createCommonUpdaters, createUniformUpdater, createUniformUpdaters } from './lib/createUniformUpdater';
 export type { InstanceAttribute, InstancingConfig, WorkerMode } from '@/types';

--- a/src/react/lib/captureLiveness.ts
+++ b/src/react/lib/captureLiveness.ts
@@ -2,7 +2,7 @@ export type SpringsInFlight = () => boolean;
 
 export type NonReproducible = () => boolean;
 
-export type CaptureBlocker = 'spring' | 'audio';
+export type CaptureBlocker = 'spring' | 'audio' | 'texture';
 
 export type CapturesAreNonReproducible = () => CaptureBlocker | null;
 
@@ -16,6 +16,16 @@ export function nonReproducibleCaptureMessage(
             `${engine}.${method}: a spring transition is still in flight. Springs integrate frame to frame, so a `
             + 'captured frame depends on the frames rendered before it, and this export would not reproduce. Wait for '
             + 'the spring to settle, or use a tween transition, which is deterministic under setFrame.'
+        );
+    }
+
+    if (blocker === 'texture') {
+        return (
+            `${engine}.${method}: a live video or webcam texture is playing. Every frame samples whatever the video `
+            + 'or camera happens to be showing right now, so the picture is wall-clock-dependent and a synthesized '
+            + 'frame number cannot reproduce it. This export would not reproduce. Pause the video or call stop() on '
+            + 'the webcam hook before exporting for a deterministic frame; renderToBlob() with no frame, record() and '
+            + 'captureStream() capture the live picture and remain available.'
         );
     }
 

--- a/src/react/lib/fakeVideo.ts
+++ b/src/react/lib/fakeVideo.ts
@@ -1,0 +1,143 @@
+import type { VideoFrameCallbackMetadata } from '@/react/lib/videoTextureDriver';
+
+export interface FakeVideo {
+    readyState: number;
+    videoWidth: number;
+    videoHeight: number;
+    paused: boolean;
+    ended: boolean;
+    muted: boolean;
+    playsInline: boolean;
+    loop: boolean;
+    crossOrigin: string;
+    src: string;
+    srcObject: unknown;
+    error: { code: number } | null;
+    playCalls: number;
+    pauseCalls: number;
+    loadCalls: number;
+    removedAttributes: string[];
+    setAttributes: [string, string][];
+    play: () => Promise<void> | undefined;
+    pause: () => void;
+    load: () => void;
+    setAttribute: (name: string, value: string) => void;
+    removeAttribute: (name: string) => void;
+    addEventListener: (type: string, listener: () => void) => void;
+    emitError: () => void;
+}
+
+export function makeFakeVideo(overrides: Partial<FakeVideo> = {}): FakeVideo {
+    const listeners = new Map<string, (() => void)[]>();
+    const video: FakeVideo = {
+        readyState: 2,
+        videoWidth: 640,
+        videoHeight: 480,
+        paused: false,
+        ended: false,
+        muted: false,
+        playsInline: false,
+        loop: false,
+        crossOrigin: '',
+        src: '',
+        srcObject: null,
+        error: null,
+        playCalls: 0,
+        pauseCalls: 0,
+        loadCalls: 0,
+        removedAttributes: [],
+        setAttributes: [],
+        play: () => undefined,
+        pause: () => undefined,
+        load: () => undefined,
+        setAttribute: () => undefined,
+        removeAttribute: () => undefined,
+        addEventListener: () => undefined,
+        emitError: () => undefined,
+        ...overrides
+    };
+
+    const basePlay = video.play;
+    video.play = () => { video.playCalls += 1; return basePlay() };
+    video.pause = () => { video.pauseCalls += 1; video.paused = true };
+    video.load = () => { video.loadCalls += 1 };
+    video.setAttribute = (name, value) => { video.setAttributes.push([name, value]) };
+    video.removeAttribute = name => { video.removedAttributes.push(name) };
+    video.addEventListener = (type, listener) => {
+        const bucket = listeners.get(type) ?? [];
+        bucket.push(listener);
+        listeners.set(type, bucket);
+    };
+    video.emitError = () => {
+        (listeners.get('error') ?? []).forEach(listener => { listener() });
+    };
+
+    return video;
+}
+
+export function asVideoElement(video: FakeVideo): HTMLVideoElement {
+    return video as unknown as HTMLVideoElement;
+}
+
+export interface FakeTrack {
+    stopped: boolean;
+    stop: () => void;
+}
+
+export interface FakeStream {
+    stream: MediaStream;
+    tracks: FakeTrack[];
+}
+
+export function makeFakeStream(): FakeStream {
+    const tracks: FakeTrack[] = [
+        { stopped: false, stop() { this.stopped = true } },
+        { stopped: false, stop() { this.stopped = true } }
+    ];
+    const stream = { getTracks: () => tracks } as unknown as MediaStream;
+    return { stream, tracks };
+}
+
+export interface RvfcScheduler {
+    request: (video: HTMLVideoElement, callback: (now: number, metadata: VideoFrameCallbackMetadata) => void) => number;
+    cancel: (video: HTMLVideoElement, handle: number) => void;
+    fire: (now?: number) => void;
+    readonly pending: boolean;
+    readonly activeCount: number;
+    readonly cancelled: number[];
+}
+
+export function makeRvfcScheduler(): RvfcScheduler {
+    const active = new Map<number, (now: number, metadata: VideoFrameCallbackMetadata) => void>();
+    let handle = 0;
+    let latest: number | null = null;
+    const cancelled: number[] = [];
+    return {
+        request: (_video, cb) => {
+            handle += 1;
+            active.set(handle, cb);
+            latest = handle;
+            return handle;
+        },
+        cancel: (_video, h) => {
+            if (active.delete(h)) {
+                cancelled.push(h);
+            }
+            if (latest === h) {
+                latest = null;
+            }
+        },
+        fire: (now = 0) => {
+            if (latest === null) {
+                return;
+            }
+            const current = active.get(latest);
+            active.delete(latest);
+            latest = null;
+            current?.(now, { width: 640, height: 480 });
+        },
+        get pending() { return latest !== null },
+        get activeCount() { return active.size },
+        get cancelled() { return cancelled }
+    };
+}

--- a/src/react/lib/potCanvas.ts
+++ b/src/react/lib/potCanvas.ts
@@ -34,7 +34,7 @@ export function resizeSourceToPot(
     const { width, height } = sourceDimensions(source);
     if (width < 1 || height < 1) {
         throw new Error(
-            `micugl useImageTexture: resizeToPOT got a source measuring ${width}x${height}. A source without `
+            `micugl textures: resizeToPOT got a source measuring ${width}x${height}. A source without `
             + 'positive dimensions has no pixels to draw onto a power-of-two canvas, and copying it would upload '
             + 'a blank texture instead of failing loud. Size or decode the source before passing it in.'
         );
@@ -48,7 +48,7 @@ export function resizeSourceToPot(
 
     if (isImageData(source)) {
         throw new Error(
-            'micugl useImageTexture: resizeToPOT cannot draw an ImageData source onto a power-of-two canvas '
+            'micugl textures: resizeToPOT cannot draw an ImageData source onto a power-of-two canvas '
             + 'because ImageData is not a CanvasImageSource that drawImage accepts. Convert the ImageData with '
             + 'createImageBitmap(imageData) before passing it in, or drop resizeToPOT for this input.'
         );
@@ -58,7 +58,7 @@ export function resizeSourceToPot(
     const context = canvas.getContext('2d');
     if (!context) {
         throw new Error(
-            'micugl useImageTexture: resizeToPOT needs a 2D canvas context to draw the source onto a '
+            'micugl textures: resizeToPOT needs a 2D canvas context to draw the source onto a '
             + 'power-of-two canvas, but getContext("2d") returned null.'
         );
     }

--- a/src/react/lib/videoTextureDriver.test.ts
+++ b/src/react/lib/videoTextureDriver.test.ts
@@ -291,6 +291,27 @@ describe('videoTextureDriver: the play call', () => {
         expect(activeError).toBe(denied);
     });
 
+    it('D7: raises a single error when a play() rejection and an element error event describe the same failure', async () => {
+        const rvfc = makeRvfcScheduler();
+        const denied = new Error('NotAllowedError');
+        const video = makeFakeVideo({ play: () => Promise.reject(denied) });
+        const errors: unknown[] = [];
+        const driver = createVideoTextureDriver(config({ onError: error => { errors.push(error) } }), {
+            createVideo: () => asVideoElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+
+        driver.start('https://example.test/clip.mp4');
+        await flushMicrotasks();
+
+        video.error = { code: 4 };
+        video.emitError();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toBe(denied);
+    });
+
     it('D7: swallows a play() rejection that lands after stop() and does not flip to error', async () => {
         const rvfc = makeRvfcScheduler();
         let reject: (error: unknown) => void = () => undefined;

--- a/src/react/lib/videoTextureDriver.test.ts
+++ b/src/react/lib/videoTextureDriver.test.ts
@@ -1,115 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import type { InvalidationKind } from '@/core/lib/frameInvalidation';
-import type {
-    VideoFrameCallbackMetadata,
-    VideoTextureDriverConfig
-} from '@/react/lib/videoTextureDriver';
+import type { FakeVideo } from '@/react/lib/fakeVideo';
+import { asVideoElement, makeFakeVideo, makeRvfcScheduler } from '@/react/lib/fakeVideo';
+import type { VideoTextureDriverConfig } from '@/react/lib/videoTextureDriver';
 import { createVideoTextureDriver } from '@/react/lib/videoTextureDriver';
-
-interface FakeVideo {
-    readyState: number;
-    videoWidth: number;
-    videoHeight: number;
-    paused: boolean;
-    ended: boolean;
-    muted: boolean;
-    playsInline: boolean;
-    loop: boolean;
-    crossOrigin: string;
-    src: string;
-    srcObject: unknown;
-    error: { code: number } | null;
-    play: () => Promise<void> | undefined;
-    pauseCalls: number;
-    loadCalls: number;
-    removedAttributes: string[];
-    setAttributes: [string, string][];
-    requestVideoFrameCallback?: (callback: (now: number, metadata: VideoFrameCallbackMetadata) => void) => number;
-    emitError: () => void;
-}
-
-function makeFakeVideo(overrides: Partial<FakeVideo> = {}): FakeVideo {
-    const listeners = new Map<string, (() => void)[]>();
-    const video: FakeVideo = {
-        readyState: 2,
-        videoWidth: 640,
-        videoHeight: 480,
-        paused: false,
-        ended: false,
-        muted: false,
-        playsInline: false,
-        loop: false,
-        crossOrigin: '',
-        src: '',
-        srcObject: null,
-        error: null,
-        play: () => undefined,
-        pauseCalls: 0,
-        loadCalls: 0,
-        removedAttributes: [],
-        setAttributes: [],
-        emitError: () => {
-            (listeners.get('error') ?? []).forEach(listener => { listener() });
-        },
-        ...overrides
-    };
-
-    const withDom = video as FakeVideo & {
-        pause: () => void;
-        load: () => void;
-        setAttribute: (name: string, value: string) => void;
-        removeAttribute: (name: string) => void;
-        addEventListener: (type: string, listener: () => void) => void;
-    };
-    withDom.pause = () => { video.pauseCalls += 1; video.paused = true };
-    withDom.load = () => { video.loadCalls += 1 };
-    withDom.setAttribute = (name, value) => { video.setAttributes.push([name, value]) };
-    withDom.removeAttribute = name => { video.removedAttributes.push(name) };
-    withDom.addEventListener = (type, listener) => {
-        const bucket = listeners.get(type) ?? [];
-        bucket.push(listener);
-        listeners.set(type, bucket);
-    };
-
-    return video;
-}
-
-function asElement(video: FakeVideo): HTMLVideoElement {
-    return video as unknown as HTMLVideoElement;
-}
-
-interface RvfcScheduler {
-    request: (video: HTMLVideoElement, callback: (now: number, metadata: VideoFrameCallbackMetadata) => void) => number;
-    cancel: (video: HTMLVideoElement, handle: number) => void;
-    fire: (now?: number) => void;
-    readonly pending: boolean;
-    readonly cancelled: number[];
-}
-
-function makeRvfcScheduler(): RvfcScheduler {
-    let callback: ((now: number, metadata: VideoFrameCallbackMetadata) => void) | null = null;
-    let handle = 0;
-    const cancelled: number[] = [];
-    return {
-        request: (_video, cb) => {
-            callback = cb;
-            handle += 1;
-            return handle;
-        },
-        cancel: (_video, h) => {
-            cancelled.push(h);
-            callback = null;
-        },
-        fire: (now = 0) => {
-            const current = callback;
-            callback = null;
-            current?.(now, { width: 640, height: 480 });
-        },
-        get pending() { return callback !== null },
-        get cancelled() { return cancelled }
-    };
-}
 
 interface RafScheduler {
     request: (callback: (now: number) => void) => number;
@@ -166,7 +61,7 @@ describe('videoTextureDriver: the requestVideoFrameCallback pump', () => {
         const rvfc = makeRvfcScheduler();
         const video = makeFakeVideo();
         const driver = createVideoTextureDriver(config(), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         });
@@ -191,7 +86,7 @@ describe('videoTextureDriver: the requestAnimationFrame fallback pump', () => {
         const raf = makeRafScheduler();
         const video = makeFakeVideo({ paused: true });
         const driver = createVideoTextureDriver(config(), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestAnimationFrame: raf.request,
             cancelAnimationFrame: raf.cancel
         });
@@ -219,7 +114,7 @@ describe('videoTextureDriver: getFrame readiness', () => {
         const rvfc = makeRvfcScheduler();
         const video = makeFakeVideo({ readyState: 0, videoWidth: 0, videoHeight: 0 });
         const driver = createVideoTextureDriver(config(), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         });
@@ -254,7 +149,7 @@ describe('videoTextureDriver: resizeToPOT laziness', () => {
             } as unknown as HTMLCanvasElement;
         };
         const driver = createVideoTextureDriver(config({ resizeToPOT: true }), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel,
             createPotCanvas
@@ -295,7 +190,7 @@ describe('videoTextureDriver: stop', () => {
         const rvfc = makeRvfcScheduler();
         const video = makeFakeVideo();
         const driver = createVideoTextureDriver(config(), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         });
@@ -318,12 +213,12 @@ describe('videoTextureDriver: stop', () => {
         const adopted = makeFakeVideo({ srcObject: { adopted: true } });
         let created = 0;
         const driver = createVideoTextureDriver(config(), {
-            createVideo: () => { created += 1; return asElement(makeFakeVideo()) },
+            createVideo: () => { created += 1; return asVideoElement(makeFakeVideo()) },
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         });
 
-        driver.start(asElement(adopted));
+        driver.start(asVideoElement(adopted));
         expect(created).toBe(0);
 
         driver.stop();
@@ -340,7 +235,7 @@ describe('videoTextureDriver: the playing predicate', () => {
         const rvfc = makeRvfcScheduler();
         const video = makeFakeVideo();
         const driver = createVideoTextureDriver(config(), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         });
@@ -368,7 +263,7 @@ describe('videoTextureDriver: the play call', () => {
         const rvfc = makeRvfcScheduler();
         const video = makeFakeVideo({ play: () => undefined });
         const driver = createVideoTextureDriver(config(), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         });
@@ -383,7 +278,7 @@ describe('videoTextureDriver: the play call', () => {
         const denied = new Error('NotAllowedError');
         const video = makeFakeVideo({ play: () => Promise.reject(denied) });
         const driver = createVideoTextureDriver(config({ onError: error => { activeError = error } }), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         });
@@ -401,7 +296,7 @@ describe('videoTextureDriver: the play call', () => {
         let reject: (error: unknown) => void = () => undefined;
         const video = makeFakeVideo({ play: () => new Promise<void>((_resolve, rej) => { reject = rej }) });
         const driver = createVideoTextureDriver(config(), {
-            createVideo: () => asElement(video),
+            createVideo: () => asVideoElement(video),
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel
         });
@@ -430,7 +325,7 @@ describe('videoTextureDriver: input change', () => {
                     throw new Error('unexpected extra createVideo');
                 }
                 created.push(next);
-                return asElement(next);
+                return asVideoElement(next);
             },
             requestVideoFrameCallback: rvfc.request,
             cancelVideoFrameCallback: rvfc.cancel

--- a/src/react/lib/videoTextureDriver.test.ts
+++ b/src/react/lib/videoTextureDriver.test.ts
@@ -1,0 +1,453 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { InvalidationKind } from '@/core/lib/frameInvalidation';
+import type {
+    VideoFrameCallbackMetadata,
+    VideoTextureDriverConfig
+} from '@/react/lib/videoTextureDriver';
+import { createVideoTextureDriver } from '@/react/lib/videoTextureDriver';
+
+interface FakeVideo {
+    readyState: number;
+    videoWidth: number;
+    videoHeight: number;
+    paused: boolean;
+    ended: boolean;
+    muted: boolean;
+    playsInline: boolean;
+    loop: boolean;
+    crossOrigin: string;
+    src: string;
+    srcObject: unknown;
+    error: { code: number } | null;
+    play: () => Promise<void> | undefined;
+    pauseCalls: number;
+    loadCalls: number;
+    removedAttributes: string[];
+    setAttributes: [string, string][];
+    requestVideoFrameCallback?: (callback: (now: number, metadata: VideoFrameCallbackMetadata) => void) => number;
+    emitError: () => void;
+}
+
+function makeFakeVideo(overrides: Partial<FakeVideo> = {}): FakeVideo {
+    const listeners = new Map<string, (() => void)[]>();
+    const video: FakeVideo = {
+        readyState: 2,
+        videoWidth: 640,
+        videoHeight: 480,
+        paused: false,
+        ended: false,
+        muted: false,
+        playsInline: false,
+        loop: false,
+        crossOrigin: '',
+        src: '',
+        srcObject: null,
+        error: null,
+        play: () => undefined,
+        pauseCalls: 0,
+        loadCalls: 0,
+        removedAttributes: [],
+        setAttributes: [],
+        emitError: () => {
+            (listeners.get('error') ?? []).forEach(listener => { listener() });
+        },
+        ...overrides
+    };
+
+    const withDom = video as FakeVideo & {
+        pause: () => void;
+        load: () => void;
+        setAttribute: (name: string, value: string) => void;
+        removeAttribute: (name: string) => void;
+        addEventListener: (type: string, listener: () => void) => void;
+    };
+    withDom.pause = () => { video.pauseCalls += 1; video.paused = true };
+    withDom.load = () => { video.loadCalls += 1 };
+    withDom.setAttribute = (name, value) => { video.setAttributes.push([name, value]) };
+    withDom.removeAttribute = name => { video.removedAttributes.push(name) };
+    withDom.addEventListener = (type, listener) => {
+        const bucket = listeners.get(type) ?? [];
+        bucket.push(listener);
+        listeners.set(type, bucket);
+    };
+
+    return video;
+}
+
+function asElement(video: FakeVideo): HTMLVideoElement {
+    return video as unknown as HTMLVideoElement;
+}
+
+interface RvfcScheduler {
+    request: (video: HTMLVideoElement, callback: (now: number, metadata: VideoFrameCallbackMetadata) => void) => number;
+    cancel: (video: HTMLVideoElement, handle: number) => void;
+    fire: (now?: number) => void;
+    readonly pending: boolean;
+    readonly cancelled: number[];
+}
+
+function makeRvfcScheduler(): RvfcScheduler {
+    let callback: ((now: number, metadata: VideoFrameCallbackMetadata) => void) | null = null;
+    let handle = 0;
+    const cancelled: number[] = [];
+    return {
+        request: (_video, cb) => {
+            callback = cb;
+            handle += 1;
+            return handle;
+        },
+        cancel: (_video, h) => {
+            cancelled.push(h);
+            callback = null;
+        },
+        fire: (now = 0) => {
+            const current = callback;
+            callback = null;
+            current?.(now, { width: 640, height: 480 });
+        },
+        get pending() { return callback !== null },
+        get cancelled() { return cancelled }
+    };
+}
+
+interface RafScheduler {
+    request: (callback: (now: number) => void) => number;
+    cancel: (handle: number) => void;
+    fire: (now?: number) => void;
+    readonly cancelled: number[];
+}
+
+function makeRafScheduler(): RafScheduler {
+    let callback: ((now: number) => void) | null = null;
+    let handle = 0;
+    const cancelled: number[] = [];
+    return {
+        request: cb => {
+            callback = cb;
+            handle += 1;
+            return handle;
+        },
+        cancel: h => {
+            cancelled.push(h);
+            callback = null;
+        },
+        fire: (now = 0) => {
+            const current = callback;
+            callback = null;
+            current?.(now);
+        },
+        get cancelled() { return cancelled }
+    };
+}
+
+function config(overrides: Partial<VideoTextureDriverConfig> = {}): VideoTextureDriverConfig {
+    return {
+        crossOrigin: 'anonymous',
+        loop: false,
+        resizeToPOT: false,
+        ...overrides
+    };
+}
+
+const STREAM = { getTracks: () => [] } as unknown as MediaStream;
+
+function flushMicrotasks(): Promise<void> {
+    return Promise.resolve().then(() => undefined).then(() => undefined);
+}
+
+let activeError: unknown = null;
+afterEach(() => {
+    activeError = null;
+});
+
+describe('videoTextureDriver: the requestVideoFrameCallback pump', () => {
+    it('D1: advances the version once per decoded frame and emits discrete then continuous kinds', () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo();
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => asElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+        const kinds: InvalidationKind[] = [];
+        driver.invalidation.connect(kind => { kinds.push(kind) });
+
+        driver.start(STREAM);
+        expect(rvfc.pending).toBe(true);
+
+        rvfc.fire();
+        rvfc.fire();
+        rvfc.fire();
+
+        expect(driver.version).toBe(3);
+        expect(kinds).toEqual(['discrete', 'continuous', 'continuous']);
+        expect(driver.status).toBe('ready');
+    });
+});
+
+describe('videoTextureDriver: the requestAnimationFrame fallback pump', () => {
+    it('D2: pumps only while the element is playing, and keeps the same discrete-then-continuous protocol', () => {
+        const raf = makeRafScheduler();
+        const video = makeFakeVideo({ paused: true });
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => asElement(video),
+            requestAnimationFrame: raf.request,
+            cancelAnimationFrame: raf.cancel
+        });
+        const kinds: InvalidationKind[] = [];
+        driver.invalidation.connect(kind => { kinds.push(kind) });
+
+        driver.start(STREAM);
+
+        raf.fire();
+        raf.fire();
+        expect(driver.version).toBe(0);
+        expect(kinds).toEqual([]);
+
+        video.paused = false;
+        raf.fire();
+        raf.fire();
+
+        expect(driver.version).toBe(2);
+        expect(kinds).toEqual(['discrete', 'continuous']);
+    });
+});
+
+describe('videoTextureDriver: getFrame readiness', () => {
+    it('D3: returns null until the element has a decoded frame with positive dimensions, then the element', () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo({ readyState: 0, videoWidth: 0, videoHeight: 0 });
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => asElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+
+        driver.start(STREAM);
+        expect(driver.getFrame()).toBeNull();
+
+        video.readyState = 2;
+        expect(driver.getFrame()).toBeNull();
+
+        video.videoWidth = 320;
+        video.videoHeight = 240;
+        expect(driver.getFrame()).toBe(video);
+    });
+});
+
+describe('videoTextureDriver: resizeToPOT laziness', () => {
+    it('D4: draws the power-of-two copy once per version, reallocates on a dimension change, and passes POT through', () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo({ videoWidth: 640, videoHeight: 480 });
+        const drawCounts: number[] = [];
+        const allocated: { width: number; height: number }[] = [];
+        const createPotCanvas = (width: number, height: number): HTMLCanvasElement => {
+            const index = allocated.length;
+            allocated.push({ width, height });
+            drawCounts[index] = 0;
+            return {
+                width,
+                height,
+                getContext: (kind: string) =>
+                    (kind === '2d' ? { drawImage: () => { drawCounts[index] += 1 } } : null)
+            } as unknown as HTMLCanvasElement;
+        };
+        const driver = createVideoTextureDriver(config({ resizeToPOT: true }), {
+            createVideo: () => asElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel,
+            createPotCanvas
+        });
+
+        driver.start(STREAM);
+        rvfc.fire();
+
+        const firstA = driver.getFrame();
+        const firstB = driver.getFrame();
+        expect(firstA).toBe(firstB);
+        expect(allocated[0]).toEqual({ width: 1024, height: 512 });
+        expect(drawCounts[0]).toBe(1);
+
+        rvfc.fire();
+        driver.getFrame();
+        expect(drawCounts[0]).toBe(2);
+        expect(allocated).toHaveLength(1);
+
+        video.videoWidth = 100;
+        video.videoHeight = 100;
+        rvfc.fire();
+        const reallocated = driver.getFrame();
+        expect(allocated).toHaveLength(2);
+        expect(allocated[1]).toEqual({ width: 128, height: 128 });
+        expect(reallocated).not.toBe(firstA);
+
+        video.videoWidth = 256;
+        video.videoHeight = 256;
+        rvfc.fire();
+        expect(driver.getFrame()).toBe(video);
+        expect(allocated).toHaveLength(2);
+    });
+});
+
+describe('videoTextureDriver: stop', () => {
+    it('D5: cancels the pump and, for an owned element, pauses and detaches it', () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo();
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => asElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+
+        driver.start(STREAM);
+        expect(rvfc.pending).toBe(true);
+
+        driver.stop();
+
+        expect(rvfc.cancelled).toHaveLength(1);
+        expect(video.pauseCalls).toBe(1);
+        expect(video.removedAttributes).toContain('src');
+        expect(video.srcObject).toBeNull();
+        expect(video.loadCalls).toBe(1);
+        expect(driver.status).toBe('idle');
+    });
+
+    it('D5: for an adopted element, stops pumping but never pauses it or touches its srcObject', () => {
+        const rvfc = makeRvfcScheduler();
+        const adopted = makeFakeVideo({ srcObject: { adopted: true } });
+        let created = 0;
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => { created += 1; return asElement(makeFakeVideo()) },
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+
+        driver.start(asElement(adopted));
+        expect(created).toBe(0);
+
+        driver.stop();
+
+        expect(rvfc.cancelled).toHaveLength(1);
+        expect(adopted.pauseCalls).toBe(0);
+        expect(adopted.srcObject).toEqual({ adopted: true });
+        expect(adopted.loadCalls).toBe(0);
+    });
+});
+
+describe('videoTextureDriver: the playing predicate', () => {
+    it('D6: is true while attached and advancing, and false after stop, pause, or end', () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo();
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => asElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+
+        expect(driver.playing()).toBe(false);
+
+        driver.start(STREAM);
+        expect(driver.playing()).toBe(true);
+
+        video.paused = true;
+        expect(driver.playing()).toBe(false);
+        video.paused = false;
+
+        video.ended = true;
+        expect(driver.playing()).toBe(false);
+        video.ended = false;
+
+        driver.stop();
+        expect(driver.playing()).toBe(false);
+    });
+});
+
+describe('videoTextureDriver: the play call', () => {
+    it('D7: survives play() returning undefined', () => {
+        const rvfc = makeRvfcScheduler();
+        const video = makeFakeVideo({ play: () => undefined });
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => asElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+
+        expect(() => { driver.start(STREAM) }).not.toThrow();
+        rvfc.fire();
+        expect(driver.status).toBe('ready');
+    });
+
+    it('D7: surfaces a play() rejection while the start is still desired as an error', async () => {
+        const rvfc = makeRvfcScheduler();
+        const denied = new Error('NotAllowedError');
+        const video = makeFakeVideo({ play: () => Promise.reject(denied) });
+        const driver = createVideoTextureDriver(config({ onError: error => { activeError = error } }), {
+            createVideo: () => asElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+
+        driver.start(STREAM);
+        await flushMicrotasks();
+
+        expect(driver.status).toBe('error');
+        expect(driver.error).toBe(denied);
+        expect(activeError).toBe(denied);
+    });
+
+    it('D7: swallows a play() rejection that lands after stop() and does not flip to error', async () => {
+        const rvfc = makeRvfcScheduler();
+        let reject: (error: unknown) => void = () => undefined;
+        const video = makeFakeVideo({ play: () => new Promise<void>((_resolve, rej) => { reject = rej }) });
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => asElement(video),
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+
+        driver.start(STREAM);
+        driver.stop();
+        reject(new Error('AbortError: interrupted by stop'));
+        await flushMicrotasks();
+
+        expect(driver.status).toBe('idle');
+        expect(driver.error).toBeNull();
+    });
+});
+
+describe('videoTextureDriver: input change', () => {
+    it('D8: stops the previous attachment and paints a fresh discrete first frame for the new input', () => {
+        const rvfc = makeRvfcScheduler();
+        const first = makeFakeVideo();
+        const second = makeFakeVideo();
+        const created: FakeVideo[] = [];
+        const queue = [first, second];
+        const driver = createVideoTextureDriver(config(), {
+            createVideo: () => {
+                const next = queue.shift();
+                if (!next) {
+                    throw new Error('unexpected extra createVideo');
+                }
+                created.push(next);
+                return asElement(next);
+            },
+            requestVideoFrameCallback: rvfc.request,
+            cancelVideoFrameCallback: rvfc.cancel
+        });
+        const kinds: InvalidationKind[] = [];
+        driver.invalidation.connect(kind => { kinds.push(kind) });
+
+        driver.start(STREAM);
+        rvfc.fire();
+        rvfc.fire();
+        expect(kinds).toEqual(['discrete', 'continuous']);
+
+        driver.start({ getTracks: () => [] } as unknown as MediaStream);
+        expect(first.pauseCalls).toBe(1);
+        rvfc.fire();
+
+        expect(created).toEqual([first, second]);
+        expect(kinds).toEqual(['discrete', 'continuous', 'discrete']);
+    });
+});

--- a/src/react/lib/videoTextureDriver.ts
+++ b/src/react/lib/videoTextureDriver.ts
@@ -208,30 +208,26 @@ export function createVideoTextureDriver(
         }
     }
 
+    function raiseError(video: HTMLVideoElement, cause: unknown): void {
+        if (desired !== 'running' || attachment === null || attachment.video !== video || status === 'error') {
+            return;
+        }
+        error = toError(cause);
+        setStatus('error');
+        config.onError?.(cause);
+        invalidation.request();
+    }
+
     function attemptPlay(video: HTMLVideoElement): void {
-        Promise.resolve(video.play()).catch((cause: unknown) => {
-            if (desired !== 'running' || attachment === null || attachment.video !== video) {
-                return;
-            }
-            error = toError(cause);
-            setStatus('error');
-            config.onError?.(cause);
-            invalidation.request();
-        });
+        Promise.resolve(video.play()).catch((cause: unknown) => { raiseError(video, cause) });
     }
 
     function onOwnedError(video: HTMLVideoElement): void {
-        if (desired !== 'running' || attachment === null || attachment.video !== video) {
-            return;
-        }
         const mediaError = video.error;
         const cause = mediaError
             ? new Error(`micugl textures: the video failed to load (media error code ${String(mediaError.code)}).`)
             : new Error('micugl textures: the video failed to load.');
-        error = cause;
-        setStatus('error');
-        config.onError?.(cause);
-        invalidation.request();
+        raiseError(video, cause);
     }
 
     function resetFrameState(): void {

--- a/src/react/lib/videoTextureDriver.ts
+++ b/src/react/lib/videoTextureDriver.ts
@@ -1,0 +1,340 @@
+import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
+import type { PotCanvasFactory } from '@/react/lib/potCanvas';
+import { defaultPotCanvasFactory, resizeSourceToPot } from '@/react/lib/potCanvas';
+import type { TextureStatus, TextureUploadSource } from '@/types';
+
+export type VideoInput = HTMLVideoElement | MediaStream | string;
+
+export interface VideoFrameCallbackMetadata {
+    width: number;
+    height: number;
+}
+
+export interface VideoTextureDriverDeps {
+    createVideo?: () => HTMLVideoElement;
+    requestVideoFrameCallback?: (
+        video: HTMLVideoElement,
+        callback: (now: number, metadata: VideoFrameCallbackMetadata) => void
+    ) => number;
+    cancelVideoFrameCallback?: (video: HTMLVideoElement, handle: number) => void;
+    requestAnimationFrame?: (callback: (now: number) => void) => number;
+    cancelAnimationFrame?: (handle: number) => void;
+    createPotCanvas?: PotCanvasFactory;
+}
+
+export interface VideoTextureDriverConfig {
+    crossOrigin: string;
+    loop: boolean;
+    resizeToPOT: boolean;
+    onError?: (error: unknown) => void;
+}
+
+export interface VideoTextureDriver {
+    start(input: VideoInput): void;
+    stop(): void;
+    getFrame(): TextureUploadSource | null;
+    playing(): boolean;
+    subscribe: (onChange: () => void) => () => void;
+    readonly version: number;
+    readonly status: TextureStatus;
+    readonly error: unknown;
+    readonly video: HTMLVideoElement | null;
+    readonly invalidation: FrameInvalidation;
+}
+
+const HAVE_CURRENT_DATA = 2;
+
+type Attachment =
+    | { kind: 'owned'; video: HTMLVideoElement }
+    | { kind: 'adopted'; video: HTMLVideoElement };
+
+type DesiredState = 'running' | 'stopped';
+
+function isMediaStream(input: VideoInput): input is MediaStream {
+    if (typeof MediaStream !== 'undefined') {
+        return input instanceof MediaStream;
+    }
+    return typeof input === 'object'
+        && typeof (input as { getTracks?: unknown }).getTracks === 'function';
+}
+
+function defaultCreateVideo(): HTMLVideoElement {
+    if (typeof document === 'undefined') {
+        throw new Error(
+            'micugl textures: this environment cannot create a <video> element, so a webcam or URL video cannot be '
+            + 'pumped. Video textures are browser-only; start() must run in a browser, never during server rendering.'
+        );
+    }
+    return document.createElement('video');
+}
+
+function toError(cause: unknown): Error {
+    return cause instanceof Error ? cause : new Error(String(cause));
+}
+
+export function createVideoTextureDriver(
+    config: VideoTextureDriverConfig,
+    deps: VideoTextureDriverDeps = {}
+): VideoTextureDriver {
+    const invalidation = createFrameInvalidation();
+    const listeners = new Set<() => void>();
+    const createVideo = deps.createVideo ?? defaultCreateVideo;
+    const createPotCanvas = deps.createPotCanvas ?? defaultPotCanvasFactory;
+
+    let attachment: Attachment | null = null;
+    let desired: DesiredState = 'stopped';
+    let status: TextureStatus = 'idle';
+    let error: unknown = null;
+    let version = 0;
+    let firstReadyEmitted = false;
+
+    let rvfcHandle: number | null = null;
+    let rafHandle: number | null = null;
+
+    let potCanvas: HTMLCanvasElement | null = null;
+    let potCache: TextureUploadSource | null = null;
+    let potCacheVersion = -1;
+
+    function notify(): void {
+        listeners.forEach(listener => { listener() });
+    }
+
+    function setStatus(next: TextureStatus): void {
+        status = next;
+        notify();
+    }
+
+    function currentVideo(): HTMLVideoElement | null {
+        return attachment ? attachment.video : null;
+    }
+
+    function frameReady(): boolean {
+        const video = currentVideo();
+        if (video === null) {
+            return false;
+        }
+        return video.readyState >= HAVE_CURRENT_DATA && video.videoWidth > 0 && video.videoHeight > 0;
+    }
+
+    function reusePotCanvas(width: number, height: number): HTMLCanvasElement {
+        if (potCanvas === null || potCanvas.width !== width || potCanvas.height !== height) {
+            potCanvas = createPotCanvas(width, height);
+        }
+        return potCanvas;
+    }
+
+    function pumpTick(): void {
+        if (desired !== 'running' || !frameReady()) {
+            return;
+        }
+        version += 1;
+        const kind = firstReadyEmitted ? 'continuous' : 'discrete';
+        firstReadyEmitted = true;
+        if (status !== 'ready') {
+            error = null;
+            setStatus('ready');
+        }
+        invalidation.request(kind);
+    }
+
+    function usesRvfc(video: HTMLVideoElement): boolean {
+        if (deps.requestVideoFrameCallback) {
+            return true;
+        }
+        return typeof (video as { requestVideoFrameCallback?: unknown }).requestVideoFrameCallback === 'function';
+    }
+
+    function scheduleRvfc(video: HTMLVideoElement): void {
+        const request = deps.requestVideoFrameCallback
+            ?? ((element, callback) => element.requestVideoFrameCallback(callback));
+        rvfcHandle = request(video, () => {
+            rvfcHandle = null;
+            if (desired !== 'running') {
+                return;
+            }
+            pumpTick();
+            if (attachment && attachment.video === video) {
+                scheduleRvfc(video);
+            }
+        });
+    }
+
+    function scheduleRaf(video: HTMLVideoElement): void {
+        const request = deps.requestAnimationFrame
+            ?? (typeof requestAnimationFrame === 'function' ? requestAnimationFrame : null);
+        if (request === null) {
+            throw new Error(
+                'micugl textures: no requestAnimationFrame is available to pump this video and the element has no '
+                + 'requestVideoFrameCallback. Run in a browser, or inject a scheduler through the driver deps.'
+            );
+        }
+        rafHandle = request(() => {
+            rafHandle = null;
+            if (desired !== 'running') {
+                return;
+            }
+            if (!video.paused && !video.ended) {
+                pumpTick();
+            }
+            if (attachment && attachment.video === video) {
+                scheduleRaf(video);
+            }
+        });
+    }
+
+    function startPump(video: HTMLVideoElement): void {
+        if (usesRvfc(video)) {
+            scheduleRvfc(video);
+        } else {
+            scheduleRaf(video);
+        }
+    }
+
+    function cancelPump(video: HTMLVideoElement): void {
+        if (rvfcHandle !== null) {
+            const cancel = deps.cancelVideoFrameCallback
+                ?? ((element, handle) => { element.cancelVideoFrameCallback(handle) });
+            cancel(video, rvfcHandle);
+            rvfcHandle = null;
+        }
+        if (rafHandle !== null) {
+            const cancel = deps.cancelAnimationFrame
+                ?? (typeof cancelAnimationFrame === 'function' ? cancelAnimationFrame : null);
+            if (cancel !== null) {
+                cancel(rafHandle);
+            }
+            rafHandle = null;
+        }
+    }
+
+    function attemptPlay(video: HTMLVideoElement): void {
+        Promise.resolve(video.play()).catch((cause: unknown) => {
+            if (desired !== 'running' || attachment === null || attachment.video !== video) {
+                return;
+            }
+            error = toError(cause);
+            setStatus('error');
+            config.onError?.(cause);
+            invalidation.request();
+        });
+    }
+
+    function onOwnedError(video: HTMLVideoElement): void {
+        if (desired !== 'running' || attachment === null || attachment.video !== video) {
+            return;
+        }
+        const mediaError = video.error;
+        const cause = mediaError
+            ? new Error(`micugl textures: the video failed to load (media error code ${String(mediaError.code)}).`)
+            : new Error('micugl textures: the video failed to load.');
+        error = cause;
+        setStatus('error');
+        config.onError?.(cause);
+        invalidation.request();
+    }
+
+    function resetFrameState(): void {
+        firstReadyEmitted = false;
+        potCache = null;
+        potCacheVersion = -1;
+    }
+
+    function start(input: VideoInput): void {
+        stop();
+        desired = 'running';
+        error = null;
+        resetFrameState();
+
+        let video: HTMLVideoElement;
+        let kind: Attachment['kind'];
+
+        if (typeof input !== 'string' && !isMediaStream(input)) {
+            video = input;
+            kind = 'adopted';
+            attachment = { kind, video };
+            setStatus('loading');
+        } else {
+            video = createVideo();
+            kind = 'owned';
+            video.muted = true;
+            video.playsInline = true;
+            video.setAttribute('playsinline', '');
+            video.loop = config.loop;
+            video.addEventListener('error', () => { onOwnedError(video) });
+            if (typeof input === 'string') {
+                video.crossOrigin = config.crossOrigin;
+                video.src = input;
+            } else {
+                video.srcObject = input;
+            }
+            attachment = { kind, video };
+            setStatus('loading');
+            attemptPlay(video);
+        }
+
+        startPump(video);
+    }
+
+    function stop(): void {
+        desired = 'stopped';
+        const current = attachment;
+        attachment = null;
+
+        if (current === null) {
+            return;
+        }
+
+        cancelPump(current.video);
+
+        if (current.kind === 'owned') {
+            current.video.pause();
+            current.video.removeAttribute('src');
+            current.video.srcObject = null;
+            current.video.load();
+        }
+
+        resetFrameState();
+        setStatus('idle');
+    }
+
+    function getFrame(): TextureUploadSource | null {
+        const video = currentVideo();
+        if (video === null || !frameReady()) {
+            return null;
+        }
+        if (!config.resizeToPOT) {
+            return video;
+        }
+        if (potCacheVersion === version && potCache !== null) {
+            return potCache;
+        }
+        potCache = resizeSourceToPot(video, reusePotCanvas);
+        potCacheVersion = version;
+        return potCache;
+    }
+
+    function playing(): boolean {
+        const video = currentVideo();
+        if (video === null) {
+            return false;
+        }
+        return !video.paused && !video.ended && video.readyState >= HAVE_CURRENT_DATA;
+    }
+
+    return {
+        start,
+        stop,
+        getFrame,
+        playing,
+        subscribe: onChange => {
+            listeners.add(onChange);
+            return () => { listeners.delete(onChange) };
+        },
+        get version() { return version },
+        get status() { return status },
+        get error() { return error },
+        get video() { return currentVideo() },
+        invalidation
+    };
+}

--- a/src/react/lib/webcamAcquisition.test.ts
+++ b/src/react/lib/webcamAcquisition.test.ts
@@ -1,26 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { makeFakeStream } from '@/react/lib/fakeVideo';
 import type { WebcamAcquisitionDeps } from '@/react/lib/webcamAcquisition';
 import { buildWebcamConstraints, createWebcamAcquisition } from '@/react/lib/webcamAcquisition';
-
-interface FakeTrack {
-    stopped: boolean;
-    stop: () => void;
-}
-
-interface FakeStream {
-    stream: MediaStream;
-    tracks: FakeTrack[];
-}
-
-function makeStream(): FakeStream {
-    const tracks: FakeTrack[] = [
-        { stopped: false, stop() { this.stopped = true } },
-        { stopped: false, stop() { this.stopped = true } }
-    ];
-    const stream = { getTracks: () => tracks } as unknown as MediaStream;
-    return { stream, tracks };
-}
 
 function noopDeps(overrides: Partial<WebcamAcquisitionDeps>): WebcamAcquisitionDeps {
     return {
@@ -44,7 +26,7 @@ describe('buildWebcamConstraints', () => {
 
 describe('webcamAcquisition: releasing a grant', () => {
     it('A2: stops every track when the step after the grant throws', async () => {
-        const { stream, tracks } = makeStream();
+        const { stream, tracks } = makeFakeStream();
         const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
             getUserMedia: () => Promise.resolve(stream),
             attach: () => { throw new Error('attach exploded') }
@@ -58,7 +40,7 @@ describe('webcamAcquisition: releasing a grant', () => {
     });
 
     it('A3: a stop() during the prompt releases the grant when it lands, with no error', async () => {
-        const { stream, tracks } = makeStream();
+        const { stream, tracks } = makeFakeStream();
         let grant: (value: MediaStream) => void = () => undefined;
         let attaches = 0;
         const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
@@ -84,7 +66,7 @@ describe('webcamAcquisition: releasing a grant', () => {
 
 describe('webcamAcquisition: reconciling repeated starts', () => {
     it('A4: start() while starting opens the camera exactly once', async () => {
-        const { stream } = makeStream();
+        const { stream } = makeFakeStream();
         let calls = 0;
         const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
             getUserMedia: () => { calls += 1; return Promise.resolve(stream) }
@@ -101,7 +83,7 @@ describe('webcamAcquisition: reconciling repeated starts', () => {
     });
 
     it('A4: start() then stop() then start() while the prompt is open adopts the one grant it asked for', async () => {
-        const { stream } = makeStream();
+        const { stream } = makeFakeStream();
         let calls = 0;
         let attaches = 0;
         let grant: (value: MediaStream) => void = () => undefined;
@@ -126,7 +108,7 @@ describe('webcamAcquisition: reconciling repeated starts', () => {
 
 describe('webcamAcquisition: stopping a live camera', () => {
     it('A5: stops every track and detaches when stopped from running', async () => {
-        const { stream, tracks } = makeStream();
+        const { stream, tracks } = makeFakeStream();
         let detaches = 0;
         const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
             getUserMedia: () => Promise.resolve(stream),

--- a/src/react/lib/webcamAcquisition.test.ts
+++ b/src/react/lib/webcamAcquisition.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WebcamAcquisitionDeps } from '@/react/lib/webcamAcquisition';
+import { buildWebcamConstraints, createWebcamAcquisition } from '@/react/lib/webcamAcquisition';
+
+interface FakeTrack {
+    stopped: boolean;
+    stop: () => void;
+}
+
+interface FakeStream {
+    stream: MediaStream;
+    tracks: FakeTrack[];
+}
+
+function makeStream(): FakeStream {
+    const tracks: FakeTrack[] = [
+        { stopped: false, stop() { this.stopped = true } },
+        { stopped: false, stop() { this.stopped = true } }
+    ];
+    const stream = { getTracks: () => tracks } as unknown as MediaStream;
+    return { stream, tracks };
+}
+
+function noopDeps(overrides: Partial<WebcamAcquisitionDeps>): WebcamAcquisitionDeps {
+    return {
+        attach: () => undefined,
+        detach: () => undefined,
+        ...overrides
+    };
+}
+
+describe('buildWebcamConstraints', () => {
+    it('A1: always disables audio and passes the video hints through', () => {
+        expect(buildWebcamConstraints()).toEqual({ video: true, audio: false });
+        expect(buildWebcamConstraints({})).toEqual({ video: true, audio: false });
+        expect(buildWebcamConstraints({ deviceId: 'cam-2', facingMode: 'environment', width: 1280, height: 720 }))
+            .toEqual({
+                video: { deviceId: 'cam-2', facingMode: 'environment', width: 1280, height: 720 },
+                audio: false
+            });
+    });
+});
+
+describe('webcamAcquisition: releasing a grant', () => {
+    it('A2: stops every track when the step after the grant throws', async () => {
+        const { stream, tracks } = makeStream();
+        const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
+            getUserMedia: () => Promise.resolve(stream),
+            attach: () => { throw new Error('attach exploded') }
+        }));
+
+        await expect(acquisition.start()).rejects.toThrow('attach exploded');
+
+        expect(tracks.every(track => track.stopped)).toBe(true);
+        expect(acquisition.status).toBe('error');
+        expect(acquisition.error).toBeInstanceOf(Error);
+    });
+
+    it('A3: a stop() during the prompt releases the grant when it lands, with no error', async () => {
+        const { stream, tracks } = makeStream();
+        let grant: (value: MediaStream) => void = () => undefined;
+        let attaches = 0;
+        const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
+            getUserMedia: () => new Promise<MediaStream>(resolve => { grant = resolve }),
+            attach: () => { attaches += 1 }
+        }));
+
+        const starting = acquisition.start();
+        expect(acquisition.status).toBe('starting');
+
+        acquisition.stop();
+        expect(acquisition.status).toBe('stopped');
+
+        grant(stream);
+        await expect(starting).resolves.toBeUndefined();
+
+        expect(attaches).toBe(0);
+        expect(tracks.every(track => track.stopped)).toBe(true);
+        expect(acquisition.status).toBe('stopped');
+        expect(acquisition.error).toBeNull();
+    });
+});
+
+describe('webcamAcquisition: reconciling repeated starts', () => {
+    it('A4: start() while starting opens the camera exactly once', async () => {
+        const { stream } = makeStream();
+        let calls = 0;
+        const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
+            getUserMedia: () => { calls += 1; return Promise.resolve(stream) }
+        }));
+
+        const first = acquisition.start();
+        const second = acquisition.start();
+        expect(acquisition.status).toBe('starting');
+
+        await Promise.all([first, second]);
+
+        expect(calls).toBe(1);
+        expect(acquisition.status).toBe('running');
+    });
+
+    it('A4: start() then stop() then start() while the prompt is open adopts the one grant it asked for', async () => {
+        const { stream } = makeStream();
+        let calls = 0;
+        let attaches = 0;
+        let grant: (value: MediaStream) => void = () => undefined;
+        const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
+            getUserMedia: () => { calls += 1; return new Promise<MediaStream>(resolve => { grant = resolve }) },
+            attach: () => { attaches += 1 }
+        }));
+
+        const first = acquisition.start();
+        acquisition.stop();
+        const third = acquisition.start();
+        expect(acquisition.status).toBe('starting');
+
+        grant(stream);
+        await Promise.all([first, third]);
+
+        expect(calls).toBe(1);
+        expect(attaches).toBe(1);
+        expect(acquisition.status).toBe('running');
+    });
+});
+
+describe('webcamAcquisition: stopping a live camera', () => {
+    it('A5: stops every track and detaches when stopped from running', async () => {
+        const { stream, tracks } = makeStream();
+        let detaches = 0;
+        const acquisition = createWebcamAcquisition(buildWebcamConstraints(), noopDeps({
+            getUserMedia: () => Promise.resolve(stream),
+            detach: () => { detaches += 1 }
+        }));
+
+        await acquisition.start();
+        expect(acquisition.status).toBe('running');
+        expect(acquisition.stream).toBe(stream);
+
+        acquisition.stop();
+
+        expect(detaches).toBe(1);
+        expect(tracks.every(track => track.stopped)).toBe(true);
+        expect(acquisition.status).toBe('stopped');
+        expect(acquisition.stream).toBeNull();
+    });
+});

--- a/src/react/lib/webcamAcquisition.ts
+++ b/src/react/lib/webcamAcquisition.ts
@@ -1,0 +1,195 @@
+export interface WebcamConstraintOptions {
+    deviceId?: string;
+    facingMode?: 'user' | 'environment';
+    width?: number;
+    height?: number;
+}
+
+export interface WebcamAcquisitionDeps {
+    getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+    attach: (stream: MediaStream) => void;
+    detach: () => void;
+}
+
+export type WebcamAcquisitionStatus = 'idle' | 'starting' | 'running' | 'stopped' | 'error';
+
+export interface WebcamAcquisition {
+    start: () => Promise<void>;
+    stop: () => void;
+    subscribe: (onChange: () => void) => () => void;
+    readonly status: WebcamAcquisitionStatus;
+    readonly error: Error | null;
+    readonly stream: MediaStream | null;
+}
+
+type AcquisitionState =
+    | { kind: 'idle' }
+    | { kind: 'starting'; pending: Promise<void> }
+    | { kind: 'running'; stream: MediaStream }
+    | { kind: 'stopped' }
+    | { kind: 'error'; error: Error };
+
+type DesiredState = 'running' | 'stopped';
+
+export function buildWebcamConstraints(options: WebcamConstraintOptions = {}): MediaStreamConstraints {
+    const video: MediaTrackConstraints = {};
+
+    if (options.deviceId !== undefined) {
+        video.deviceId = options.deviceId;
+    }
+    if (options.facingMode !== undefined) {
+        video.facingMode = options.facingMode;
+    }
+    if (options.width !== undefined) {
+        video.width = options.width;
+    }
+    if (options.height !== undefined) {
+        video.height = options.height;
+    }
+
+    return {
+        video: Object.keys(video).length === 0 ? true : video,
+        audio: false
+    };
+}
+
+function defaultGetUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream> {
+    if (typeof navigator !== 'object' || typeof navigator.mediaDevices !== 'object') {
+        throw new Error(
+            'micugl textures: navigator.mediaDevices.getUserMedia is unavailable, so the webcam cannot be opened. '
+            + 'getUserMedia only exists in a secure context: serve the page over https, or from localhost.'
+        );
+    }
+    return navigator.mediaDevices.getUserMedia(constraints);
+}
+
+function toError(cause: unknown): Error {
+    return cause instanceof Error ? cause : new Error(String(cause));
+}
+
+function keepRejectionHandled(promise: Promise<void>): void {
+    void promise.catch(() => undefined);
+}
+
+function stopTracks(stream: MediaStream): void {
+    for (const track of stream.getTracks()) {
+        track.stop();
+    }
+}
+
+export function createWebcamAcquisition(
+    constraints: MediaStreamConstraints,
+    deps: WebcamAcquisitionDeps
+): WebcamAcquisition {
+    const listeners = new Set<() => void>();
+    const getUserMedia = deps.getUserMedia ?? defaultGetUserMedia;
+
+    let state: AcquisitionState = { kind: 'idle' };
+    let desired: DesiredState = 'stopped';
+
+    function notify(): void {
+        listeners.forEach(listener => { listener() });
+    }
+
+    function setState(next: AcquisitionState): void {
+        state = next;
+        notify();
+    }
+
+    function readStatus(): WebcamAcquisitionStatus {
+        if (state.kind === 'starting' && desired === 'stopped') {
+            return 'stopped';
+        }
+        return state.kind;
+    }
+
+    async function beginStart(): Promise<void> {
+        let stream: MediaStream | null = null;
+        let attached = false;
+        let failure: Error | null = null;
+
+        try {
+            stream = await getUserMedia(constraints);
+            if (desired === 'running') {
+                deps.attach(stream);
+                attached = true;
+            }
+        } catch (cause) {
+            failure = toError(cause);
+        }
+
+        if (!attached && stream !== null) {
+            stopTracks(stream);
+        }
+
+        if (failure !== null) {
+            if (desired === 'running') {
+                desired = 'stopped';
+                setState({ kind: 'error', error: failure });
+            } else {
+                setState({ kind: 'stopped' });
+            }
+            throw failure;
+        }
+
+        if (!attached || stream === null) {
+            setState({ kind: 'stopped' });
+            return;
+        }
+
+        setState({ kind: 'running', stream });
+    }
+
+    function start(): Promise<void> {
+        const wasStopping = desired === 'stopped';
+        desired = 'running';
+
+        if (state.kind === 'running') {
+            return Promise.resolve();
+        }
+        if (state.kind === 'starting') {
+            if (wasStopping) {
+                notify();
+            }
+            return state.pending;
+        }
+
+        const run = beginStart();
+        keepRejectionHandled(run);
+        setState({ kind: 'starting', pending: run });
+
+        return run;
+    }
+
+    function stop(): void {
+        const wasStarting = desired === 'running';
+        desired = 'stopped';
+
+        if (state.kind === 'starting') {
+            if (wasStarting) {
+                notify();
+            }
+            return;
+        }
+
+        if (state.kind !== 'running') {
+            return;
+        }
+
+        deps.detach();
+        stopTracks(state.stream);
+        setState({ kind: 'stopped' });
+    }
+
+    return {
+        start,
+        stop,
+        subscribe: onChange => {
+            listeners.add(onChange);
+            return () => { listeners.delete(onChange) };
+        },
+        get status() { return readStatus() },
+        get error() { return state.kind === 'error' ? state.error : null },
+        get stream() { return state.kind === 'running' ? state.stream : null }
+    };
+}

--- a/src/react/lib/webcamAcquisition.ts
+++ b/src/react/lib/webcamAcquisition.ts
@@ -9,6 +9,7 @@ export interface WebcamAcquisitionDeps {
     getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
     attach: (stream: MediaStream) => void;
     detach: () => void;
+    onError?: (error: unknown) => void;
 }
 
 export type WebcamAcquisitionStatus = 'idle' | 'starting' | 'running' | 'stopped' | 'error';
@@ -16,6 +17,7 @@ export type WebcamAcquisitionStatus = 'idle' | 'starting' | 'running' | 'stopped
 export interface WebcamAcquisition {
     start: () => Promise<void>;
     stop: () => void;
+    fail: (cause: unknown) => void;
     subscribe: (onChange: () => void) => () => void;
     readonly status: WebcamAcquisitionStatus;
     readonly error: Error | null;
@@ -126,6 +128,7 @@ export function createWebcamAcquisition(
             if (desired === 'running') {
                 desired = 'stopped';
                 setState({ kind: 'error', error: failure });
+                deps.onError?.(failure);
             } else {
                 setState({ kind: 'stopped' });
             }
@@ -181,9 +184,24 @@ export function createWebcamAcquisition(
         setState({ kind: 'stopped' });
     }
 
+    function fail(cause: unknown): void {
+        if (state.kind === 'error') {
+            return;
+        }
+        const failure = toError(cause);
+        desired = 'stopped';
+        if (state.kind === 'running') {
+            deps.detach();
+            stopTracks(state.stream);
+        }
+        setState({ kind: 'error', error: failure });
+        deps.onError?.(failure);
+    }
+
     return {
         start,
         stop,
+        fail,
         subscribe: onChange => {
             listeners.add(onChange);
             return () => { listeners.delete(onChange) };

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,7 @@ export interface TextureSource {
   options: ResolvedSourceTextureOptions;
   getFrame: () => TextureUploadSource | null;
   invalidation: FrameInvalidation;
+  nonReproducible?: () => boolean;
 }
 
 export interface TextureBindingSpec {


### PR DESCRIPTION
Input-textures T3: `useVideoTexture` + `useWebcamTexture` + `?scene=webcam` + a fake-device e2e spec. Closes the video/webcam half of the input-textures track.

## What ships

- **`useVideoTexture(input, options)`** — `HTMLVideoElement | MediaStream | string`. A caller-provided element is ADOPTED (micugl never calls `play()`/`pause()` or touches `srcObject` on it — you own playback, micugl pumps and samples); a URL or stream gets a hidden micugl-owned element (`muted`, `playsInline`, played automatically — no permission involved). Returns `{ texture, status, error, video }` with the image-hook error surface (no `onError` = re-throw into the nearest boundary).
- **`useWebcamTexture(options)`** — explicit `start()`/`stop()`, never auto-starts. `getUserMedia({ video: constraints, audio: false })` — audio is never requested, there is no option to. `deviceId`/`facingMode`/`width`/`height` passthrough only. Desired-state lifecycle (the audio-driver model): StrictMode cannot double-prompt, a throw after the grant releases the tracks, `stop()` during the prompt releases the stream when it lands, unmount ends all tracks.
- **Frame pump** — `requestVideoFrameCallback` per decoded frame (one-shot, re-armed each frame), rAF fallback. The first ready frame requests `'discrete'` (a gated reduced-motion poster repaints exactly once showing a frozen first frame — probed: all-continuous would leave the placeholder black forever); every subsequent frame requests `'continuous'`, which a static gate suppresses (#60's contract). The kind rides `TextureSource.invalidation` through the existing fan-in verbatim — no new subscription path.
- **Deterministic capture fails loud on a PLAYING video** — `CaptureBlocker` gains `'texture'`; `TextureSource.nonReproducible` is a predicate collected through `useTextureBindings` and composed with the uniform blockers in both single-program base components. `renderToBlob({frame})` / `renderSequence` throw naming the culprit while a video/webcam is playing; a paused video or stopped camera does NOT block; the live-clock paths — `renderToBlob()` with no frame, `record()`, `captureStream()` — stay open (the demo's Capture PNG button uses exactly that path on a running camera).
- **`resizeToPOT` works on video** — lazy POT copy at upload time, at most one `drawImage` per decoded frame actually uploaded (a gated engine pays nothing), cached canvas reallocated on dimension change. Mipmap min-filters regenerate per upload (T2 semantics); costs documented in the README.
- **Demo** — `?scene=webcam`: Enable/Disable camera, status + error line, live Capture PNG. Never auto-starts.
- **e2e** — `e2e/webcam.spec.ts` with Chromium fake-device flags scoped to the file (`--use-fake-device-for-media-stream`, `--use-fake-ui-for-media-stream`): enable → pixels change AND uploads advance; disable → pixels freeze. No real hardware is ever touched by any test.

## Review record

Opus implementer (plan built from live probes: the capture hole, the gated-poster kinds, jsdom's promiseless `play()`), then double read-only Opus review, one apply pass, and a standalone edit-empowered pass:

- Style lens found the blocking bug (fifth time): webcam `onError` never fired on a getUserMedia rejection — the dominant webcam failure — and its covering test collected the reports array without asserting on it. Fixed: `onError` fires exactly once from the failure transition; a driver-side `play()` failure now routes through the acquisition, releasing the tracks (camera indicator clears) and surfacing `'error'`.
- Correctness lens confirmed the anchor test drives the real wiring and the kind trap-test discriminates both directions; flagged H5's vacuous half (fixed with a second invalidation source + total-upload deltas — `fullUploads()` counts only `texImage2D` and is blind to same-size `texSubImage2D` re-uploads, a pattern also fixed in H4).
- Standalone pass found one more product defect post-apply: a broken URL video rejects `play()` AND fires an `error` event, so video `onError` fired twice with two different errors; both paths now dedupe through one guarded `raiseError`. Also added the placeholder-then-first-frame component test (the always-ready fake had masked that transition).

1070 vitest tests (was 1031), counters 19/19, worker+webcam e2e 10/10. Every new test revert-verified (red without its feature, spot-checked by reviewers).

## Manual real-camera checklist (Micu — nothing below is machine-verified; all automated coverage uses injected fakes or Chromium fake devices)

1. `bun run dev` → `?scene=webcam`. The scene must NOT prompt for the camera at load.
2. Click **Enable camera** → browser prompt appears; grant. Live feed samples into the shader; the OS camera indicator turns on.
3. Click **Disable camera** → the indicator CLEARS (tracks ended, not just paused). The canvas freezes.
4. Enable again, then click **Capture PNG** while running → a PNG of the current live frame downloads (this is the honest live path; it must NOT throw).
5. With the camera running, in the console: `document.querySelector('canvas')` handle path if you have one wired, or simply verify from the scene that a deterministic export is refused — the scene has no such button, so optionally skip; the unit suite covers it.
6. Reload with `&strict=1` → Enable camera → the permission prompt appears exactly ONCE (StrictMode double-mount must not double-prompt).
7. Start the camera, then RELOAD mid-prompt (click Enable, don't answer, reload) → after the reload the indicator must be off.
8. OS reduced-motion ON → reload → Enable camera → the canvas shows a FROZEN first frame (not black, not animating). Disable reduced motion → animation resumes on the next interaction/invalidation.
9. Unplug/deny path: deny the permission prompt → the scene's error line renders the failure (no crash, no silent black).
