### PR TITLE
composition: C1 core - graph planner, source texture bindings through Passes, per-pass output dims

### DIFF
--- a/src/core/lib/graphPlanning.test.ts
+++ b/src/core/lib/graphPlanning.test.ts
@@ -86,6 +86,28 @@ describe('planGraph: malformed graphs', () => {
         expect(() => planGraph(root)).toThrow(/node "root"/);
         expect(() => planGraph(root)).toThrow(/uniform "bad"/);
     });
+
+    it('throws naming node and uniform when a uniform value is null, not a raw type error', () => {
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg(),
+            uniforms: { hook: null as unknown as GraphUniformValue }
+        });
+
+        expect(() => planGraph(root)).toThrow(/node "root"/);
+        expect(() => planGraph(root)).toThrow(/uniform "hook"/);
+    });
+
+    it('throws naming node and uniform when a uniform value is undefined, not a raw type error', () => {
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg(),
+            uniforms: { hook: undefined as unknown as GraphUniformValue }
+        });
+
+        expect(() => planGraph(root)).toThrow(/node "root"/);
+        expect(() => planGraph(root)).toThrow(/uniform "hook"/);
+    });
 });
 
 describe('planGraph: framebuffers and root', () => {
@@ -190,6 +212,16 @@ describe('planGraph: sampler names', () => {
 
         expect(() => planGraph(root)).toThrow(/for both a texture sampler and a value/);
     });
+
+    it('throws when two value uniforms normalize to the same name', () => {
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg({ u_k: 'float' }),
+            uniforms: { k: { type: 'float', value: 1 }, u_k: { type: 'float', value: 2 } }
+        });
+
+        expect(() => planGraph(root)).toThrow(/two value uniforms that both resolve to "u_k"/);
+    });
 });
 
 describe('planGraph: sources', () => {
@@ -237,9 +269,15 @@ describe('planGraph: program configs', () => {
 });
 
 describe('planGraph: topology', () => {
-    it('emits a topology derivable from the passes, with a null framebuffer only for the root', () => {
+    it('emits a topology whose nodes, edges, sources, dims and uniform names match the built plan', () => {
         const source = fakeSource('img');
-        const leaf = shaderNode({ id: 'leaf', shaderConfig: cfg(), uniforms: { img: source } });
+        const leaf = shaderNode({
+            id: 'leaf',
+            shaderConfig: cfg(),
+            uniforms: { img: source },
+            width: 16,
+            height: 8
+        });
         const root = shaderNode({
             id: 'root',
             shaderConfig: cfg({ u_k: 'float' }),
@@ -250,26 +288,36 @@ describe('planGraph: topology', () => {
 
         expect(plan.topology.rootId).toBe('root');
 
+        const topoIds = plan.topology.nodes.map(topoNode => topoNode.id).sort();
+        expect(topoIds).toEqual(plan.order.map(node => node.id).sort());
+        expect(topoIds).toEqual(plan.passes.map(pass => pass.nodeId).sort());
+
+        const topoById = new Map(plan.topology.nodes.map(topoNode => [topoNode.id, topoNode]));
+
+        expect(topoById.get('leaf')).toEqual({
+            id: 'leaf',
+            framebufferId: 'leaf-out',
+            width: 16,
+            height: 8,
+            edges: [],
+            sources: [{ samplerName: 'u_img', sourceId: 'img' }],
+            uniformNames: []
+        });
+
+        expect(topoById.get('root')).toEqual({
+            id: 'root',
+            framebufferId: null,
+            width: 0,
+            height: 0,
+            edges: [{ samplerName: 'u_tex', childId: 'leaf' }],
+            sources: [],
+            uniformNames: ['u_k']
+        });
+
         for (const topoNode of plan.topology.nodes) {
             const pass = plan.passes.find(candidate => candidate.nodeId === topoNode.id);
-            expect(pass).toBeDefined();
             expect(topoNode.framebufferId).toBe(pass?.outputFramebufferId);
-
-            const edgeChildIds = topoNode.edges.map(edge => edge.childId);
-            const sourceIds = topoNode.sources.map(entry => entry.sourceId);
-            for (const input of pass?.inputs ?? []) {
-                if (input.kind === 'node') {
-                    expect(edgeChildIds).toContain(input.childId);
-                } else {
-                    expect(sourceIds).toContain(input.sourceId);
-                }
-            }
         }
-
-        const nullFramebufferIds = plan.topology.nodes
-            .filter(topoNode => topoNode.framebufferId === null)
-            .map(topoNode => topoNode.id);
-        expect(nullFramebufferIds).toEqual(['root']);
     });
 });
 
@@ -285,21 +333,23 @@ describe('toRenderPasses', () => {
         });
 
         const plan = planGraph(root);
+        const valueById: Record<string, number> = { leaf: 11, root: 22 };
         const uniformsFor = (nodeId: string): Record<string, { type: UniformType; value: number }> =>
-            ({ u_k: { type: 'float', value: nodeId.length } });
+            ({ u_k: { type: 'float', value: valueById[nodeId] } });
         const passes = toRenderPasses(plan, uniformsFor);
 
         expect(passes[0].inputTextures).toEqual([
             { id: 'img', textureUnit: 0, bindingType: 'source', samplerName: 'u_img' }
         ]);
         expect(passes[0].outputFramebuffer).toBe('leaf-out');
-        expect(passes[0].uniforms).toEqual({ u_k: { type: 'float', value: 4 } });
+        expect(passes[0].uniforms).toEqual({ u_k: { type: 'float', value: 11 } });
         expect(passes[0].renderOptions).toEqual({ clear: true });
 
         expect(passes[1].inputTextures).toEqual([
             { id: 'leaf-out', textureUnit: 0, bindingType: 'read', samplerName: 'u_tex' }
         ]);
         expect(passes[1].outputFramebuffer).toBeNull();
+        expect(passes[1].uniforms).toEqual({ u_k: { type: 'float', value: 22 } });
         expect(passes[1].renderOptions).toEqual({ clear: false });
     });
 });

--- a/src/core/lib/graphPlanning.test.ts
+++ b/src/core/lib/graphPlanning.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
+import { GL_LINEAR, GL_NEAREST } from '@/core/lib/glConstants';
+import type { GraphUniformValue } from '@/core/lib/graphPlanning';
+import { isShaderNode, planGraph, shaderNode, toRenderPasses } from '@/core/lib/graphPlanning';
+import { resolveSourceTextureOptions } from '@/core/lib/sourceTextureOptions';
+import type { ShaderProgramConfig, TextureSource, UniformType } from '@/types';
+
+function cfg(uniformNames: Record<string, UniformType> = {}): ShaderProgramConfig {
+    return {
+        vertexShader: '',
+        fragmentShader: '',
+        uniforms: Object.entries(uniformNames).map(([name, type]) => ({ name, type }))
+    };
+}
+
+function fakeSource(id: string): TextureSource {
+    return {
+        id,
+        version: 0,
+        options: resolveSourceTextureOptions(),
+        getFrame: () => null,
+        invalidation: createFrameInvalidation()
+    };
+}
+
+describe('planGraph: order', () => {
+    it('emits a linear chain in post-order, leaf before parent, pass order = execution order', () => {
+        const leaf = shaderNode({ id: 'leaf', shaderConfig: cfg(), uniforms: {} });
+        const mid = shaderNode({ id: 'mid', shaderConfig: cfg(), uniforms: { tex: leaf } });
+        const root = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { tex: mid } });
+
+        const plan = planGraph(root);
+
+        expect(plan.order.map(node => node.id)).toEqual(['leaf', 'mid', 'root']);
+        expect(plan.passes.map(pass => pass.nodeId)).toEqual(['leaf', 'mid', 'root']);
+    });
+
+    it('plans a shared child once and both parents bind its framebuffer', () => {
+        const shared = shaderNode({ id: 'shared', shaderConfig: cfg(), uniforms: {} });
+        const left = shaderNode({ id: 'left', shaderConfig: cfg(), uniforms: { tex: shared } });
+        const right = shaderNode({ id: 'right', shaderConfig: cfg(), uniforms: { tex: shared } });
+        const root = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { a: left, b: right } });
+
+        const plan = planGraph(root);
+
+        expect(plan.passes.filter(pass => pass.nodeId === 'shared')).toHaveLength(1);
+        expect(Object.keys(plan.framebuffers).filter(id => id === 'shared-out')).toHaveLength(1);
+
+        const leftPass = plan.passes.find(pass => pass.nodeId === 'left');
+        const rightPass = plan.passes.find(pass => pass.nodeId === 'right');
+        expect(leftPass?.inputs).toEqual([{ kind: 'node', childId: 'shared', samplerName: 'u_tex', textureUnit: 0 }]);
+        expect(rightPass?.inputs).toEqual([{ kind: 'node', childId: 'shared', samplerName: 'u_tex', textureUnit: 0 }]);
+    });
+});
+
+describe('planGraph: malformed graphs', () => {
+    it('throws with the full path when a cycle is built by mutation', () => {
+        const nodeA = shaderNode({ id: 'a', shaderConfig: cfg(), uniforms: {} });
+        const nodeB = shaderNode({ id: 'b', shaderConfig: cfg(), uniforms: { tex: nodeA } });
+        nodeA.uniforms.loop = nodeB;
+
+        expect(() => planGraph(nodeA)).toThrow(/a -> b -> a/);
+    });
+
+    it('throws for two different node objects with the same id, but treats the same object twice as a diamond', () => {
+        const first = shaderNode({ id: 'x', shaderConfig: cfg(), uniforms: {} });
+        const second = shaderNode({ id: 'x', shaderConfig: cfg(), uniforms: {} });
+        const collide = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { a: first, b: second } });
+
+        expect(() => planGraph(collide)).toThrow(/two different nodes share the id "x"/);
+
+        const same = shaderNode({ id: 'y', shaderConfig: cfg(), uniforms: {} });
+        const diamond = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { a: same, b: same } });
+        expect(() => planGraph(diamond)).not.toThrow();
+    });
+
+    it('throws when a uniform value is neither a param, a node, nor a source, naming node and uniform', () => {
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg(),
+            uniforms: { bad: 42 as unknown as GraphUniformValue }
+        });
+
+        expect(() => planGraph(root)).toThrow(/node "root"/);
+        expect(() => planGraph(root)).toThrow(/uniform "bad"/);
+    });
+});
+
+describe('planGraph: framebuffers and root', () => {
+    it('gives the root a null output framebuffer and throws if the root is sized', () => {
+        const root = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: {} });
+        expect(planGraph(root).passes[0].outputFramebufferId).toBeNull();
+
+        const sizedRoot = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: {}, width: 10, height: 10 });
+        expect(() => planGraph(sizedRoot)).toThrow(/root node "root" declares width\/height/);
+    });
+
+    it('allocates a single-texture framebuffer per non-root node, defaulting size to 0 and filters to LINEAR', () => {
+        const leaf = shaderNode({ id: 'leaf', shaderConfig: cfg(), uniforms: {} });
+        const root = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { tex: leaf } });
+
+        expect(planGraph(root).framebuffers['leaf-out']).toEqual({
+            width: 0,
+            height: 0,
+            textureCount: 1,
+            textureOptions: { minFilter: GL_LINEAR, magFilter: GL_LINEAR }
+        });
+
+        const sized = shaderNode({
+            id: 'sized',
+            shaderConfig: cfg(),
+            uniforms: {},
+            width: 16,
+            height: 8,
+            textureOptions: { minFilter: GL_NEAREST }
+        });
+        const rootWithSized = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { tex: sized } });
+
+        expect(planGraph(rootWithSized).framebuffers['sized-out']).toEqual({
+            width: 16,
+            height: 8,
+            textureCount: 1,
+            textureOptions: { minFilter: GL_NEAREST }
+        });
+    });
+});
+
+describe('planGraph: texture units', () => {
+    it('assigns units 0..n-1 in declaration order across mixed node and source inputs', () => {
+        const first = shaderNode({ id: 'c1', shaderConfig: cfg(), uniforms: {} });
+        const second = shaderNode({ id: 'c2', shaderConfig: cfg(), uniforms: {} });
+        const source = fakeSource('s1');
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg(),
+            uniforms: { a: first, b: source, c: second }
+        });
+
+        const rootPass = planGraph(root).passes.find(pass => pass.nodeId === 'root');
+        expect(rootPass?.inputs).toEqual([
+            { kind: 'node', childId: 'c1', samplerName: 'u_a', textureUnit: 0 },
+            { kind: 'source', sourceId: 's1', samplerName: 'u_b', textureUnit: 1 },
+            { kind: 'node', childId: 'c2', samplerName: 'u_c', textureUnit: 2 }
+        ]);
+    });
+
+    it('throws with the count when a node binds past the unit limit, and honours maxTextureUnits', () => {
+        const uniforms: Record<string, GraphUniformValue> = {};
+        for (let index = 0; index < 9; index++) {
+            uniforms[`t${index}`] = fakeSource(`s${index}`);
+        }
+        const tooMany = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms });
+        expect(() => planGraph(tooMany)).toThrow(/binds 9 texture inputs, past the limit of 8/);
+
+        const three = shaderNode({
+            id: 'root',
+            shaderConfig: cfg(),
+            uniforms: { a: fakeSource('a'), b: fakeSource('b'), c: fakeSource('c') }
+        });
+        expect(() => planGraph(three, { maxTextureUnits: 2 })).toThrow(/binds 3 texture inputs, past the limit of 2/);
+    });
+});
+
+describe('planGraph: sampler names', () => {
+    it('normalizes a bare uniform key into a sampler name', () => {
+        const child = shaderNode({ id: 'c', shaderConfig: cfg(), uniforms: {} });
+        const root = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { src: child } });
+
+        const rootPass = planGraph(root).passes.find(pass => pass.nodeId === 'root');
+        expect(rootPass?.inputs[0].samplerName).toBe('u_src');
+    });
+
+    it('throws when two texture inputs normalize to the same sampler name', () => {
+        const first = shaderNode({ id: 'c1', shaderConfig: cfg(), uniforms: {} });
+        const second = shaderNode({ id: 'c2', shaderConfig: cfg(), uniforms: {} });
+        const root = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { tex: first, u_tex: second } });
+
+        expect(() => planGraph(root)).toThrow(/both resolve to sampler "u_tex"/);
+    });
+
+    it('throws when a sampler name collides with one of the node value-uniform names', () => {
+        const child = shaderNode({ id: 'c', shaderConfig: cfg(), uniforms: {} });
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg(),
+            uniforms: { mix: child, u_mix: { type: 'float', value: 0 } }
+        });
+
+        expect(() => planGraph(root)).toThrow(/for both a texture sampler and a value/);
+    });
+});
+
+describe('planGraph: sources', () => {
+    it('dedupes the same source object across nodes and throws for two objects sharing an id', () => {
+        const source = fakeSource('img');
+        const left = shaderNode({ id: 'left', shaderConfig: cfg(), uniforms: { img: source } });
+        const right = shaderNode({ id: 'right', shaderConfig: cfg(), uniforms: { img: source } });
+        const root = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { a: left, b: right } });
+
+        const plan = planGraph(root);
+        expect(plan.sources).toHaveLength(1);
+        expect(plan.sources[0]).toBe(source);
+
+        const one = fakeSource('img');
+        const two = fakeSource('img');
+        const leftClash = shaderNode({ id: 'left', shaderConfig: cfg(), uniforms: { img: one } });
+        const rightClash = shaderNode({ id: 'right', shaderConfig: cfg(), uniforms: { img: two } });
+        const rootClash = shaderNode({ id: 'root', shaderConfig: cfg(), uniforms: { a: leftClash, b: rightClash } });
+
+        expect(() => planGraph(rootClash)).toThrow(/different source object already claims that id/);
+    });
+});
+
+describe('planGraph: program configs', () => {
+    it('auto-declares samplers for edges and sources without duplicating an existing declaration', () => {
+        const child = shaderNode({ id: 'c', shaderConfig: cfg(), uniforms: {} });
+        const source = fakeSource('img');
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg({ u_tex: 'sampler2D' }),
+            uniforms: { tex: child, img: source }
+        });
+
+        const rootConfig = planGraph(root).programConfigs.root;
+        const names = rootConfig.uniforms.map(uniform => uniform.name);
+
+        expect(names).toContain('u_tex');
+        expect(names).toContain('u_img');
+        expect(rootConfig.uniforms.find(uniform => uniform.name === 'u_img')).toEqual({
+            name: 'u_img',
+            type: 'sampler2D'
+        });
+        expect(rootConfig.uniforms.filter(uniform => uniform.name === 'u_tex')).toHaveLength(1);
+    });
+});
+
+describe('planGraph: topology', () => {
+    it('emits a topology derivable from the passes, with a null framebuffer only for the root', () => {
+        const source = fakeSource('img');
+        const leaf = shaderNode({ id: 'leaf', shaderConfig: cfg(), uniforms: { img: source } });
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg({ u_k: 'float' }),
+            uniforms: { tex: leaf, k: { type: 'float', value: 1 } }
+        });
+
+        const plan = planGraph(root);
+
+        expect(plan.topology.rootId).toBe('root');
+
+        for (const topoNode of plan.topology.nodes) {
+            const pass = plan.passes.find(candidate => candidate.nodeId === topoNode.id);
+            expect(pass).toBeDefined();
+            expect(topoNode.framebufferId).toBe(pass?.outputFramebufferId);
+
+            const edgeChildIds = topoNode.edges.map(edge => edge.childId);
+            const sourceIds = topoNode.sources.map(entry => entry.sourceId);
+            for (const input of pass?.inputs ?? []) {
+                if (input.kind === 'node') {
+                    expect(edgeChildIds).toContain(input.childId);
+                } else {
+                    expect(sourceIds).toContain(input.sourceId);
+                }
+            }
+        }
+
+        const nullFramebufferIds = plan.topology.nodes
+            .filter(topoNode => topoNode.framebufferId === null)
+            .map(topoNode => topoNode.id);
+        expect(nullFramebufferIds).toEqual(['root']);
+    });
+});
+
+describe('toRenderPasses', () => {
+    it('maps edges to read bindings, sources to source bindings, and injects per-node uniforms', () => {
+        const source = fakeSource('img');
+        const leaf = shaderNode({ id: 'leaf', shaderConfig: cfg(), uniforms: { img: source } });
+        const root = shaderNode({
+            id: 'root',
+            shaderConfig: cfg(),
+            uniforms: { tex: leaf },
+            renderOptions: { clear: false }
+        });
+
+        const plan = planGraph(root);
+        const uniformsFor = (nodeId: string): Record<string, { type: UniformType; value: number }> =>
+            ({ u_k: { type: 'float', value: nodeId.length } });
+        const passes = toRenderPasses(plan, uniformsFor);
+
+        expect(passes[0].inputTextures).toEqual([
+            { id: 'img', textureUnit: 0, bindingType: 'source', samplerName: 'u_img' }
+        ]);
+        expect(passes[0].outputFramebuffer).toBe('leaf-out');
+        expect(passes[0].uniforms).toEqual({ u_k: { type: 'float', value: 4 } });
+        expect(passes[0].renderOptions).toEqual({ clear: true });
+
+        expect(passes[1].inputTextures).toEqual([
+            { id: 'leaf-out', textureUnit: 0, bindingType: 'read', samplerName: 'u_tex' }
+        ]);
+        expect(passes[1].outputFramebuffer).toBeNull();
+        expect(passes[1].renderOptions).toEqual({ clear: false });
+    });
+});
+
+describe('isShaderNode', () => {
+    it('recognizes shader nodes and rejects params and sources', () => {
+        const node = shaderNode({ id: 'n', shaderConfig: cfg(), uniforms: {} });
+        expect(isShaderNode(node)).toBe(true);
+        expect(isShaderNode({ type: 'float', value: 0 })).toBe(false);
+        expect(isShaderNode(fakeSource('s'))).toBe(false);
+    });
+});

--- a/src/core/lib/graphPlanning.ts
+++ b/src/core/lib/graphPlanning.ts
@@ -67,7 +67,10 @@ export function shaderNode(node: Omit<ShaderNode, 'kind'>): ShaderNode {
 }
 
 export function isShaderNode(value: GraphUniformValue): value is ShaderNode {
-    return (value as { kind?: unknown }).kind === 'shader-node';
+    const candidate = value as unknown;
+    return typeof candidate === 'object'
+        && candidate !== null
+        && (candidate as { kind?: unknown }).kind === 'shader-node';
 }
 
 function isTextureSource(value: unknown): value is TextureSource {
@@ -205,8 +208,15 @@ function visit(state: PlanState, node: ShaderNode, isRoot: boolean): void {
             continue;
         }
         if (isUniformParam(value)) {
-            valueNameSet.add(normalizeUniformName(key));
-            uniformNames.push(normalizeUniformName(key));
+            const valueName = normalizeUniformName(key);
+            if (valueNameSet.has(valueName)) {
+                throw new Error(
+                    `micugl graph: node "${node.id}" has two value uniforms that both resolve to "${valueName}". `
+                    + 'One name names one uniform, so the second would overwrite the first. Rename one of the uniforms.'
+                );
+            }
+            valueNameSet.add(valueName);
+            uniformNames.push(valueName);
             continue;
         }
         throw new Error(

--- a/src/core/lib/graphPlanning.ts
+++ b/src/core/lib/graphPlanning.ts
@@ -228,7 +228,8 @@ function visit(state: PlanState, node: ShaderNode, isRoot: boolean): void {
     if (textureUnit > state.maxTextureUnits) {
         throw new Error(
             `micugl graph: node "${node.id}" binds ${textureUnit} texture inputs, past the limit of `
-            + `${state.maxTextureUnits}. WebGL1 guarantees at least 8 texture units. Reduce the node's texture inputs.`
+            + `${state.maxTextureUnits} texture units for one node. Reduce the node's texture inputs, or split the `
+            + 'work across more graph nodes.'
         );
     }
 

--- a/src/core/lib/graphPlanning.ts
+++ b/src/core/lib/graphPlanning.ts
@@ -1,0 +1,326 @@
+import { GL_LINEAR } from '@/core/lib/glConstants';
+import { normalizeUniformName } from '@/core/lib/uniformNames';
+import type {
+    FramebufferOptions,
+    RenderOptions,
+    RenderPass,
+    ShaderProgramConfig,
+    TextureOptions,
+    TextureSource,
+    UniformConfig,
+    UniformParam
+} from '@/types';
+
+export interface ShaderNode {
+    kind: 'shader-node';
+    id: string;
+    shaderConfig: ShaderProgramConfig;
+    uniforms: Record<string, GraphUniformValue>;
+    width?: number;
+    height?: number;
+    textureOptions?: Partial<TextureOptions>;
+    renderOptions?: RenderOptions;
+}
+
+export type GraphUniformValue = UniformParam | ShaderNode | TextureSource;
+
+export type PlannedInput =
+    | { kind: 'node'; childId: string; samplerName: string; textureUnit: number }
+    | { kind: 'source'; sourceId: string; samplerName: string; textureUnit: number };
+
+export interface PlannedPass {
+    nodeId: string;
+    programId: string;
+    outputFramebufferId: string | null;
+    inputs: PlannedInput[];
+    renderOptions: RenderOptions | undefined;
+}
+
+export interface GraphTopologyNode {
+    id: string;
+    framebufferId: string | null;
+    width: number;
+    height: number;
+    edges: { samplerName: string; childId: string }[];
+    sources: { samplerName: string; sourceId: string }[];
+    uniformNames: string[];
+}
+
+export interface GraphTopology {
+    rootId: string;
+    nodes: GraphTopologyNode[];
+}
+
+export interface GraphPlan {
+    order: ShaderNode[];
+    programConfigs: Record<string, ShaderProgramConfig>;
+    framebuffers: Record<string, FramebufferOptions>;
+    passes: PlannedPass[];
+    sources: TextureSource[];
+    topology: GraphTopology;
+}
+
+const DEFAULT_MAX_TEXTURE_UNITS = 8;
+
+export function shaderNode(node: Omit<ShaderNode, 'kind'>): ShaderNode {
+    return { kind: 'shader-node', ...node };
+}
+
+export function isShaderNode(value: GraphUniformValue): value is ShaderNode {
+    return (value as { kind?: unknown }).kind === 'shader-node';
+}
+
+function isTextureSource(value: unknown): value is TextureSource {
+    return typeof value === 'object'
+        && value !== null
+        && typeof (value as { getFrame?: unknown }).getFrame === 'function';
+}
+
+function isUniformParam(value: unknown): value is UniformParam {
+    return typeof value === 'object'
+        && value !== null
+        && 'type' in value
+        && 'value' in value;
+}
+
+function framebufferId(nodeId: string): string {
+    return `${nodeId}-out`;
+}
+
+function augmentConfig(config: ShaderProgramConfig, samplerNames: string[]): ShaderProgramConfig {
+    const declared = new Set(config.uniforms.map(uniform => uniform.name));
+    const additions: UniformConfig[] = [];
+
+    for (const samplerName of samplerNames) {
+        if (declared.has(samplerName)) {
+            continue;
+        }
+        declared.add(samplerName);
+        additions.push({ name: samplerName, type: 'sampler2D' });
+    }
+
+    if (additions.length === 0) {
+        return config;
+    }
+
+    return { ...config, uniforms: [...config.uniforms, ...additions] };
+}
+
+interface PlanState {
+    maxTextureUnits: number;
+    order: ShaderNode[];
+    programConfigs: Record<string, ShaderProgramConfig>;
+    framebuffers: Record<string, FramebufferOptions>;
+    passes: PlannedPass[];
+    sources: TextureSource[];
+    sourceById: Map<string, TextureSource>;
+    idToNode: Map<string, ShaderNode>;
+    onStack: Set<ShaderNode>;
+    pathStack: string[];
+    topologyNodes: GraphTopologyNode[];
+}
+
+function registerSource(state: PlanState, nodeId: string, source: TextureSource): void {
+    const existing = state.sourceById.get(source.id);
+    if (existing === undefined) {
+        state.sourceById.set(source.id, source);
+        state.sources.push(source);
+        return;
+    }
+    if (existing !== source) {
+        throw new Error(
+            `micugl graph: node "${nodeId}" feeds a texture source with id "${source.id}", but a different source `
+            + 'object already claims that id in this graph. One id owns one GL texture and one upload version, so '
+            + 'two sources sharing an id would upload over each other. Give each source its own id.'
+        );
+    }
+}
+
+function visit(state: PlanState, node: ShaderNode, isRoot: boolean): void {
+    if (state.onStack.has(node)) {
+        const cyclePath = [...state.pathStack, node.id].join(' -> ');
+        throw new Error(`micugl graph: cycle detected: ${cyclePath}. Shader graphs must be acyclic.`);
+    }
+
+    const existing = state.idToNode.get(node.id);
+    if (existing !== undefined) {
+        if (existing !== node) {
+            throw new Error(
+                `micugl graph: two different nodes share the id "${node.id}". Each node id names one framebuffer and `
+                + 'one program, so a duplicate id would collide their outputs. Give each node a unique id.'
+            );
+        }
+        return;
+    }
+
+    if (isRoot && (node.width !== undefined || node.height !== undefined)) {
+        throw new Error(
+            `micugl graph: the root node "${node.id}" declares width/height, but the root renders to the canvas, `
+            + 'whose size is set by the component props. Remove width/height on the root node.'
+        );
+    }
+
+    state.onStack.add(node);
+    state.pathStack.push(node.id);
+    state.idToNode.set(node.id, node);
+
+    const inputs: PlannedInput[] = [];
+    const childNodes: ShaderNode[] = [];
+    const edges: { samplerName: string; childId: string }[] = [];
+    const sourceRefs: { samplerName: string; sourceId: string }[] = [];
+    const uniformNames: string[] = [];
+    const samplerNames: string[] = [];
+    const samplerNameSet = new Set<string>();
+    const valueNameSet = new Set<string>();
+    let textureUnit = 0;
+
+    const claimSampler = (samplerName: string): void => {
+        if (samplerNameSet.has(samplerName)) {
+            throw new Error(
+                `micugl graph: node "${node.id}" has two texture inputs that both resolve to sampler "${samplerName}". `
+                + 'One sampler holds one texture, so the second would overwrite the first. Rename one of the uniforms.'
+            );
+        }
+        samplerNameSet.add(samplerName);
+        samplerNames.push(samplerName);
+    };
+
+    for (const [key, value] of Object.entries(node.uniforms)) {
+        if (isShaderNode(value)) {
+            const samplerName = normalizeUniformName(key);
+            claimSampler(samplerName);
+            edges.push({ samplerName, childId: value.id });
+            inputs.push({ kind: 'node', childId: value.id, samplerName, textureUnit });
+            childNodes.push(value);
+            textureUnit += 1;
+            continue;
+        }
+        if (isTextureSource(value)) {
+            const samplerName = normalizeUniformName(key);
+            claimSampler(samplerName);
+            registerSource(state, node.id, value);
+            sourceRefs.push({ samplerName, sourceId: value.id });
+            inputs.push({ kind: 'source', sourceId: value.id, samplerName, textureUnit });
+            textureUnit += 1;
+            continue;
+        }
+        if (isUniformParam(value)) {
+            valueNameSet.add(normalizeUniformName(key));
+            uniformNames.push(normalizeUniformName(key));
+            continue;
+        }
+        throw new Error(
+            `micugl graph: node "${node.id}" gives uniform "${key}" a value that is not a uniform param, a shader `
+            + 'node, or a texture source. A graph uniform must be one of those three. Check the value you passed.'
+        );
+    }
+
+    if (textureUnit > state.maxTextureUnits) {
+        throw new Error(
+            `micugl graph: node "${node.id}" binds ${textureUnit} texture inputs, past the limit of `
+            + `${state.maxTextureUnits}. WebGL1 guarantees at least 8 texture units. Reduce the node's texture inputs.`
+        );
+    }
+
+    for (const samplerName of samplerNames) {
+        if (valueNameSet.has(samplerName)) {
+            throw new Error(
+                `micugl graph: node "${node.id}" uses "${samplerName}" for both a texture sampler and a value `
+                + 'uniform. One name names one uniform. Rename one of them.'
+            );
+        }
+    }
+
+    for (const child of childNodes) {
+        visit(state, child, false);
+    }
+
+    const outputFramebufferId = isRoot ? null : framebufferId(node.id);
+    if (!isRoot) {
+        state.framebuffers[framebufferId(node.id)] = {
+            width: node.width ?? 0,
+            height: node.height ?? 0,
+            textureCount: 1,
+            textureOptions: node.textureOptions ?? { minFilter: GL_LINEAR, magFilter: GL_LINEAR }
+        };
+    }
+
+    state.programConfigs[node.id] = augmentConfig(node.shaderConfig, samplerNames);
+
+    state.passes.push({
+        nodeId: node.id,
+        programId: node.id,
+        outputFramebufferId,
+        inputs,
+        renderOptions: node.renderOptions
+    });
+
+    state.order.push(node);
+
+    state.topologyNodes.push({
+        id: node.id,
+        framebufferId: outputFramebufferId,
+        width: node.width ?? 0,
+        height: node.height ?? 0,
+        edges,
+        sources: sourceRefs,
+        uniformNames
+    });
+
+    state.onStack.delete(node);
+    state.pathStack.pop();
+}
+
+export function planGraph(root: ShaderNode, options?: { maxTextureUnits?: number }): GraphPlan {
+    const state: PlanState = {
+        maxTextureUnits: options?.maxTextureUnits ?? DEFAULT_MAX_TEXTURE_UNITS,
+        order: [],
+        programConfigs: {},
+        framebuffers: {},
+        passes: [],
+        sources: [],
+        sourceById: new Map(),
+        idToNode: new Map(),
+        onStack: new Set(),
+        pathStack: [],
+        topologyNodes: []
+    };
+
+    visit(state, root, true);
+
+    return {
+        order: state.order,
+        programConfigs: state.programConfigs,
+        framebuffers: state.framebuffers,
+        passes: state.passes,
+        sources: state.sources,
+        topology: { rootId: root.id, nodes: state.topologyNodes }
+    };
+}
+
+export function toRenderPasses(
+    plan: GraphPlan,
+    uniformsFor: (nodeId: string) => RenderPass['uniforms']
+): RenderPass[] {
+    return plan.passes.map(pass => ({
+        programId: pass.programId,
+        inputTextures: pass.inputs.map(input =>
+            input.kind === 'node'
+                ? {
+                    id: framebufferId(input.childId),
+                    textureUnit: input.textureUnit,
+                    bindingType: 'read' as const,
+                    samplerName: input.samplerName
+                }
+                : {
+                    id: input.sourceId,
+                    textureUnit: input.textureUnit,
+                    bindingType: 'source' as const,
+                    samplerName: input.samplerName
+                }
+        ),
+        outputFramebuffer: pass.outputFramebufferId,
+        uniforms: uniformsFor(pass.nodeId),
+        renderOptions: pass.renderOptions ?? { clear: true }
+    }));
+}

--- a/src/core/lib/passPlanning.test.ts
+++ b/src/core/lib/passPlanning.test.ts
@@ -100,7 +100,7 @@ describe('compilePass', () => {
         };
 
         const compiled = compilePass(pass, allPingPong);
-        expect(compiled.inputs.map(i => i.pingPongUseReadIndex)).toEqual([true, false, true]);
-        expect(compiled.inputs.map(i => i.staticIndex)).toEqual([0, 1, 1]);
+        expect(compiled.inputs.map(i => i.kind === 'fbo' ? i.pingPongUseReadIndex : null)).toEqual([true, false, true]);
+        expect(compiled.inputs.map(i => i.kind === 'fbo' ? i.staticIndex : null)).toEqual([0, 1, 1]);
     });
 });

--- a/src/core/lib/passPlanning.ts
+++ b/src/core/lib/passPlanning.ts
@@ -61,23 +61,34 @@ export function planPassSwaps(pass: RenderPass, isPingPong: (id: string) => bool
 
 export function compilePass(pass: RenderPass, isPingPong: (id: string) => boolean): CompiledPass {
     const inputs: CompiledInput[] = pass.inputTextures.map(texture => {
-        if (texture.bindingType === 'source') {
-            return {
-                kind: 'source',
-                id: texture.id,
-                textureUnit: texture.textureUnit,
-                samplerName: texture.samplerName
-            };
+        switch (texture.bindingType) {
+            case 'source':
+                return {
+                    kind: 'source',
+                    id: texture.id,
+                    textureUnit: texture.textureUnit,
+                    samplerName: texture.samplerName
+                };
+            case 'read':
+            case 'write':
+            case 'readwrite':
+                return {
+                    kind: 'fbo',
+                    id: texture.id,
+                    textureUnit: texture.textureUnit,
+                    samplerName: texture.samplerName,
+                    isPingPong: isPingPong(texture.id),
+                    pingPongUseReadIndex: texture.bindingType === 'read' || texture.bindingType === 'readwrite',
+                    staticIndex: texture.bindingType === 'read' ? 0 : 1
+                };
+            default: {
+                const unreachable: never = texture.bindingType;
+                throw new Error(
+                    `micugl: pass on program "${pass.programId}" has a texture binding of type `
+                    + `"${String(unreachable)}", which compilePass does not handle. This is a bug in micugl.`
+                );
+            }
         }
-        return {
-            kind: 'fbo',
-            id: texture.id,
-            textureUnit: texture.textureUnit,
-            samplerName: texture.samplerName,
-            isPingPong: isPingPong(texture.id),
-            pingPongUseReadIndex: texture.bindingType === 'read' || texture.bindingType === 'readwrite',
-            staticIndex: texture.bindingType === 'read' ? 0 : 1
-        };
     });
 
     const uniforms: CompiledUniform[] = pass.uniforms

--- a/src/core/lib/passPlanning.ts
+++ b/src/core/lib/passPlanning.ts
@@ -1,6 +1,7 @@
 import type { RenderOptions, RenderPass, RenderPassUniformValue, UniformType } from '@/types';
 
-export interface CompiledInput {
+export interface CompiledFboInput {
+    kind: 'fbo';
     id: string;
     textureUnit: number;
     samplerName: string;
@@ -8,6 +9,15 @@ export interface CompiledInput {
     pingPongUseReadIndex: boolean;
     staticIndex: number;
 }
+
+export interface CompiledSourceInput {
+    kind: 'source';
+    id: string;
+    textureUnit: number;
+    samplerName: string;
+}
+
+export type CompiledInput = CompiledFboInput | CompiledSourceInput;
 
 export interface CompiledUniform {
     name: string;
@@ -50,14 +60,25 @@ export function planPassSwaps(pass: RenderPass, isPingPong: (id: string) => bool
 }
 
 export function compilePass(pass: RenderPass, isPingPong: (id: string) => boolean): CompiledPass {
-    const inputs: CompiledInput[] = pass.inputTextures.map(texture => ({
-        id: texture.id,
-        textureUnit: texture.textureUnit,
-        samplerName: texture.samplerName,
-        isPingPong: isPingPong(texture.id),
-        pingPongUseReadIndex: texture.bindingType === 'read' || texture.bindingType === 'readwrite',
-        staticIndex: texture.bindingType === 'read' ? 0 : 1
-    }));
+    const inputs: CompiledInput[] = pass.inputTextures.map(texture => {
+        if (texture.bindingType === 'source') {
+            return {
+                kind: 'source',
+                id: texture.id,
+                textureUnit: texture.textureUnit,
+                samplerName: texture.samplerName
+            };
+        }
+        return {
+            kind: 'fbo',
+            id: texture.id,
+            textureUnit: texture.textureUnit,
+            samplerName: texture.samplerName,
+            isPingPong: isPingPong(texture.id),
+            pingPongUseReadIndex: texture.bindingType === 'read' || texture.bindingType === 'readwrite',
+            staticIndex: texture.bindingType === 'read' ? 0 : 1
+        };
+    });
 
     const uniforms: CompiledUniform[] = pass.uniforms
         ? Object.entries(pass.uniforms).map(([name, uniform]) => ({

--- a/src/core/lib/uniformNames.ts
+++ b/src/core/lib/uniformNames.ts
@@ -1,0 +1,3 @@
+export function normalizeUniformName(name: string): string {
+    return name.startsWith('u_') ? name : `u_${name}`;
+}

--- a/src/core/managers/FBOManager.ts
+++ b/src/core/managers/FBOManager.ts
@@ -261,6 +261,14 @@ export class FBOManager {
         return (resources.currentTextureIndex + 1) % resources.textures.length;
     }
 
+    getSize(id: string): { width: number; height: number } {
+        const resources = this.resources.get(id);
+        if (!resources) {
+            throw new Error(`Framebuffer with id ${id} not found`);
+        }
+        return { width: resources.width, height: resources.height };
+    }
+
     getTextureCount(id: string): number {
         const resources = this.resources.get(id);
         if (!resources) {

--- a/src/core/managers/TextureManager.ts
+++ b/src/core/managers/TextureManager.ts
@@ -125,6 +125,14 @@ export class TextureManager {
         resources.uploadedVersion = source.version;
     }
 
+    uploadIfStaleById(id: string): void {
+        const resources = this.resources.get(id);
+        if (!resources) {
+            throw new Error(unknownTextureMessage('uploadIfStaleById', id));
+        }
+        this.uploadIfStale(resources.owner);
+    }
+
     private uploadFrame(resources: SourceTextureResources, id: string, frame: TextureUploadSource): void {
         const gl = this.gl;
         const dimensions = sourceDimensions(frame);

--- a/src/core/managers/WebGLManager.ts
+++ b/src/core/managers/WebGLManager.ts
@@ -305,12 +305,23 @@ export class WebGLManager {
 
         const location = this.checkedUniformLocation(resources, programId, samplerName, 'sampler2D');
         if (location === null) {
-            throw new Error(
-                `WebGLManager.assertSourceSamplerLocation: the shader on program "${programId}" never samples `
-                + `"${samplerName}", so binding a source texture to it can never affect the picture. Sample it in `
-                + 'the shader, or fix the sampler name on the graph node that feeds this source.'
-            );
+            throw new Error(this.missingSamplerMessage(
+                'Passes.initializeResources',
+                programId,
+                samplerName,
+                'Sample it in the shader, or fix the sampler name on the graph node that feeds this source.'
+            ));
         }
+    }
+
+    private missingSamplerMessage(
+        operation: string,
+        programId: string,
+        samplerName: string,
+        remedy: string
+    ): string {
+        return `${operation}: the shader on program "${programId}" never samples "${samplerName}", so binding `
+            + `a texture to it can never affect the picture. ${remedy}`;
     }
 
     registerUniformUpdater<T extends UniformType>(
@@ -422,11 +433,12 @@ export class WebGLManager {
     ): WebGLUniformLocation {
         const location = this.checkedUniformLocation(resources, programId, binding.samplerName, 'sampler2D');
         if (location === null) {
-            throw new Error(
-                `WebGLManager.registerTextureBinding: the shader on program "${programId}" never samples `
-                + `"${binding.samplerName}", so binding a texture to it can never affect the picture. Sample it in `
-                + 'the shader, fix the sampler name, or remove its entry from the "textures" prop.'
-            );
+            throw new Error(this.missingSamplerMessage(
+                'WebGLManager.registerTextureBinding',
+                programId,
+                binding.samplerName,
+                'Sample it in the shader, fix the sampler name, or remove its entry from the "textures" prop.'
+            ));
         }
         return location;
     }

--- a/src/core/managers/WebGLManager.ts
+++ b/src/core/managers/WebGLManager.ts
@@ -297,6 +297,22 @@ export class WebGLManager {
         this.checkedUniformLocation(resources, programId, uniformName, type);
     }
 
+    assertSourceSamplerLocation(programId: string, samplerName: string): void {
+        const resources = this.resources.get(programId);
+        if (!resources) {
+            throw new Error(`Program with id ${programId} not found`);
+        }
+
+        const location = this.checkedUniformLocation(resources, programId, samplerName, 'sampler2D');
+        if (location === null) {
+            throw new Error(
+                `WebGLManager.assertSourceSamplerLocation: the shader on program "${programId}" never samples `
+                + `"${samplerName}", so binding a source texture to it can never affect the picture. Sample it in `
+                + 'the shader, or fix the sampler name on the graph node that feeds this source.'
+            );
+        }
+    }
+
     registerUniformUpdater<T extends UniformType>(
         programId: string,
         uniformName: string,

--- a/src/core/systems/Passes.ts
+++ b/src/core/systems/Passes.ts
@@ -48,7 +48,16 @@ export class Passes {
 
         this.webglManager.prepareRender(pass.programId, pass.renderOptions);
 
+        let boundSource = false;
         for (const input of pass.inputs) {
+            if (input.kind === 'source') {
+                this.webglManager.textures.bindToUnit(input.id, input.textureUnit);
+                this.webglManager.textures.uploadIfStaleById(input.id);
+                this.webglManager.setUniform(pass.programId, input.samplerName, input.textureUnit, 'sampler2D');
+                boundSource = true;
+                continue;
+            }
+
             let textureIndex = input.staticIndex;
             if (input.isPingPong) {
                 textureIndex = input.pingPongUseReadIndex
@@ -58,6 +67,10 @@ export class Passes {
 
             fbo.bindTexture(input.id, input.textureUnit, textureIndex);
             this.webglManager.setUniform(pass.programId, input.samplerName, input.textureUnit, 'sampler2D');
+        }
+
+        if (boundSource) {
+            gl.activeTexture(gl.TEXTURE0);
         }
 
         this.webglManager.updateUniforms(pass.programId, time, width, height);
@@ -83,7 +96,14 @@ export class Passes {
         const resolvedHeight = height ?? gl.canvas.height;
 
         for (const pass of this.compiled) {
+            let passWidth = resolvedWidth;
+            let passHeight = resolvedHeight;
+
             if (pass.outputFramebuffer !== null) {
+                const size = fbo.getSize(pass.outputFramebuffer);
+                passWidth = size.width;
+                passHeight = size.height;
+
                 if (pass.outputIsPingPong) {
                     fbo.bindFramebuffer(pass.outputFramebuffer, fbo.getWriteIndex(pass.outputFramebuffer));
                 } else {
@@ -93,7 +113,7 @@ export class Passes {
                 fbo.bindFramebuffer(null);
             }
 
-            this.runCompiledPass(pass, time, resolvedWidth, resolvedHeight);
+            this.runCompiledPass(pass, time, passWidth, passHeight);
 
             for (const id of pass.swapIds) {
                 fbo.swapTextures(id);
@@ -142,6 +162,18 @@ export class Passes {
 
     private assertUniformsDeclared(pass: CompiledPass): void {
         for (const input of pass.inputs) {
+            if (input.kind === 'source') {
+                if (!this.webglManager.textures.has(input.id)) {
+                    throw new Error(
+                        `Passes.initializeResources: pass on program "${pass.programId}" samples source texture `
+                        + `"${input.id}", but no such source texture is defined. Call `
+                        + 'TextureManager.defineTexture(source) for it before initializing the passes, or the sampler '
+                        + 'would read the 1x1 placeholder for the life of the program.'
+                    );
+                }
+                this.webglManager.assertSourceSamplerLocation(pass.programId, input.samplerName);
+                continue;
+            }
             this.webglManager.assertUniformDeclared(pass.programId, input.samplerName, 'sampler2D');
         }
 

--- a/src/core/systems/graphRender.test.ts
+++ b/src/core/systems/graphRender.test.ts
@@ -301,12 +301,23 @@ describe('graph render: source with a null sampler location (T20)', () => {
 
         expect(() => { passSystem.initializeResources() }).toThrow(/never samples "u_img"/);
         expect(() => { passSystem.initializeResources() }).toThrow(/program "R"/);
+    });
 
-        const corrected = createSource('img');
-        const correctedRoot = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { img: corrected.source } });
-        expect(() => setupGraph(correctedRoot, {
-            stubConfig: { activeUniforms: { u_img: 'sampler2D' } }
-        })).not.toThrow();
+    it('recovers on the same passSystem once the throwing cause is fixed, with no ghost state', () => {
+        const image = createSource('img');
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { img: image.source } });
+
+        const { manager, passSystem } = setupGraph(root, {
+            stubConfig: { activeUniforms: { u_img: 'sampler2D' } },
+            defineSources: false,
+            initialize: false
+        });
+
+        expect(() => { passSystem.initializeResources() }).toThrow(/defineTexture/);
+
+        manager.textures.defineTexture(image.source);
+
+        expect(() => { passSystem.initializeResources() }).not.toThrow();
     });
 });
 

--- a/src/core/systems/graphRender.test.ts
+++ b/src/core/systems/graphRender.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
+import { GL_TEXTURE0 } from '@/core/lib/glConstants';
+import type { ShaderNode } from '@/core/lib/graphPlanning';
+import { planGraph, shaderNode, toRenderPasses } from '@/core/lib/graphPlanning';
+import { resolveSourceTextureOptions } from '@/core/lib/sourceTextureOptions';
+import { WebGLManager } from '@/core/managers/WebGLManager';
+import { Passes } from '@/core/systems/Passes';
+import type { CanvasStubHandle, GLStubConfig } from '@/testing';
+import { createCanvasStub } from '@/testing';
+import type { RenderPass, ShaderProgramConfig, TextureSource, TextureUploadSource, UniformType } from '@/types';
+
+type UniformsFor = (nodeId: string) => RenderPass['uniforms'];
+
+function gcfg(uniformNames: Record<string, UniformType> = {}): ShaderProgramConfig {
+    return {
+        vertexShader: '',
+        fragmentShader: '',
+        uniforms: Object.entries(uniformNames).map(([name, type]) => ({ name, type })),
+        attributes: [{ name: 'a_position', size: 2, type: 'FLOAT', normalized: false, stride: 0, offset: 0 }]
+    };
+}
+
+const f32 = (values: number[]): Float32Array => new Float32Array(values);
+
+const bitmap = (width: number, height: number): TextureUploadSource =>
+    ({ width, height }) as unknown as TextureUploadSource;
+
+interface SourceHandle {
+    source: TextureSource;
+    push: (frame: TextureUploadSource) => void;
+}
+
+function createSource(id: string): SourceHandle {
+    let frame: TextureUploadSource | null = null;
+    let version = 0;
+
+    const source: TextureSource = {
+        id,
+        get version() { return version },
+        options: resolveSourceTextureOptions(),
+        getFrame: () => frame,
+        invalidation: createFrameInvalidation()
+    };
+
+    return {
+        source,
+        push: (next: TextureUploadSource) => {
+            frame = next;
+            version += 1;
+        }
+    };
+}
+
+interface GraphSetup {
+    stub: CanvasStubHandle;
+    manager: WebGLManager;
+    passSystem: Passes;
+    plan: ReturnType<typeof planGraph>;
+}
+
+interface GraphSetupOptions {
+    uniformsFor?: UniformsFor;
+    stubConfig?: GLStubConfig;
+    sources?: TextureSource[];
+    defineSources?: boolean;
+    initialize?: boolean;
+}
+
+function setupGraph(root: ShaderNode, options: GraphSetupOptions = {}): GraphSetup {
+    const stub = createCanvasStub(options.stubConfig);
+    const manager = new WebGLManager(stub.canvas);
+    const plan = planGraph(root);
+
+    for (const node of plan.order) {
+        manager.createProgram(node.id, plan.programConfigs[node.id]);
+    }
+    for (const [id, framebufferOptions] of Object.entries(plan.framebuffers)) {
+        manager.fbo.createFramebuffer(id, framebufferOptions);
+    }
+    if (options.defineSources !== false) {
+        for (const source of options.sources ?? plan.sources) {
+            manager.textures.defineTexture(source);
+        }
+    }
+
+    const passSystem = new Passes(manager);
+    const uniformsFor: UniformsFor = options.uniformsFor ?? (() => ({}));
+    for (const pass of toRenderPasses(plan, uniformsFor)) {
+        passSystem.addPass(pass);
+    }
+    if (options.initialize !== false) {
+        passSystem.initializeResources();
+    }
+
+    return { stub, manager, passSystem, plan };
+}
+
+function location(manager: WebGLManager, programId: string, name: string): WebGLUniformLocation | null {
+    return manager.resources.get(programId)?.uniforms[name] ?? null;
+}
+
+describe('graph render: end-to-end honesty (T14 anchor)', () => {
+    it('draws a source-fed chain in topological order, advancing per-node uniforms and uploading the frame', () => {
+        const image = createSource('img');
+        const phaseName = (id: string): string => `u_phase_${id}`;
+        const uniformsFor: UniformsFor = id =>
+            ({ [phaseName(id)]: { type: 'float', value: (time: number) => time } });
+
+        const leaf = shaderNode({ id: 'L', shaderConfig: gcfg({ u_phase_L: 'float' }), uniforms: { img: image.source } });
+        const mid = shaderNode({ id: 'M', shaderConfig: gcfg({ u_phase_M: 'float' }), uniforms: { tex: leaf }, width: 4, height: 4 });
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg({ u_phase_R: 'float' }), uniforms: { tex: mid } });
+
+        const { stub, manager, passSystem } = setupGraph(root, { uniformsFor });
+
+        image.push(bitmap(4, 4));
+        stub.reset();
+
+        passSystem.execute(1);
+
+        const programs = ['L', 'M', 'R'].map(id => manager.resources.get(id)?.program);
+        expect(stub.useProgramCalls.slice(0, 3)).toEqual(programs);
+
+        const frameAllocations = stub.texImage2DCalls.filter(call => call.source === image.source.getFrame());
+        expect(frameAllocations).toHaveLength(1);
+        expect(frameAllocations[0]).toMatchObject({ width: 4, height: 4 });
+
+        const samplerLoc = location(manager, 'L', 'u_img');
+        const samplerUploads = stub.uniformCalls.filter(
+            call => call.name === 'uniform1i' && call.location === samplerLoc
+        );
+        expect(samplerUploads.map(call => call.value)).toEqual([0]);
+
+        passSystem.execute(2);
+
+        for (const id of ['L', 'M', 'R']) {
+            const phaseLoc = location(manager, id, phaseName(id));
+            const values = stub.uniformCalls
+                .filter(call => call.name === 'uniform1f' && call.location === phaseLoc)
+                .map(call => call.value);
+            expect(values).toEqual([1, 2]);
+        }
+    });
+});
+
+describe('graph render: source upload gating (T15)', () => {
+    it('uploads on the first frame, skips while the version holds, and re-uploads once it advances', () => {
+        const image = createSource('img');
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { img: image.source } });
+
+        const { stub, passSystem } = setupGraph(root);
+
+        image.push(bitmap(4, 4));
+        stub.reset();
+
+        passSystem.execute(1);
+        expect(stub.texImage2DCalls).toHaveLength(1);
+        expect(stub.texSubImage2DCalls).toHaveLength(0);
+
+        passSystem.execute(2);
+        expect(stub.texImage2DCalls).toHaveLength(1);
+        expect(stub.texSubImage2DCalls).toHaveLength(0);
+        expect(stub.calls.filter(call => call.name === 'drawArrays')).toHaveLength(2);
+
+        image.push(bitmap(4, 4));
+        passSystem.execute(3);
+        expect(stub.texSubImage2DCalls).toHaveLength(1);
+        expect(stub.texSubImage2DCalls[0]).toMatchObject({ width: 4, height: 4 });
+    });
+});
+
+describe('graph render: one source feeding two nodes (T16)', () => {
+    it('defines it once, uploads once per version, and binds it at each pass own unit', () => {
+        const image = createSource('img');
+        const mid = shaderNode({ id: 'M', shaderConfig: gcfg(), uniforms: { img: image.source }, width: 4, height: 4 });
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { tex: mid, img: image.source } });
+
+        const { stub, plan, passSystem } = setupGraph(root);
+
+        expect(plan.sources).toHaveLength(1);
+
+        image.push(bitmap(4, 4));
+        stub.reset();
+
+        passSystem.execute(1);
+
+        expect(stub.texImage2DCalls).toHaveLength(1);
+        expect(stub.texSubImage2DCalls).toHaveLength(0);
+
+        const bindPairs: { unit: unknown; tex: unknown }[] = [];
+        let currentUnit: unknown;
+        for (const call of stub.calls) {
+            if (call.name === 'activeTexture') {
+                currentUnit = call.args[0];
+            }
+            if (call.name === 'bindTexture') {
+                bindPairs.push({ unit: currentUnit, tex: call.args[1] });
+            }
+        }
+
+        const atUnitOne = bindPairs.find(pair => pair.unit === GL_TEXTURE0 + 1);
+        expect(atUnitOne).toBeDefined();
+        const sourceTexture = atUnitOne?.tex;
+        const atUnitZero = bindPairs.filter(pair => pair.tex === sourceTexture && pair.unit === GL_TEXTURE0);
+        expect(atUnitZero.length).toBeGreaterThanOrEqual(1);
+    });
+});
+
+describe('graph render: per-pass output dimensions (T17)', () => {
+    it('feeds each pass its output surface size to both pass-uniform fns and registered updaters', () => {
+        const mid = shaderNode({
+            id: 'M',
+            shaderConfig: gcfg({ u_probe_m: 'vec2', u_res: 'vec2' }),
+            uniforms: {},
+            width: 16,
+            height: 8
+        });
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg({ u_probe_r: 'vec2' }), uniforms: { tex: mid } });
+
+        const probeFn = (_t: number, width: number, height: number): never => f32([width, height]) as never;
+        const uniformsFor: UniformsFor = (nodeId): RenderPass['uniforms'] => {
+            if (nodeId === 'M') {
+                return { u_probe_m: { type: 'vec2', value: probeFn } };
+            }
+            return { u_probe_r: { type: 'vec2', value: probeFn } };
+        };
+
+        const { stub, manager, passSystem } = setupGraph(root, { uniformsFor });
+
+        manager.registerUniformUpdater('M', 'u_res', 'vec2', (_t, width, height) => f32([width ?? 0, height ?? 0]) as never);
+
+        stub.reset();
+        passSystem.execute(1);
+
+        const probeValue = (programId: string, name: string): number[] => {
+            const loc = location(manager, programId, name);
+            const call = stub.uniformCalls.find(entry => entry.name === 'uniform2fv' && entry.location === loc);
+            return Array.from(call?.value as Float32Array);
+        };
+
+        expect(probeValue('M', 'u_probe_m')).toEqual([16, 8]);
+        expect(probeValue('R', 'u_probe_r')).toEqual([300, 150]);
+
+        const resLoc = location(manager, 'M', 'u_res');
+        const resCall = stub.uniformCalls.find(entry => entry.name === 'uniform2fv' && entry.location === resLoc);
+        expect(Array.from(resCall?.value as Float32Array)).toEqual([16, 8]);
+    });
+});
+
+describe('graph render: capture path keeps explicit dims (T18)', () => {
+    it('feeds renderFinalPassTo target dims to the final pass uniforms, not the canvas size', () => {
+        const leaf = shaderNode({ id: 'L', shaderConfig: gcfg(), uniforms: {}, width: 4, height: 4 });
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg({ u_probe: 'vec2' }), uniforms: { tex: leaf } });
+
+        const uniformsFor: UniformsFor = (nodeId): RenderPass['uniforms'] => {
+            if (nodeId === 'R') {
+                return { u_probe: { type: 'vec2', value: (_t: number, width: number, height: number) => f32([width, height]) as never } };
+            }
+            return {};
+        };
+
+        const { stub, manager, passSystem } = setupGraph(root, { uniformsFor });
+        manager.fbo.createFramebuffer('scratch', { width: 20, height: 10, textureCount: 1 });
+
+        stub.reset();
+        passSystem.renderFinalPassTo('scratch', 20, 10, 5);
+
+        const loc = location(manager, 'R', 'u_probe');
+        const call = stub.uniformCalls.find(entry => entry.name === 'uniform2fv' && entry.location === loc);
+        expect(Array.from(call?.value as Float32Array)).toEqual([20, 10]);
+    });
+});
+
+describe('graph render: single-texture swap degeneration (T19)', () => {
+    it('keeps the read index pinned at 0 for a textureCount-1 graph framebuffer across frames', () => {
+        const leaf = shaderNode({ id: 'L', shaderConfig: gcfg(), uniforms: {}, width: 4, height: 4 });
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { tex: leaf } });
+
+        const { manager, passSystem } = setupGraph(root);
+
+        expect(manager.fbo.getTextureCount('L-out')).toBe(1);
+
+        passSystem.execute(1);
+        expect(manager.fbo.getReadIndex('L-out')).toBe(0);
+
+        passSystem.execute(2);
+        expect(manager.fbo.getReadIndex('L-out')).toBe(0);
+    });
+});
+
+describe('graph render: source with a null sampler location (T20)', () => {
+    it('throws at initializeResources naming the sampler and program, and repeatably with no ghost state', () => {
+        const image = createSource('img');
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { img: image.source } });
+
+        const { passSystem } = setupGraph(root, {
+            stubConfig: { activeUniforms: { u_time: 'float' } },
+            initialize: false
+        });
+
+        expect(() => { passSystem.initializeResources() }).toThrow(/never samples "u_img"/);
+        expect(() => { passSystem.initializeResources() }).toThrow(/program "R"/);
+
+        const corrected = createSource('img');
+        const correctedRoot = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { img: corrected.source } });
+        expect(() => setupGraph(correctedRoot, {
+            stubConfig: { activeUniforms: { u_img: 'sampler2D' } }
+        })).not.toThrow();
+    });
+});
+
+describe('graph render: undefined source texture (T21)', () => {
+    it('throws at initializeResources with the defineTexture remedy when the source was never defined', () => {
+        const image = createSource('img');
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { img: image.source } });
+
+        expect(() => setupGraph(root, { defineSources: false })).toThrow(/defineTexture/);
+        expect(() => setupGraph(root, { defineSources: false })).toThrow(/"img"/);
+    });
+});
+
+describe('graph render: shared program, per-pass values (T22)', () => {
+    it('uploads each pass own uniform value before its own draw', () => {
+        const stub = createCanvasStub();
+        const manager = new WebGLManager(stub.canvas);
+        manager.createProgram('blur', {
+            vertexShader: '',
+            fragmentShader: '',
+            uniforms: [{ name: 'u_dir', type: 'vec2' }, { name: 'u_texture0', type: 'sampler2D' }],
+            attributes: [{ name: 'a_position', size: 2, type: 'FLOAT', normalized: false, stride: 0, offset: 0 }]
+        });
+        manager.fbo.createFramebuffer('fb-a', { width: 4, height: 4, textureCount: 1 });
+        manager.fbo.createFramebuffer('fb-b', { width: 4, height: 4, textureCount: 1 });
+
+        const passSystem = new Passes(manager);
+        passSystem.addPass({
+            programId: 'blur',
+            inputTextures: [{ id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
+            outputFramebuffer: 'fb-b',
+            uniforms: { u_dir: { type: 'vec2', value: f32([1, 0]) as never } }
+        });
+        passSystem.addPass({
+            programId: 'blur',
+            inputTextures: [{ id: 'fb-b', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }],
+            outputFramebuffer: null,
+            uniforms: { u_dir: { type: 'vec2', value: f32([0, 1]) as never } }
+        });
+        passSystem.initializeResources();
+
+        stub.reset();
+        passSystem.execute(0);
+
+        const dirLoc = manager.resources.get('blur')?.uniforms.u_dir;
+        const timeline = stub.calls
+            .filter(call =>
+                (call.name === 'uniform2fv' && call.args[0] === dirLoc)
+                || call.name === 'drawArrays')
+            .map(call => call.name === 'drawArrays' ? 'draw' : Array.from(call.args[1] as Float32Array));
+
+        expect(timeline).toEqual([[1, 0], 'draw', [0, 1], 'draw']);
+    });
+});
+
+describe('graph render: single-program texture-binding boundary (T24)', () => {
+    it('still throws the prepareRender guard for a program with registered source-texture bindings', () => {
+        const stub = createCanvasStub();
+        const manager = new WebGLManager(stub.canvas);
+        manager.createProgram('img', gcfg({ u_image: 'sampler2D' }));
+
+        const image = createSource('u_image');
+        manager.registerTextureBinding('img', { unit: 0, samplerName: 'u_image', source: image.source });
+
+        const passSystem = new Passes(manager);
+        passSystem.addPass({ programId: 'img', inputTextures: [], outputFramebuffer: null });
+        passSystem.initializeResources();
+
+        expect(() => { passSystem.execute(0) }).toThrow(/source-texture bindings/);
+    });
+});

--- a/src/core/systems/graphRender.test.ts
+++ b/src/core/systems/graphRender.test.ts
@@ -168,6 +168,41 @@ describe('graph render: source upload gating (T15)', () => {
         expect(stub.texSubImage2DCalls).toHaveLength(1);
         expect(stub.texSubImage2DCalls[0]).toMatchObject({ width: 4, height: 4 });
     });
+
+    it('re-binds the source every frame even when the upload is skipped, so the sampler never goes stale', () => {
+        const image = createSource('img');
+        const root = shaderNode({ id: 'R', shaderConfig: gcfg(), uniforms: { img: image.source } });
+
+        const { stub, passSystem } = setupGraph(root);
+
+        image.push(bitmap(4, 4));
+        stub.reset();
+
+        passSystem.execute(1);
+        const boundAtUnitZero = (): unknown[] => {
+            const bound: unknown[] = [];
+            let unit: unknown;
+            for (const call of stub.calls) {
+                if (call.name === 'activeTexture') {
+                    unit = call.args[0];
+                }
+                if (call.name === 'bindTexture' && unit === GL_TEXTURE0) {
+                    bound.push(call.args[1]);
+                }
+            }
+            return bound;
+        };
+        const sourceTexture = boundAtUnitZero()[0];
+        expect(sourceTexture).toBeDefined();
+
+        stub.reset();
+        passSystem.execute(2);
+
+        expect(stub.texImage2DCalls).toHaveLength(0);
+        expect(stub.texSubImage2DCalls).toHaveLength(0);
+        expect(boundAtUnitZero()).toContain(sourceTexture);
+        expect(stub.calls.filter(call => call.name === 'drawArrays')).toHaveLength(1);
+    });
 });
 
 describe('graph render: one source feeding two nodes (T16)', () => {

--- a/src/react/lib/liveUniformUpdaters.ts
+++ b/src/react/lib/liveUniformUpdaters.ts
@@ -1,5 +1,6 @@
 import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { UNIFORM_COMPONENTS } from '@/core/lib/uniformComponents';
+import { normalizeUniformName } from '@/core/lib/uniformNames';
 import type { NonReproducible } from '@/react/lib/captureLiveness';
 import { createCommonUpdaters } from '@/react/lib/createUniformUpdater';
 import type { TransitionRuntime } from '@/react/lib/transitionRuntime';
@@ -140,9 +141,7 @@ export function combineUniformDebugPorts(ports: UniformDebugPort[]): UniformDebu
     };
 }
 
-export function normalizeUniformName(name: string): string {
-    return name.startsWith('u_') ? name : `u_${name}`;
-}
+export { normalizeUniformName };
 
 export function normalizeUniformParams(
     uniforms: Record<string, UniformParam>

--- a/src/react/lib/workerMode.test.ts
+++ b/src/react/lib/workerMode.test.ts
@@ -359,6 +359,35 @@ describe('findWorkerBlock: render passes', () => {
             name: 'u_amount'
         });
     });
+
+    it('blocks a pass that samples a texture source, and explains it with the textures message', () => {
+        const block = findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: {} },
+            passes: [{
+                programId: PROGRAM_ID,
+                inputTextures: [
+                    { id: 'u_image', textureUnit: 0, bindingType: 'source', samplerName: 'u_image' }
+                ],
+                outputFramebuffer: null
+            }]
+        }));
+
+        expect(block).toEqual({ kind: 'textures' });
+        expect(workerBlockMessage('BaseShaderComponent', block!)).toMatch(/"textures" prop/);
+    });
+
+    it('does not block a pass whose inputs are all framebuffer reads', () => {
+        expect(findWorkerBlock(blockInputs({
+            uniforms: { [PROGRAM_ID]: {} },
+            passes: [{
+                programId: PROGRAM_ID,
+                inputTextures: [
+                    { id: 'fb-a', textureUnit: 0, bindingType: 'read', samplerName: 'u_texture0' }
+                ],
+                outputFramebuffer: null
+            }]
+        }))).toBeNull();
+    });
 });
 
 describe('workerPingPongUniforms', () => {

--- a/src/react/lib/workerMode.ts
+++ b/src/react/lib/workerMode.ts
@@ -124,6 +124,15 @@ function findProgramUniformBlock(inputs: WorkerBlockInputs): WorkerBlock | null 
     return null;
 }
 
+function findPassTextureBlock(passes: RenderPass[]): WorkerBlock | null {
+    for (const pass of passes) {
+        if (pass.inputTextures.some(texture => texture.bindingType === 'source')) {
+            return { kind: 'textures' };
+        }
+    }
+    return null;
+}
+
 function findPassUniformBlock(passes: RenderPass[]): WorkerBlock | null {
     for (let passIndex = 0; passIndex < passes.length; passIndex++) {
         const pass = passes[passIndex];
@@ -155,6 +164,7 @@ export function findWorkerBlock(inputs: WorkerBlockInputs): WorkerBlock | null {
 
     return findLiveUniformBlock(inputs)
         ?? findProgramUniformBlock(inputs)
+        ?? findPassTextureBlock(inputs.passes ?? [])
         ?? findPassUniformBlock(inputs.passes ?? []);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -300,7 +300,7 @@ export type ImageInput =
 export interface TextureBinding {
   id: string;
   textureUnit: number;
-  bindingType: 'read' | 'write' | 'readwrite';
+  bindingType: 'read' | 'write' | 'readwrite' | 'source';
   samplerName: string;
 }
 


### PR DESCRIPTION
Track 5 (composition-effects) slice C1 of 6: the core, React-free half of shader-graph composition. A pure planner compiles a plain-data node DAG into the props `PingPongShaderEngine` already takes, plus the two `Passes`-layer changes composition needs. No public barrel exports yet — C2 (`composition-react`) lands `useShaderGraph`/`ShaderGraph` and the public surface.

## What's here

- **`src/core/lib/graphPlanning.ts`** — `shaderNode()` / `planGraph()` / `toRenderPasses()`. Plain-data nodes; uniform values are `UniformParam | ShaderNode | TextureSource` (a texture leaf is the object `useImageTexture`/`useVideoTexture`/`useWebcamTexture` already hand out). DFS post-order; diamonds render once; cycles, duplicate ids, foreign sources sharing an id, sampler-name collisions (including post-`u_` normalization, and value-uniform collisions), root with width/height, and over-limit texture units all fail loud naming the offender. Sampler uniforms are auto-declared in each node's config (the framework declares what the framework uploads). `GraphTopology` is emitted by the same walk that emits the passes — the C3 inspector will render the compiler's own output, not a reconstruction.
- **`TextureBinding.bindingType` gains `'source'`** — a graph leaf binds via `TextureManager.bindToUnit` + a new `uploadIfStaleById` (one version-gating path) + the same per-pass sampler upload as FBO inputs. `registerTextureBinding` and the `prepareRender` guard are untouched: the single-program path keeps its boundary (regression-tested), and `compilePass` is an exhaustive switch so a future binding type cannot silently fall into the FBO path.
- **Per-pass output dimensions** (approved behavior fix): a pass's uniform fns and `updateUniforms` now see the surface being drawn into (`FBOManager.getSize`, canvas when null) instead of always the canvas. Pre-1.0 behavior change only for fixed-size FBOs whose shaders read `u_resolution` — previously a 16x8 node on a 300x150 canvas saw (300,150), so texel math was wrong. Capture paths (`renderFinalPassTo`) keep their explicit dims (tested).
- **`initializeResources` source guards**: undefined source id and null sampler location both throw before any mutation; the corrected-retry test re-inits the same manager instance.
- **Worker boundary**: `findWorkerBlock` now blocks any pass with a `'source'` input (`kind: 'textures'`) instead of letting it reach a worker that could never upload it.
- `normalizeUniformName` moved to `src/core/lib/uniformNames.ts` (core cannot import react); react re-exports, importers untouched.

## Probe-verified premises (design pass, observed on master before implementation)

- A hand-built 3-node DAG already renders through `Passes` in topological order with per-node pass-uniform values advancing — composition compiles to existing machinery, no new engine.
- Every `outputFramebuffer` gets swap treatment, but `textureCount: 1` degenerates it to a no-op (anchored by test).
- Two passes can share one program with different per-pass uniform values (C5's Blur will be one program, two passes).
- A source-texture leaf via per-program registration throws at `prepareRender` — this slice crosses that boundary by design, on the pass path only.

## Review record

Double read-only Opus review (correctness lens + style lens) -> adjudicated apply pass -> standalone edit-empowered Opus pass. Both reviewers converged on the missed `compilePass` exhaustiveness requirement and a vacuous test leg. Correctness found `isShaderNode` crashing with a raw TypeError on `null`/`undefined` uniform values (realistic C2 input — a source hook pre-load) instead of the designed message. Style found two test-honesty gaps (a fixture that couldn't discriminate per-node uniforms; three topology fields with zero coverage). The standalone pass found no surviving product defect and added a re-bind-every-frame honesty test (a refactor gating `bindToUnit` behind the upload would keep every other test green while samplers silently read stale unit-0 state).

## Gates

- `typecheck` / `lint` / `test` / `build`: green, **1,104 tests** (was 1,070 on master)
- counters: **19/19** · worker e2e (`MICUGL_E2E=1`): **10/10**

## Deferred to C2 (filed, deliberate)

- Graph-EDGE (`'read'`) null-location semantics: a node whose shader never samples its child edge currently renders "successfully" without the child (the `u_texture0` null-skip is load-bearing for #58's no-breaking-change rule; graph edges need their own decision).
- Worker `{ kind: 'textures' }` message framing for graph sources (message mentions the `textures` prop, which isn't involved).
- Promoting the `createSource`/`bitmap` test fixtures into `@/testing` (second copy landed here; do it before C5 adds a third).
- `initializeResources` validate-all-then-create restructure (pre-existing interleave, benign today).
