### PR TITLE
effects: C4 foundation - micugl/effects subpath, MeshGradient + Grain with audio-reactive props

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,80 @@ suppressed while the component is motion-gated, so a reduced-motion user gets th
 of a live stream. When in doubt, `request()`: repainting a poster once is the safe default. See
 [What repaints the poster, and what freezes](#what-repaints-the-poster-and-what-freezes).
 
+## Effects
+
+`micugl/effects` is a set of polished, prop-driven fullscreen components. Each rides
+`BaseShaderComponent` (the fast path, no FBO), owns a local `speed` prop that is an in-shader
+animation multiplier (not the engine clock scale), and takes an optional `audio` prop — the object
+`useAudioUniforms` returns — whose LEVEL uniform drives a reaction. Colors are `Vec3` arrays of
+`0..1` floats. Numbers must be finite and colors well-formed; the components throw a named error
+rather than clamping or silently substituting. Every render prop except `speed` and `worker` is
+forwarded to `BaseShaderComponent`.
+
+```tsx
+import { MeshGradient, Grain } from 'micugl/effects';
+```
+
+### MeshGradient
+
+Four color control points drift on seeded paths and blend by inverse-distance weighting, with a
+value-noise domain warp for organic, non-radial edges. At `speed={0}` it is a still, seeded
+composition — a deliberate poster:
+
+```tsx
+<MeshGradient speed={0} seed={3} colors={[[0.96, 0.76, 0.85], [0.74, 0.85, 0.96], [0.80, 0.95, 0.82]]} />
+```
+
+Animated, with audio:
+
+```tsx
+const audio = useAudioUniforms({ type: 'mic' });
+<MeshGradient audio={audio} audioStrength={1.5} />;  // call audio.start() on a user gesture
+```
+
+| prop | type | default |
+|---|---|---|
+| `colors` | `Vec3[]` (2 to 4) | four pastels |
+| `speed` | `number` | `0.2` |
+| `warp` | `number` | `0.6` |
+| `warpScale` | `number` | `1.2` |
+| `seed` | `number` | `0` |
+| `audio` | `AudioUniformsResult` | none |
+| `audioStrength` | `number` | `1` |
+
+Audio reaction: the warp depth and drift rate grow with the audio level, so the gradient visibly
+breathes with the sound.
+
+### Grain
+
+Filmic white-noise grain re-seeded in ~24 fps steps, composited over a base color. At `speed={0}`
+it is a single frozen grain field:
+
+```tsx
+<Grain speed={0} intensity={0.08} scale={2} />
+```
+
+Animated flicker over a dark base:
+
+```tsx
+<Grain color={[0.02, 0.02, 0.04]} grainColor={[0.95, 0.95, 1]} intensity={0.12} />
+```
+
+| prop | type | default |
+|---|---|---|
+| `color` | `Vec3` | `[0, 0, 0]` |
+| `grainColor` | `Vec3` | `[1, 1, 1]` |
+| `intensity` | `number` | `0.08` |
+| `scale` | `number` (cell px) | `2` |
+| `speed` | `number` | `1` |
+| `audio` | `AudioUniformsResult` | none |
+| `audioStrength` | `number` | `1` |
+
+Audio reaction: the grain intensity scales with the audio level, so louder passages grain harder.
+
+The `audio` prop must come from `useAudioUniforms` with its default uniform names; a custom
+`names.level` option makes the effect throw, since it reads the level by its default name.
+
 ## Textures
 
 Bind an image to a `sampler2D` with the `textures` prop. `useImageTexture` owns the decode

--- a/README.md
+++ b/README.md
@@ -523,8 +523,8 @@ of a live stream. When in doubt, `request()`: repainting a poster once is the sa
 animation multiplier (not the engine clock scale), and takes an optional `audio` prop — the object
 `useAudioUniforms` returns — whose LEVEL uniform drives a reaction. Colors are `Vec3` arrays of
 `0..1` floats. Numbers must be finite and colors well-formed; the components throw a named error
-rather than clamping or silently substituting. Every render prop except `speed` and `worker` is
-forwarded to `BaseShaderComponent`.
+rather than clamping or silently substituting. Every render prop except `speed` and the worker
+props (`worker`, `createWorker`) is forwarded to `BaseShaderComponent`.
 
 ```tsx
 import { MeshGradient, Grain } from 'micugl/effects';
@@ -557,8 +557,8 @@ const audio = useAudioUniforms({ type: 'mic' });
 | `audio` | `AudioUniformsResult` | none |
 | `audioStrength` | `number` | `1` |
 
-Audio reaction: the warp depth and drift rate grow with the audio level, so the gradient visibly
-breathes with the sound.
+Audio reaction: the warp depth grows with the audio level and the drift phase gets a bounded
+forward push, so the gradient visibly breathes with the sound and settles back when it fades.
 
 ### Grain
 

--- a/demo/scenes/EffectsGallery.tsx
+++ b/demo/scenes/EffectsGallery.tsx
@@ -3,8 +3,29 @@ import { useState } from 'react';
 import { Grain } from '../../src/effects/Grain/Grain';
 import { MeshGradient } from '../../src/effects/MeshGradient/MeshGradient';
 import { useAudioUniforms } from '../../src/react/hooks/useAudioUniforms';
+import type { Vec3 } from '../../src/types';
 
 const MIC = { type: 'mic' } as const;
+
+interface ColorPreset {
+    label: string;
+    colors: Vec3[];
+}
+
+const COLOR_PRESETS: ColorPreset[] = [
+    {
+        label: 'pastel quad (4)',
+        colors: [[0.96, 0.76, 0.85], [0.74, 0.85, 0.96], [0.80, 0.95, 0.82], [0.98, 0.92, 0.76]]
+    },
+    {
+        label: 'spring trio (3)',
+        colors: [[0.96, 0.76, 0.85], [0.74, 0.85, 0.96], [0.80, 0.95, 0.82]]
+    },
+    {
+        label: 'ember duo (2)',
+        colors: [[0.10, 0.12, 0.35], [0.95, 0.55, 0.25]]
+    }
+];
 
 const panelStyle = {
     position: 'absolute',
@@ -59,13 +80,14 @@ const Knob = ({ label, value, min, max, step, onChange }: KnobProps) => (
                 value={value}
                 onChange={event => { onChange(Number(event.target.value)) }}
             />
-            <span style={{ width: '40px', textAlign: 'right' }}>{value.toFixed(2)}</span>
+            <span style={{ width: '40px', textAlign: 'right' }}>{value.toFixed(step < 1 ? 2 : 0)}</span>
         </span>
     </label>
 );
 
 export const EffectsGallery = () => {
     const [poster, setPoster] = useState(false);
+    const [presetIndex, setPresetIndex] = useState(0);
     const [meshSpeed, setMeshSpeed] = useState(0.2);
     const [warp, setWarp] = useState(0.6);
     const [warpScale, setWarpScale] = useState(1.2);
@@ -77,6 +99,8 @@ export const EffectsGallery = () => {
 
     const audio = useAudioUniforms(MIC, { attack: 0.05, release: 0.25 });
     const running = audio.status === 'running';
+    const starting = audio.status === 'starting';
+    const preset = COLOR_PRESETS[presetIndex];
 
     const half = { position: 'relative', flex: '1 1 0', minWidth: 0 } as const;
 
@@ -84,6 +108,7 @@ export const EffectsGallery = () => {
         <div style={{ width: '100vw', height: '100vh', display: 'flex' }}>
             <div style={half}>
                 <MeshGradient
+                    colors={preset.colors}
                     speed={poster ? 0 : meshSpeed}
                     warp={warp}
                     warpScale={warpScale}
@@ -111,6 +136,13 @@ export const EffectsGallery = () => {
             <div style={panelStyle}>
                 <div style={columnStyle}>
                     <strong>MeshGradient</strong>
+                    <button
+                        type='button'
+                        style={buttonStyle(false)}
+                        onClick={() => { setPresetIndex(index => (index + 1) % COLOR_PRESETS.length) }}
+                    >
+                        colors: {preset.label}
+                    </button>
                     <Knob label='speed' value={meshSpeed} min={0} max={2} step={0.05} onChange={setMeshSpeed} />
                     <Knob label='warp' value={warp} min={0} max={2} step={0.05} onChange={setWarp} />
                     <Knob label='warpScale' value={warpScale} min={0.2} max={4} step={0.1} onChange={setWarpScale} />
@@ -129,7 +161,8 @@ export const EffectsGallery = () => {
                     </button>
                     <button
                         type='button'
-                        style={buttonStyle(running)}
+                        style={{ ...buttonStyle(running), opacity: starting ? 0.5 : 1 }}
+                        disabled={starting}
                         onClick={() => {
                             if (running) {
                                 audio.stop();
@@ -138,7 +171,7 @@ export const EffectsGallery = () => {
                             }
                         }}
                     >
-                        {running ? 'audio: stop' : 'audio: start (mic)'}
+                        {starting ? 'audio: starting' : running ? 'audio: stop' : 'audio: start (mic)'}
                     </button>
                     <Knob
                         label='audioStrength'

--- a/demo/scenes/EffectsGallery.tsx
+++ b/demo/scenes/EffectsGallery.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+
+import { Grain } from '../../src/effects/Grain/Grain';
+import { MeshGradient } from '../../src/effects/MeshGradient/MeshGradient';
+import { useAudioUniforms } from '../../src/react/hooks/useAudioUniforms';
+
+const MIC = { type: 'mic' } as const;
+
+const panelStyle = {
+    position: 'absolute',
+    left: '12px',
+    bottom: '12px',
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '16px',
+    padding: '14px 16px',
+    background: 'rgba(0, 0, 0, 0.62)',
+    color: '#fff',
+    fontFamily: 'monospace',
+    fontSize: '12px',
+    borderRadius: '6px',
+    maxWidth: 'calc(100vw - 24px)'
+} as const;
+
+const columnStyle = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    minWidth: '180px'
+} as const;
+
+const buttonStyle = (active: boolean) => ({
+    padding: '6px 10px',
+    background: active ? '#e94560' : '#0f3460',
+    border: 'none',
+    borderRadius: '4px',
+    color: '#fff',
+    cursor: 'pointer'
+});
+
+interface KnobProps {
+    label: string;
+    value: number;
+    min: number;
+    max: number;
+    step: number;
+    onChange: (value: number) => void;
+}
+
+const Knob = ({ label, value, min, max, step, onChange }: KnobProps) => (
+    <label style={{ display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'center' }}>
+        <span>{label}</span>
+        <span style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+            <input
+                type='range'
+                min={min}
+                max={max}
+                step={step}
+                value={value}
+                onChange={event => { onChange(Number(event.target.value)) }}
+            />
+            <span style={{ width: '40px', textAlign: 'right' }}>{value.toFixed(2)}</span>
+        </span>
+    </label>
+);
+
+export const EffectsGallery = () => {
+    const [poster, setPoster] = useState(false);
+    const [meshSpeed, setMeshSpeed] = useState(0.2);
+    const [warp, setWarp] = useState(0.6);
+    const [warpScale, setWarpScale] = useState(1.2);
+    const [seed, setSeed] = useState(0);
+    const [grainSpeed, setGrainSpeed] = useState(1);
+    const [intensity, setIntensity] = useState(0.08);
+    const [scale, setScale] = useState(2);
+    const [audioStrength, setAudioStrength] = useState(1);
+
+    const audio = useAudioUniforms(MIC, { attack: 0.05, release: 0.25 });
+    const running = audio.status === 'running';
+
+    const half = { position: 'relative', flex: '1 1 0', minWidth: 0 } as const;
+
+    return (
+        <div style={{ width: '100vw', height: '100vh', display: 'flex' }}>
+            <div style={half}>
+                <MeshGradient
+                    speed={poster ? 0 : meshSpeed}
+                    warp={warp}
+                    warpScale={warpScale}
+                    seed={seed}
+                    audio={audio}
+                    audioStrength={audioStrength}
+                    style={{ width: '100%', height: '100%', display: 'block' }}
+                    fit='element'
+                />
+            </div>
+            <div style={half}>
+                <Grain
+                    color={[0.02, 0.02, 0.04]}
+                    grainColor={[0.95, 0.95, 1]}
+                    intensity={intensity}
+                    scale={scale}
+                    speed={poster ? 0 : grainSpeed}
+                    audio={audio}
+                    audioStrength={audioStrength}
+                    style={{ width: '100%', height: '100%', display: 'block' }}
+                    fit='element'
+                />
+            </div>
+
+            <div style={panelStyle}>
+                <div style={columnStyle}>
+                    <strong>MeshGradient</strong>
+                    <Knob label='speed' value={meshSpeed} min={0} max={2} step={0.05} onChange={setMeshSpeed} />
+                    <Knob label='warp' value={warp} min={0} max={2} step={0.05} onChange={setWarp} />
+                    <Knob label='warpScale' value={warpScale} min={0.2} max={4} step={0.1} onChange={setWarpScale} />
+                    <Knob label='seed' value={seed} min={0} max={12} step={1} onChange={setSeed} />
+                </div>
+                <div style={columnStyle}>
+                    <strong>Grain</strong>
+                    <Knob label='intensity' value={intensity} min={0} max={1} step={0.01} onChange={setIntensity} />
+                    <Knob label='scale' value={scale} min={1} max={8} step={0.5} onChange={setScale} />
+                    <Knob label='speed' value={grainSpeed} min={0} max={4} step={0.1} onChange={setGrainSpeed} />
+                </div>
+                <div style={columnStyle}>
+                    <strong>Shared</strong>
+                    <button type='button' style={buttonStyle(poster)} onClick={() => { setPoster(value => !value) }}>
+                        {poster ? 'poster: speed=0' : 'poster: off'}
+                    </button>
+                    <button
+                        type='button'
+                        style={buttonStyle(running)}
+                        onClick={() => {
+                            if (running) {
+                                audio.stop();
+                            } else {
+                                void audio.start();
+                            }
+                        }}
+                    >
+                        {running ? 'audio: stop' : 'audio: start (mic)'}
+                    </button>
+                    <Knob
+                        label='audioStrength'
+                        value={audioStrength}
+                        min={0}
+                        max={4}
+                        step={0.1}
+                        onChange={setAudioStrength}
+                    />
+                    <div>status: {audio.status}</div>
+                    {audio.error ? <div style={{ color: '#ff8fa3' }}>{audio.error.message}</div> : null}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from 'react';
 
 import { AudioBars } from './AudioBars';
 import { DevtoolsDebug } from './DevtoolsDebug';
+import { EffectsGallery } from './EffectsGallery';
 import { ExportDemo } from './ExportDemo';
 import { ImageTexture } from './ImageTexture';
 import { InstancedParticles } from './InstancedParticles';
@@ -31,6 +32,7 @@ export const scenes: Record<string, ComponentType> = {
     'reduced-motion': ReducedMotion,
     'transitions': Transitions,
     'audio-bars': AudioBars,
+    'effects-gallery': EffectsGallery,
     'visual-fixed': VisualFixed,
     'export-demo': ExportDemo,
     'image-texture': ImageTexture,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/devtools.mjs",
       "require": "./dist/devtools.js"
     },
+    "./effects": {
+      "types": "./dist/effects/index.d.ts",
+      "import": "./dist/effects.mjs",
+      "require": "./dist/effects.js"
+    },
     "./worker": {
       "types": "./dist/worker/workerEntry.d.ts",
       "worker": "./dist/worker.mjs",

--- a/scripts/assertTreeshaken.mjs
+++ b/scripts/assertTreeshaken.mjs
@@ -68,6 +68,7 @@ while (queue.length > 0) {
 }
 
 const DEVTOOLS_PREFIX = `react${sep}devtools${sep}`;
+const EFFECTS_PREFIX = `effects${sep}`;
 const failures = [];
 const rel = file => relative(distRoot, file);
 
@@ -75,6 +76,9 @@ for (const file of reachable) {
     const name = rel(file);
     if (name.startsWith(DEVTOOLS_PREFIX) && !name.endsWith(`${sep}beacon.mjs`)) {
         failures.push(`devtools panel module reachable from a main bundle: ${name}`);
+    }
+    if (name === 'effects.mjs' || name.startsWith(EFFECTS_PREFIX)) {
+        failures.push(`effects module reachable from a main bundle: ${name}`);
     }
     if (name === 'testing.mjs' || name.startsWith(`testing${sep}`)) {
         failures.push(`testing module reachable from a main bundle: ${name}`);

--- a/src/effects/Grain/Grain.test.tsx
+++ b/src/effects/Grain/Grain.test.tsx
@@ -89,5 +89,6 @@ describe('Grain: real uniforms reach the GL stub and advance', () => {
         for (let i = 1; i < times.length; i++) {
             expect(times[i]).toBeGreaterThan(times[i - 1]);
         }
+        expect(times[times.length - 1]).toBeLessThan(1);
     });
 });

--- a/src/effects/Grain/Grain.test.tsx
+++ b/src/effects/Grain/Grain.test.tsx
@@ -1,0 +1,93 @@
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Grain } from '@/effects/Grain/Grain';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type { Vec3 } from '@/types';
+
+const WIDTH = 320;
+const HEIGHT = 200;
+const FIXTURE_COLOR: Vec3 = [0.09, 0.61, 0.37];
+const FIXTURE_GRAIN: Vec3 = [0.88, 0.24, 0.66];
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let originalGetContext: unknown;
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stub = createGLStub();
+    originalGetContext = (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext;
+    (HTMLCanvasElement.prototype as unknown as { getContext: () => WebGLRenderingContext }).getContext =
+        function stubGetContext() { return stub.gl };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    (HTMLCanvasElement.prototype as unknown as { getContext: unknown }).getContext = originalGetContext;
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+function uploadsOf(name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+describe('Grain: real uniforms reach the GL stub and advance', () => {
+    it('uploads the fixture colors and drives u_time forward across ticks', async () => {
+        await mount(
+            <Grain
+                color={FIXTURE_COLOR}
+                grainColor={FIXTURE_GRAIN}
+                intensity={0.42}
+                width={WIDTH}
+                height={HEIGHT}
+                useDevicePixelRatio={false}
+                reducedMotion='ignore'
+                saveData='ignore'
+            />
+        );
+
+        for (let time = 0; time <= 160; time += 16) {
+            act(() => { frames.tick(time) });
+        }
+
+        const color = uploadsOf('u_color').map(value => Array.from(value as Float32Array));
+        expect(color.length).toBeGreaterThan(0);
+        expect(color[0]).toEqual(Array.from(new Float32Array([0.09, 0.61, 0.37])));
+
+        const grainColor = uploadsOf('u_grainColor').map(value => Array.from(value as Float32Array));
+        expect(grainColor[0]).toEqual(Array.from(new Float32Array([0.88, 0.24, 0.66])));
+
+        const intensity = uploadsOf('u_intensity') as number[];
+        expect(intensity).toContain(0.42);
+
+        const times = uploadsOf('u_time') as number[];
+        expect(times.length).toBeGreaterThan(5);
+        for (let i = 1; i < times.length; i++) {
+            expect(times[i]).toBeGreaterThan(times[i - 1]);
+        }
+    });
+});

--- a/src/effects/Grain/Grain.tsx
+++ b/src/effects/Grain/Grain.tsx
@@ -1,0 +1,45 @@
+import { forwardRef } from 'react';
+
+import { createShaderConfig } from '@/core';
+import { grainFragmentShader, grainVertexShader } from '@/effects/Grain/grainShaders';
+import type { GrainUniformProps } from '@/effects/Grain/grainUniforms';
+import { grainUniforms } from '@/effects/Grain/grainUniforms';
+import type { EffectRenderProps } from '@/effects/lib/effectProps';
+import { BaseShaderComponent } from '@/react';
+import type { ShaderHandle } from '@/types';
+
+export interface GrainProps extends EffectRenderProps, GrainUniformProps {}
+
+const PROGRAM_ID = 'micugl-effect-grain';
+
+const config = createShaderConfig({
+    vertexShader: grainVertexShader,
+    fragmentShader: grainFragmentShader,
+    uniformNames: {
+        u_color: 'vec3',
+        u_grainColor: 'vec3',
+        u_intensity: 'float',
+        u_scale: 'float',
+        u_speed: 'float',
+        u_audioLevel: 'float',
+        u_audioStrength: 'float'
+    }
+});
+
+export const Grain = forwardRef<ShaderHandle, GrainProps>((props, ref) => {
+    const { color, grainColor, intensity, scale, speed, audio, audioStrength, ...renderProps } = props;
+
+    const uniforms = grainUniforms({ color, grainColor, intensity, scale, speed, audio, audioStrength });
+
+    return (
+        <BaseShaderComponent
+            ref={ref}
+            programId={PROGRAM_ID}
+            shaderConfig={config}
+            uniforms={uniforms}
+            {...renderProps}
+        />
+    );
+});
+
+Grain.displayName = 'Grain';

--- a/src/effects/Grain/Grain.tsx
+++ b/src/effects/Grain/Grain.tsx
@@ -1,10 +1,11 @@
 import { forwardRef } from 'react';
 
 import { createShaderConfig } from '@/core';
-import { grainFragmentShader, grainVertexShader } from '@/effects/Grain/grainShaders';
+import { grainFragmentShader } from '@/effects/Grain/grainShaders';
 import type { GrainUniformProps } from '@/effects/Grain/grainUniforms';
 import { grainUniforms } from '@/effects/Grain/grainUniforms';
 import type { EffectRenderProps } from '@/effects/lib/effectProps';
+import { fullscreenVertexShader } from '@/effects/lib/fullscreenVertexShader';
 import { BaseShaderComponent } from '@/react';
 import type { ShaderHandle } from '@/types';
 
@@ -13,7 +14,7 @@ export interface GrainProps extends EffectRenderProps, GrainUniformProps {}
 const PROGRAM_ID = 'micugl-effect-grain';
 
 const config = createShaderConfig({
-    vertexShader: grainVertexShader,
+    vertexShader: fullscreenVertexShader,
     fragmentShader: grainFragmentShader,
     uniformNames: {
         u_color: 'vec3',

--- a/src/effects/Grain/grainShaders.ts
+++ b/src/effects/Grain/grainShaders.ts
@@ -1,5 +1,3 @@
-export { fullscreenVertexShader as grainVertexShader } from '@/effects/lib/fullscreenVertexShader';
-
 export const grainFragmentShader = `
     precision highp float;
 
@@ -22,8 +20,8 @@ export const grainFragmentShader = `
     }
 
     void main() {
-        float t = u_time * 0.001 * u_speed;
-        vec2 cell = floor(v_texCoord * u_resolution / max(u_scale, 1.0));
+        float t = u_time * u_speed;
+        vec2 cell = floor(v_texCoord * u_resolution / u_scale);
         float tick = floor(t * 24.0);
         float n = hash21(cell + vec2(tick, tick * 1.7));
 

--- a/src/effects/Grain/grainShaders.ts
+++ b/src/effects/Grain/grainShaders.ts
@@ -1,0 +1,34 @@
+export { fullscreenVertexShader as grainVertexShader } from '@/effects/lib/fullscreenVertexShader';
+
+export const grainFragmentShader = `
+    precision highp float;
+
+    uniform vec2 u_resolution;
+    uniform float u_time;
+    uniform vec3 u_color;
+    uniform vec3 u_grainColor;
+    uniform float u_intensity;
+    uniform float u_scale;
+    uniform float u_speed;
+    uniform float u_audioLevel;
+    uniform float u_audioStrength;
+
+    varying vec2 v_texCoord;
+
+    float hash21(vec2 p) {
+        p = fract(p * vec2(123.34, 456.21));
+        p += dot(p, p + 45.32);
+        return fract(p.x * p.y);
+    }
+
+    void main() {
+        float t = u_time * 0.001 * u_speed;
+        vec2 cell = floor(v_texCoord * u_resolution / max(u_scale, 1.0));
+        float tick = floor(t * 24.0);
+        float n = hash21(cell + vec2(tick, tick * 1.7));
+
+        float intensity = u_intensity * (1.0 + u_audioStrength * u_audioLevel);
+        vec3 col = mix(u_color, u_grainColor, n * intensity);
+        gl_FragColor = vec4(col, 1.0);
+    }
+`;

--- a/src/effects/Grain/grainUniforms.test.ts
+++ b/src/effects/Grain/grainUniforms.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFrameInvalidation } from '@/core';
+import { grainUniforms } from '@/effects/Grain/grainUniforms';
+import type { AudioUniformsResult } from '@/react';
+import type { UniformParam, Vec3 } from '@/types';
+
+const fakeAudio = (uniforms: Record<string, UniformParam>): AudioUniformsResult => ({
+    uniforms,
+    start: () => Promise.resolve(),
+    stop: () => undefined,
+    status: 'running',
+    error: null
+});
+
+describe('grainUniforms: defaults', () => {
+    it('produces the exact uniform record for default props', () => {
+        const uniforms = grainUniforms();
+
+        expect(Object.keys(uniforms).sort()).toEqual([
+            'u_audioLevel',
+            'u_audioStrength',
+            'u_color',
+            'u_grainColor',
+            'u_intensity',
+            'u_scale',
+            'u_speed'
+        ]);
+
+        expect(uniforms.u_color).toEqual({ type: 'vec3', value: new Float32Array([0, 0, 0]) });
+        expect(uniforms.u_grainColor).toEqual({ type: 'vec3', value: new Float32Array([1, 1, 1]) });
+        expect(uniforms.u_intensity).toEqual({ type: 'float', value: 0.08 });
+        expect(uniforms.u_scale).toEqual({ type: 'float', value: 2 });
+        expect(uniforms.u_speed).toEqual({ type: 'float', value: 1 });
+        expect(uniforms.u_audioLevel).toEqual({ type: 'float', value: 0 });
+        expect(uniforms.u_audioStrength).toEqual({ type: 'float', value: 0 });
+    });
+});
+
+describe('grainUniforms: prop mapping', () => {
+    it('lands each documented prop in its uniform, with vec3 conversion for colors', () => {
+        const color: Vec3 = [0.12, 0.34, 0.56];
+        const grainColor: Vec3 = [0.98, 0.76, 0.54];
+        const uniforms = grainUniforms({ color, grainColor, intensity: 0.5, scale: 6, speed: 2.5 });
+
+        expect(uniforms.u_color.value).toBeInstanceOf(Float32Array);
+        expect(uniforms.u_color.value).toEqual(new Float32Array([0.12, 0.34, 0.56]));
+        expect(uniforms.u_grainColor.value).toEqual(new Float32Array([0.98, 0.76, 0.54]));
+        expect(uniforms.u_intensity.value).toBe(0.5);
+        expect(uniforms.u_scale.value).toBe(6);
+        expect(uniforms.u_speed.value).toBe(2.5);
+    });
+
+    it('throws with the offending prop named when a number is not finite', () => {
+        expect(() => grainUniforms({ intensity: Number.POSITIVE_INFINITY })).toThrow(/"intensity".*finite/s);
+    });
+
+    it('throws when a color tuple has the wrong length', () => {
+        expect(() => grainUniforms({ color: [0.1, 0.2] as unknown as Vec3 })).toThrow(/"color".*3-number tuple/s);
+    });
+});
+
+describe('grainUniforms: audio passthrough', () => {
+    it('with audio absent: u_audioLevel is a literal 0 with no invalidation or nonReproducible', () => {
+        const uniforms = grainUniforms();
+
+        expect(uniforms.u_audioLevel).toEqual({ type: 'float', value: 0 });
+        expect('invalidation' in uniforms.u_audioLevel).toBe(false);
+        expect('nonReproducible' in uniforms.u_audioLevel).toBe(false);
+        expect(uniforms.u_audioStrength.value).toBe(0);
+    });
+
+    it('with audio present: forwards the exact u_audioLevel param object and maps strength', () => {
+        const level: UniformParam = {
+            type: 'float',
+            value: () => 0.5,
+            invalidation: createFrameInvalidation(),
+            nonReproducible: () => true
+        };
+        const audio = fakeAudio({ u_audioLevel: level });
+
+        const uniforms = grainUniforms({ audio, audioStrength: 2 });
+
+        expect(uniforms.u_audioLevel).toBe(level);
+        expect(uniforms.u_audioStrength).toEqual({ type: 'float', value: 2 });
+    });
+
+    it('throws with an actionable message when the audio result has no u_audioLevel key', () => {
+        const audio = fakeAudio({ level: { type: 'float', value: 0 } });
+
+        expect(() => grainUniforms({ audio })).toThrow(/u_audioLevel.*default uniform names/s);
+    });
+});

--- a/src/effects/Grain/grainUniforms.test.ts
+++ b/src/effects/Grain/grainUniforms.test.ts
@@ -58,6 +58,15 @@ describe('grainUniforms: prop mapping', () => {
     it('throws when a color tuple has the wrong length', () => {
         expect(() => grainUniforms({ color: [0.1, 0.2] as unknown as Vec3 })).toThrow(/"color".*3-number tuple/s);
     });
+
+    it('throws with "scale" named for zero and negative scale', () => {
+        expect(() => grainUniforms({ scale: 0 })).toThrow(/"scale".*greater than 0/s);
+        expect(() => grainUniforms({ scale: -2 })).toThrow(/"scale".*greater than 0/s);
+    });
+
+    it('passes a sub-pixel scale through without clamping', () => {
+        expect(grainUniforms({ scale: 0.5 }).u_scale.value).toBe(0.5);
+    });
 });
 
 describe('grainUniforms: audio passthrough', () => {
@@ -83,6 +92,10 @@ describe('grainUniforms: audio passthrough', () => {
 
         expect(uniforms.u_audioLevel).toBe(level);
         expect(uniforms.u_audioStrength).toEqual({ type: 'float', value: 2 });
+    });
+
+    it('throws for a non-finite audioStrength even with audio absent', () => {
+        expect(() => grainUniforms({ audioStrength: Number.NaN })).toThrow(/"audioStrength".*finite/s);
     });
 
     it('throws with an actionable message when the audio result has no u_audioLevel key', () => {

--- a/src/effects/Grain/grainUniforms.ts
+++ b/src/effects/Grain/grainUniforms.ts
@@ -30,6 +30,11 @@ export const grainUniforms = (
     const grainColor = assertVec3('grainColor', props.grainColor ?? GRAIN_DEFAULTS.grainColor);
     const intensity = assertFinite('intensity', props.intensity ?? GRAIN_DEFAULTS.intensity);
     const scale = assertFinite('scale', props.scale ?? GRAIN_DEFAULTS.scale);
+    if (scale <= 0) {
+        throw new Error(
+            `micugl effects: "scale" must be greater than 0, received ${String(scale)}.`
+        );
+    }
     const speed = assertFinite('speed', props.speed ?? GRAIN_DEFAULTS.speed);
     const audioStrength = props.audioStrength ?? GRAIN_DEFAULTS.audioStrength;
 

--- a/src/effects/Grain/grainUniforms.ts
+++ b/src/effects/Grain/grainUniforms.ts
@@ -1,0 +1,47 @@
+import { vec3 } from '@/core';
+import { resolveAudioReaction } from '@/effects/lib/audioUniforms';
+import { assertFinite, assertVec3 } from '@/effects/lib/validate';
+import type { AudioUniformsResult } from '@/react';
+import type { UniformParam, Vec3 } from '@/types';
+
+export interface GrainUniformProps {
+    color?: Vec3;
+    grainColor?: Vec3;
+    intensity?: number;
+    scale?: number;
+    speed?: number;
+    audio?: AudioUniformsResult;
+    audioStrength?: number;
+}
+
+const GRAIN_DEFAULTS = {
+    color: [0, 0, 0] as Vec3,
+    grainColor: [1, 1, 1] as Vec3,
+    intensity: 0.08,
+    scale: 2,
+    speed: 1,
+    audioStrength: 1
+} as const;
+
+export const grainUniforms = (
+    props: GrainUniformProps = {}
+): Record<string, UniformParam> => {
+    const color = assertVec3('color', props.color ?? GRAIN_DEFAULTS.color);
+    const grainColor = assertVec3('grainColor', props.grainColor ?? GRAIN_DEFAULTS.grainColor);
+    const intensity = assertFinite('intensity', props.intensity ?? GRAIN_DEFAULTS.intensity);
+    const scale = assertFinite('scale', props.scale ?? GRAIN_DEFAULTS.scale);
+    const speed = assertFinite('speed', props.speed ?? GRAIN_DEFAULTS.speed);
+    const audioStrength = props.audioStrength ?? GRAIN_DEFAULTS.audioStrength;
+
+    const audio = resolveAudioReaction(props.audio, audioStrength);
+
+    return {
+        u_color: { type: 'vec3', value: vec3(color) },
+        u_grainColor: { type: 'vec3', value: vec3(grainColor) },
+        u_intensity: { type: 'float', value: intensity },
+        u_scale: { type: 'float', value: scale },
+        u_speed: { type: 'float', value: speed },
+        u_audioLevel: audio.u_audioLevel,
+        u_audioStrength: audio.u_audioStrength
+    };
+};

--- a/src/effects/MeshGradient/MeshGradient.test.tsx
+++ b/src/effects/MeshGradient/MeshGradient.test.tsx
@@ -1,0 +1,228 @@
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MeshGradient } from '@/effects/MeshGradient/MeshGradient';
+import type { AudioUniformsResult } from '@/react';
+import { useAudioUniforms } from '@/react';
+import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
+import { asContext, createFakeStream, FakeContext, latestAnalyser, LOW_HALF } from '@/react/lib/fakeWebAudio';
+import type { GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+import type { AudioSourceSpec, Frameloop, ShaderHandle, Vec3 } from '@/types';
+
+const WIDTH = 320;
+const HEIGHT = 200;
+const MIC: AudioSourceSpec = { type: 'mic' };
+const FIXTURE_COLORS: Vec3[] = [[0.13, 0.71, 0.29], [0.82, 0.19, 0.57]];
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let originalGetContext: unknown;
+let originalToBlob: unknown;
+
+class ImageDataStub {
+    constructor(
+        public data: Uint8ClampedArray,
+        public width: number,
+        public height: number
+    ) {}
+}
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    stub = createGLStub();
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown; toBlob: unknown };
+    originalGetContext = canvasProto.getContext;
+    originalToBlob = canvasProto.toBlob;
+    canvasProto.getContext = function stubGetContext(type: string): unknown {
+        return type === '2d' ? { putImageData: () => undefined, drawImage: () => undefined } : stub.gl;
+    };
+    canvasProto.toBlob = function stubToBlob(callback: (blob: Blob) => void, type?: string): void {
+        callback(new Blob([], { type: type ?? 'image/png' }));
+    };
+    (globalThis as { ImageData?: unknown }).ImageData = ImageDataStub;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown; toBlob: unknown };
+    canvasProto.getContext = originalGetContext;
+    canvasProto.toBlob = originalToBlob;
+    delete (globalThis as { ImageData?: unknown }).ImageData;
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+function uploadsOf(name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+function timeUploads(): number[] {
+    return uploadsOf('u_time') as number[];
+}
+
+interface Fixture {
+    context: FakeContext;
+    deps: AudioAnalyserDriverDeps;
+    hear: () => void;
+}
+
+function createFixture(): Fixture {
+    const context = new FakeContext();
+    const { stream } = createFakeStream();
+    return {
+        context,
+        deps: {
+            createContext: () => asContext(context),
+            getUserMedia: () => Promise.resolve(stream)
+        },
+        hear: () => { latestAnalyser(context).spectrum = LOW_HALF }
+    };
+}
+
+interface AudioSceneProps {
+    probe: { current: AudioUniformsResult | null };
+    handleRef: { current: ShaderHandle | null };
+    deps: AudioAnalyserDriverDeps;
+    frameloop?: Frameloop;
+}
+
+const AudioScene = ({ probe, handleRef, deps, frameloop = 'always' }: AudioSceneProps) => {
+    const audio = useAudioUniforms(MIC, { bands: 2, fftSize: 64, bandLayout: 'linear', attack: 0.05, release: 0.4 }, deps);
+    probe.current = audio;
+
+    return (
+        <MeshGradient
+            ref={handleRef}
+            audio={audio}
+            colors={FIXTURE_COLORS}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop={frameloop}
+            reducedMotion='ignore'
+            saveData='ignore'
+        />
+    );
+};
+
+function current(probe: { current: AudioUniformsResult | null }): AudioUniformsResult {
+    const value = probe.current;
+    if (!value) {
+        throw new Error('the scene has not rendered yet');
+    }
+    return value;
+}
+
+describe('MeshGradient: real uniforms reach the GL stub and advance', () => {
+    it('uploads the fixture colors and drives u_time forward across ticks', async () => {
+        await mount(
+            <MeshGradient
+                colors={FIXTURE_COLORS}
+                width={WIDTH}
+                height={HEIGHT}
+                useDevicePixelRatio={false}
+                reducedMotion='ignore'
+                saveData='ignore'
+            />
+        );
+
+        for (let time = 0; time <= 160; time += 16) {
+            act(() => { frames.tick(time) });
+        }
+
+        const color0 = uploadsOf('u_color0').map(value => Array.from(value as Float32Array));
+        expect(color0.length).toBeGreaterThan(0);
+        expect(color0[0]).toEqual(Array.from(new Float32Array([0.13, 0.71, 0.29])));
+
+        const times = timeUploads();
+        expect(times.length).toBeGreaterThan(5);
+        for (let i = 1; i < times.length; i++) {
+            expect(times[i]).toBeGreaterThan(times[i - 1]);
+        }
+    });
+});
+
+describe('MeshGradient: audio capture liveness through the real component', () => {
+    it('blocks an explicit-frame export while audio runs, and allows it once stopped', async () => {
+        const probe: { current: AudioUniformsResult | null } = { current: null };
+        const handleRef: { current: ShaderHandle | null } = { current: null };
+        const fixture = createFixture();
+
+        await mount(<AudioScene probe={probe} handleRef={handleRef} deps={fixture.deps} />);
+        act(() => { frames.tick(0) });
+
+        await act(async () => { await current(probe).start() });
+        fixture.hear();
+        for (let time = 16; time <= 96; time += 16) {
+            act(() => { frames.tick(time) });
+        }
+
+        const handle = handleRef.current;
+        if (!handle) {
+            throw new Error('no shader handle');
+        }
+        await expect(handle.renderToBlob({ frame: 30 })).rejects.toThrow(/audio is running/);
+
+        act(() => { current(probe).stop() });
+        act(() => { frames.tick(112) });
+
+        await expect(handle.renderToBlob({ frame: 30 })).resolves.toBeInstanceOf(Blob);
+    });
+});
+
+describe('MeshGradient: audio invalidation drives demand-mode renders', () => {
+    it('keeps the demand loop alive while audio runs and drains it when stopped', async () => {
+        const probe: { current: AudioUniformsResult | null } = { current: null };
+        const handleRef: { current: ShaderHandle | null } = { current: null };
+        const fixture = createFixture();
+
+        await mount(<AudioScene probe={probe} handleRef={handleRef} deps={fixture.deps} frameloop='demand' />);
+        act(() => { frames.tick(0) });
+        expect(frames.pending()).toBe(0);
+
+        await act(async () => { await current(probe).start() });
+        expect(frames.pending()).toBe(1);
+        fixture.hear();
+
+        for (let time = 16; time <= 160; time += 16) {
+            act(() => { frames.tick(time) });
+            expect(frames.pending()).toBe(1);
+        }
+
+        const times = timeUploads();
+        expect(times.length).toBeGreaterThan(5);
+        for (let i = 1; i < times.length; i++) {
+            expect(times[i]).toBeGreaterThan(times[i - 1]);
+        }
+
+        act(() => { current(probe).stop() });
+        act(() => { frames.tick(176) });
+        expect(frames.pending()).toBe(0);
+
+        const settled = timeUploads().length;
+        act(() => { frames.tick(192) });
+        expect(timeUploads().length).toBe(settled);
+    });
+});

--- a/src/effects/MeshGradient/MeshGradient.test.tsx
+++ b/src/effects/MeshGradient/MeshGradient.test.tsx
@@ -161,6 +161,7 @@ describe('MeshGradient: real uniforms reach the GL stub and advance', () => {
         for (let i = 1; i < times.length; i++) {
             expect(times[i]).toBeGreaterThan(times[i - 1]);
         }
+        expect(times[times.length - 1]).toBeLessThan(1);
     });
 });
 

--- a/src/effects/MeshGradient/MeshGradient.test.tsx
+++ b/src/effects/MeshGradient/MeshGradient.test.tsx
@@ -25,6 +25,7 @@ let frames: FrameQueue;
 let stub: GLStubHandle;
 let originalGetContext: unknown;
 let originalToBlob: unknown;
+let originalMatchMedia: typeof window.matchMedia | undefined;
 
 class ImageDataStub {
     constructor(
@@ -52,6 +53,8 @@ beforeEach(() => {
     };
     (globalThis as { ImageData?: unknown }).ImageData = ImageDataStub;
 
+    originalMatchMedia = window.matchMedia;
+
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -64,7 +67,23 @@ afterEach(() => {
     canvasProto.getContext = originalGetContext;
     canvasProto.toBlob = originalToBlob;
     delete (globalThis as { ImageData?: unknown }).ImageData;
+    if (originalMatchMedia) {
+        window.matchMedia = originalMatchMedia;
+    }
 });
+
+function mockReducedMotionActive(): void {
+    window.matchMedia = ((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false
+    })) as unknown as typeof window.matchMedia;
+}
 
 async function mount(element: ReactElement): Promise<void> {
     await act(async () => {
@@ -225,5 +244,49 @@ describe('MeshGradient: audio invalidation drives demand-mode renders', () => {
         const settled = timeUploads().length;
         act(() => { frames.tick(192) });
         expect(timeUploads().length).toBe(settled);
+    });
+});
+
+const GatedAudioScene = ({ probe, deps }: { probe: { current: AudioUniformsResult | null }; deps: AudioAnalyserDriverDeps }) => {
+    const audio = useAudioUniforms(MIC, { bands: 2, fftSize: 64, bandLayout: 'linear', attack: 0.05, release: 0.4 }, deps);
+    probe.current = audio;
+
+    return (
+        <MeshGradient
+            audio={audio}
+            colors={FIXTURE_COLORS}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            saveData='ignore'
+        />
+    );
+};
+
+describe('MeshGradient: reduced motion gates the audio reaction into a frozen poster', () => {
+    it('holds u_time and u_audioLevel still while a running mic streams', async () => {
+        mockReducedMotionActive();
+        const probe: { current: AudioUniformsResult | null } = { current: null };
+        const fixture = createFixture();
+
+        await mount(<GatedAudioScene probe={probe} deps={fixture.deps} />);
+        act(() => { frames.tick(0) });
+        expect(uploadsOf('u_audioLevel')).toEqual([0]);
+        expect(frames.pending()).toBe(0);
+
+        await act(async () => { await current(probe).start() });
+        expect(frames.pending()).toBe(1);
+        fixture.hear();
+        act(() => { frames.tick(16) });
+        expect(frames.pending()).toBe(0);
+
+        const frozenTimes = timeUploads().length;
+        for (let time = 32; time <= 320; time += 16) {
+            act(() => { frames.tick(time) });
+            expect(frames.pending()).toBe(0);
+        }
+
+        expect((uploadsOf('u_audioLevel') as number[]).every(value => value === 0)).toBe(true);
+        expect(timeUploads().length).toBe(frozenTimes);
     });
 });

--- a/src/effects/MeshGradient/MeshGradient.tsx
+++ b/src/effects/MeshGradient/MeshGradient.tsx
@@ -2,10 +2,8 @@ import { forwardRef } from 'react';
 
 import { createShaderConfig } from '@/core';
 import type { EffectRenderProps } from '@/effects/lib/effectProps';
-import {
-    meshGradientFragmentShader,
-    meshGradientVertexShader
-} from '@/effects/MeshGradient/meshGradientShaders';
+import { fullscreenVertexShader } from '@/effects/lib/fullscreenVertexShader';
+import { meshGradientFragmentShader } from '@/effects/MeshGradient/meshGradientShaders';
 import type { MeshGradientUniformProps } from '@/effects/MeshGradient/meshGradientUniforms';
 import { meshGradientUniforms } from '@/effects/MeshGradient/meshGradientUniforms';
 import { BaseShaderComponent } from '@/react';
@@ -16,7 +14,7 @@ export interface MeshGradientProps extends EffectRenderProps, MeshGradientUnifor
 const PROGRAM_ID = 'micugl-effect-mesh-gradient';
 
 const config = createShaderConfig({
-    vertexShader: meshGradientVertexShader,
+    vertexShader: fullscreenVertexShader,
     fragmentShader: meshGradientFragmentShader,
     uniformNames: {
         u_color0: 'vec3',

--- a/src/effects/MeshGradient/MeshGradient.tsx
+++ b/src/effects/MeshGradient/MeshGradient.tsx
@@ -1,0 +1,61 @@
+import { forwardRef } from 'react';
+
+import { createShaderConfig } from '@/core';
+import type { EffectRenderProps } from '@/effects/lib/effectProps';
+import {
+    meshGradientFragmentShader,
+    meshGradientVertexShader
+} from '@/effects/MeshGradient/meshGradientShaders';
+import type { MeshGradientUniformProps } from '@/effects/MeshGradient/meshGradientUniforms';
+import { meshGradientUniforms } from '@/effects/MeshGradient/meshGradientUniforms';
+import { BaseShaderComponent } from '@/react';
+import type { ShaderHandle } from '@/types';
+
+export interface MeshGradientProps extends EffectRenderProps, MeshGradientUniformProps {}
+
+const PROGRAM_ID = 'micugl-effect-mesh-gradient';
+
+const config = createShaderConfig({
+    vertexShader: meshGradientVertexShader,
+    fragmentShader: meshGradientFragmentShader,
+    uniformNames: {
+        u_color0: 'vec3',
+        u_color1: 'vec3',
+        u_color2: 'vec3',
+        u_color3: 'vec3',
+        u_colorCount: 'float',
+        u_speed: 'float',
+        u_warp: 'float',
+        u_warpScale: 'float',
+        u_seed: 'float',
+        u_audioLevel: 'float',
+        u_audioStrength: 'float'
+    }
+});
+
+export const MeshGradient = forwardRef<ShaderHandle, MeshGradientProps>((props, ref) => {
+    const {
+        colors,
+        speed,
+        warp,
+        warpScale,
+        seed,
+        audio,
+        audioStrength,
+        ...renderProps
+    } = props;
+
+    const uniforms = meshGradientUniforms({ colors, speed, warp, warpScale, seed, audio, audioStrength });
+
+    return (
+        <BaseShaderComponent
+            ref={ref}
+            programId={PROGRAM_ID}
+            shaderConfig={config}
+            uniforms={uniforms}
+            {...renderProps}
+        />
+    );
+});
+
+MeshGradient.displayName = 'MeshGradient';

--- a/src/effects/MeshGradient/meshGradientShaders.ts
+++ b/src/effects/MeshGradient/meshGradientShaders.ts
@@ -1,9 +1,6 @@
-export { fullscreenVertexShader as meshGradientVertexShader } from '@/effects/lib/fullscreenVertexShader';
-
 export const meshGradientFragmentShader = `
     precision highp float;
 
-    uniform vec2 u_resolution;
     uniform float u_time;
     uniform vec3 u_color0;
     uniform vec3 u_color1;
@@ -52,7 +49,7 @@ export const meshGradientFragmentShader = `
 
     void main() {
         float audio = u_audioStrength * u_audioLevel;
-        float t = u_time * 0.001 * u_speed * (1.0 + 0.5 * audio);
+        float t = u_time * u_speed + 0.5 * audio;
         float warp = u_warp * (1.0 + audio);
 
         vec2 uv = v_texCoord;

--- a/src/effects/MeshGradient/meshGradientShaders.ts
+++ b/src/effects/MeshGradient/meshGradientShaders.ts
@@ -1,0 +1,79 @@
+export { fullscreenVertexShader as meshGradientVertexShader } from '@/effects/lib/fullscreenVertexShader';
+
+export const meshGradientFragmentShader = `
+    precision highp float;
+
+    uniform vec2 u_resolution;
+    uniform float u_time;
+    uniform vec3 u_color0;
+    uniform vec3 u_color1;
+    uniform vec3 u_color2;
+    uniform vec3 u_color3;
+    uniform float u_colorCount;
+    uniform float u_speed;
+    uniform float u_warp;
+    uniform float u_warpScale;
+    uniform float u_seed;
+    uniform float u_audioLevel;
+    uniform float u_audioStrength;
+
+    varying vec2 v_texCoord;
+
+    float hash21(vec2 p) {
+        p = fract(p * vec2(123.34, 456.21));
+        p += dot(p, p + 45.32);
+        return fract(p.x * p.y);
+    }
+
+    float valueNoise(vec2 p) {
+        vec2 i = floor(p);
+        vec2 f = fract(p);
+        vec2 u = f * f * (3.0 - 2.0 * f);
+        float a = hash21(i);
+        float b = hash21(i + vec2(1.0, 0.0));
+        float c = hash21(i + vec2(0.0, 1.0));
+        float d = hash21(i + vec2(1.0, 1.0));
+        return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+    }
+
+    vec3 colorAt(float idx) {
+        if (idx < 0.5) return u_color0;
+        if (idx < 1.5) return u_color1;
+        if (idx < 2.5) return u_color2;
+        return u_color3;
+    }
+
+    vec2 pointPos(float idx, float t) {
+        float s = u_seed + idx * 13.7;
+        vec2 freq = vec2(0.6 + 0.2 * idx, 0.8 + 0.15 * idx);
+        vec2 phase = vec2(s, s * 1.3 + 1.7);
+        return vec2(0.5) + 0.34 * vec2(sin(t * freq.x + phase.x), cos(t * freq.y + phase.y));
+    }
+
+    void main() {
+        float audio = u_audioStrength * u_audioLevel;
+        float t = u_time * 0.001 * u_speed * (1.0 + 0.5 * audio);
+        float warp = u_warp * (1.0 + audio);
+
+        vec2 uv = v_texCoord;
+        vec2 warped = uv + warp * 0.15 * vec2(
+            valueNoise(uv * u_warpScale * 3.0 + t),
+            valueNoise(uv * u_warpScale * 3.0 - t + 7.3)
+        );
+
+        vec3 col = vec3(0.0);
+        float wsum = 0.0;
+        for (int i = 0; i < 4; i++) {
+            float idx = float(i);
+            float mask = step(idx, u_colorCount - 0.5);
+            vec2 p = pointPos(idx, t);
+            float d = distance(warped, p);
+            float w = mask / (d * d + 0.0008);
+            col += colorAt(idx) * w;
+            wsum += w;
+        }
+
+        col /= max(wsum, 0.0001);
+        gl_FragColor = vec4(col, 1.0);
+    }
+`;

--- a/src/effects/MeshGradient/meshGradientUniforms.test.ts
+++ b/src/effects/MeshGradient/meshGradientUniforms.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFrameInvalidation } from '@/core';
+import {
+    MESH_GRADIENT_DEFAULT_COLORS,
+    meshGradientUniforms
+} from '@/effects/MeshGradient/meshGradientUniforms';
+import type { AudioUniformsResult } from '@/react';
+import type { UniformParam, Vec3 } from '@/types';
+
+const fakeAudio = (uniforms: Record<string, UniformParam>): AudioUniformsResult => ({
+    uniforms,
+    start: () => Promise.resolve(),
+    stop: () => undefined,
+    status: 'running',
+    error: null
+});
+
+describe('meshGradientUniforms: defaults', () => {
+    it('produces the exact uniform record for default props', () => {
+        const uniforms = meshGradientUniforms();
+
+        expect(Object.keys(uniforms).sort()).toEqual([
+            'u_audioLevel',
+            'u_audioStrength',
+            'u_color0',
+            'u_color1',
+            'u_color2',
+            'u_color3',
+            'u_colorCount',
+            'u_seed',
+            'u_speed',
+            'u_warp',
+            'u_warpScale'
+        ]);
+
+        expect(uniforms.u_color0).toEqual({ type: 'vec3', value: new Float32Array(MESH_GRADIENT_DEFAULT_COLORS[0]) });
+        expect(uniforms.u_color3).toEqual({ type: 'vec3', value: new Float32Array(MESH_GRADIENT_DEFAULT_COLORS[3]) });
+        expect(uniforms.u_colorCount).toEqual({ type: 'float', value: 4 });
+        expect(uniforms.u_speed).toEqual({ type: 'float', value: 0.2 });
+        expect(uniforms.u_warp).toEqual({ type: 'float', value: 0.6 });
+        expect(uniforms.u_warpScale).toEqual({ type: 'float', value: 1.2 });
+        expect(uniforms.u_seed).toEqual({ type: 'float', value: 0 });
+        expect(uniforms.u_audioLevel).toEqual({ type: 'float', value: 0 });
+        expect(uniforms.u_audioStrength).toEqual({ type: 'float', value: 0 });
+    });
+});
+
+describe('meshGradientUniforms: prop mapping', () => {
+    it('lands each documented prop in its uniform, with vec3 conversion for colors', () => {
+        const colors: Vec3[] = [[0.11, 0.22, 0.33], [0.44, 0.55, 0.66]];
+        const uniforms = meshGradientUniforms({
+            colors,
+            speed: 0.9,
+            warp: 0.25,
+            warpScale: 3.5,
+            seed: 7
+        });
+
+        expect(uniforms.u_color0.value).toBeInstanceOf(Float32Array);
+        expect(uniforms.u_color0.value).toEqual(new Float32Array([0.11, 0.22, 0.33]));
+        expect(uniforms.u_color1.value).toEqual(new Float32Array([0.44, 0.55, 0.66]));
+        expect(uniforms.u_color2.value).toEqual(new Float32Array([0.44, 0.55, 0.66]));
+        expect(uniforms.u_colorCount.value).toBe(2);
+        expect(uniforms.u_speed.value).toBe(0.9);
+        expect(uniforms.u_warp.value).toBe(0.25);
+        expect(uniforms.u_warpScale.value).toBe(3.5);
+        expect(uniforms.u_seed.value).toBe(7);
+    });
+
+    it('throws with the offending prop named when a number is not finite', () => {
+        expect(() => meshGradientUniforms({ warp: Number.NaN })).toThrow(/"warp".*finite/s);
+    });
+
+    it('throws when colors is outside 2 to 4', () => {
+        expect(() => meshGradientUniforms({ colors: [[0, 0, 0]] })).toThrow(/"colors".*between 2 and 4/s);
+    });
+});
+
+describe('meshGradientUniforms: audio passthrough', () => {
+    it('with audio absent: u_audioLevel is a literal 0 with no invalidation or nonReproducible', () => {
+        const uniforms = meshGradientUniforms();
+
+        expect(uniforms.u_audioLevel).toEqual({ type: 'float', value: 0 });
+        expect('invalidation' in uniforms.u_audioLevel).toBe(false);
+        expect('nonReproducible' in uniforms.u_audioLevel).toBe(false);
+        expect(uniforms.u_audioStrength.value).toBe(0);
+    });
+
+    it('with audio present: forwards the exact u_audioLevel param object and maps strength', () => {
+        const level: UniformParam = {
+            type: 'float',
+            value: () => 0.5,
+            invalidation: createFrameInvalidation(),
+            nonReproducible: () => true
+        };
+        const audio = fakeAudio({ u_audioLevel: level });
+
+        const uniforms = meshGradientUniforms({ audio, audioStrength: 0.75 });
+
+        expect(uniforms.u_audioLevel).toBe(level);
+        expect(uniforms.u_audioStrength).toEqual({ type: 'float', value: 0.75 });
+    });
+
+    it('throws with an actionable message when the audio result has no u_audioLevel key', () => {
+        const audio = fakeAudio({ level: { type: 'float', value: 0 } });
+
+        expect(() => meshGradientUniforms({ audio })).toThrow(/u_audioLevel.*default uniform names/s);
+    });
+});

--- a/src/effects/MeshGradient/meshGradientUniforms.ts
+++ b/src/effects/MeshGradient/meshGradientUniforms.ts
@@ -1,0 +1,62 @@
+import { vec3 } from '@/core';
+import { resolveAudioReaction } from '@/effects/lib/audioUniforms';
+import { assertColors, assertFinite } from '@/effects/lib/validate';
+import type { AudioUniformsResult } from '@/react';
+import type { UniformParam, Vec3 } from '@/types';
+
+export interface MeshGradientUniformProps {
+    colors?: Vec3[];
+    speed?: number;
+    warp?: number;
+    warpScale?: number;
+    seed?: number;
+    audio?: AudioUniformsResult;
+    audioStrength?: number;
+}
+
+export const MESH_GRADIENT_DEFAULT_COLORS: Vec3[] = [
+    [0.96, 0.76, 0.85],
+    [0.74, 0.85, 0.96],
+    [0.80, 0.95, 0.82],
+    [0.98, 0.92, 0.76]
+];
+
+const MESH_GRADIENT_DEFAULTS = {
+    speed: 0.2,
+    warp: 0.6,
+    warpScale: 1.2,
+    seed: 0,
+    audioStrength: 1
+} as const;
+
+const colorSlot = (colors: Vec3[], index: number): UniformParam => ({
+    type: 'vec3',
+    value: vec3(colors[Math.min(index, colors.length - 1)])
+});
+
+export const meshGradientUniforms = (
+    props: MeshGradientUniformProps = {}
+): Record<string, UniformParam> => {
+    const colors = assertColors('colors', props.colors ?? MESH_GRADIENT_DEFAULT_COLORS);
+    const speed = assertFinite('speed', props.speed ?? MESH_GRADIENT_DEFAULTS.speed);
+    const warp = assertFinite('warp', props.warp ?? MESH_GRADIENT_DEFAULTS.warp);
+    const warpScale = assertFinite('warpScale', props.warpScale ?? MESH_GRADIENT_DEFAULTS.warpScale);
+    const seed = assertFinite('seed', props.seed ?? MESH_GRADIENT_DEFAULTS.seed);
+    const audioStrength = props.audioStrength ?? MESH_GRADIENT_DEFAULTS.audioStrength;
+
+    const audio = resolveAudioReaction(props.audio, audioStrength);
+
+    return {
+        u_color0: colorSlot(colors, 0),
+        u_color1: colorSlot(colors, 1),
+        u_color2: colorSlot(colors, 2),
+        u_color3: colorSlot(colors, 3),
+        u_colorCount: { type: 'float', value: colors.length },
+        u_speed: { type: 'float', value: speed },
+        u_warp: { type: 'float', value: warp },
+        u_warpScale: { type: 'float', value: warpScale },
+        u_seed: { type: 'float', value: seed },
+        u_audioLevel: audio.u_audioLevel,
+        u_audioStrength: audio.u_audioStrength
+    };
+};

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,13 +1,8 @@
 export type { GrainProps } from '@/effects/Grain/Grain';
 export { Grain } from '@/effects/Grain/Grain';
-export { grainFragmentShader, grainVertexShader } from '@/effects/Grain/grainShaders';
-export type { GrainUniformProps } from '@/effects/Grain/grainUniforms';
+export { grainFragmentShader } from '@/effects/Grain/grainShaders';
 export type { EffectRenderProps } from '@/effects/lib/effectProps';
 export { fullscreenVertexShader } from '@/effects/lib/fullscreenVertexShader';
 export type { MeshGradientProps } from '@/effects/MeshGradient/MeshGradient';
 export { MeshGradient } from '@/effects/MeshGradient/MeshGradient';
-export {
-    meshGradientFragmentShader,
-    meshGradientVertexShader
-} from '@/effects/MeshGradient/meshGradientShaders';
-export type { MeshGradientUniformProps } from '@/effects/MeshGradient/meshGradientUniforms';
+export { meshGradientFragmentShader } from '@/effects/MeshGradient/meshGradientShaders';

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,0 +1,13 @@
+export type { GrainProps } from '@/effects/Grain/Grain';
+export { Grain } from '@/effects/Grain/Grain';
+export { grainFragmentShader, grainVertexShader } from '@/effects/Grain/grainShaders';
+export type { GrainUniformProps } from '@/effects/Grain/grainUniforms';
+export type { EffectRenderProps } from '@/effects/lib/effectProps';
+export { fullscreenVertexShader } from '@/effects/lib/fullscreenVertexShader';
+export type { MeshGradientProps } from '@/effects/MeshGradient/MeshGradient';
+export { MeshGradient } from '@/effects/MeshGradient/MeshGradient';
+export {
+    meshGradientFragmentShader,
+    meshGradientVertexShader
+} from '@/effects/MeshGradient/meshGradientShaders';
+export type { MeshGradientUniformProps } from '@/effects/MeshGradient/meshGradientUniforms';

--- a/src/effects/lib/audioUniforms.ts
+++ b/src/effects/lib/audioUniforms.ts
@@ -13,6 +13,8 @@ export const resolveAudioReaction = (
     audio: AudioUniformsResult | undefined,
     audioStrength: number
 ): AudioReaction => {
+    const strength = assertFinite('audioStrength', audioStrength);
+
     if (audio === undefined) {
         return {
             u_audioLevel: { type: 'float', value: 0 },
@@ -30,6 +32,6 @@ export const resolveAudioReaction = (
 
     return {
         u_audioLevel: audio.uniforms[LEVEL_NAME],
-        u_audioStrength: { type: 'float', value: assertFinite('audioStrength', audioStrength) }
+        u_audioStrength: { type: 'float', value: strength }
     };
 };

--- a/src/effects/lib/audioUniforms.ts
+++ b/src/effects/lib/audioUniforms.ts
@@ -1,0 +1,35 @@
+import { assertFinite } from '@/effects/lib/validate';
+import type { AudioUniformsResult } from '@/react';
+import type { UniformParam } from '@/types';
+
+const LEVEL_NAME = 'u_audioLevel';
+
+export interface AudioReaction {
+    u_audioLevel: UniformParam;
+    u_audioStrength: UniformParam;
+}
+
+export const resolveAudioReaction = (
+    audio: AudioUniformsResult | undefined,
+    audioStrength: number
+): AudioReaction => {
+    if (audio === undefined) {
+        return {
+            u_audioLevel: { type: 'float', value: 0 },
+            u_audioStrength: { type: 'float', value: 0 }
+        };
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(audio.uniforms, LEVEL_NAME)) {
+        throw new Error(
+            'micugl effects: the "audio" prop carries no "u_audioLevel" uniform. An effect reads the audio LEVEL '
+            + 'by its default name, so useAudioUniforms must keep the default uniform names. Drop the custom '
+            + '"names.level" option, or drive the audio uniforms yourself through BaseShaderComponent.'
+        );
+    }
+
+    return {
+        u_audioLevel: audio.uniforms[LEVEL_NAME],
+        u_audioStrength: { type: 'float', value: assertFinite('audioStrength', audioStrength) }
+    };
+};

--- a/src/effects/lib/effectProps.ts
+++ b/src/effects/lib/effectProps.ts
@@ -1,0 +1,9 @@
+import type { CSSProperties } from 'react';
+
+import type { RenderControlProps } from '@/types';
+
+export interface EffectRenderProps
+    extends Omit<RenderControlProps, 'speed' | 'worker' | 'createWorker'> {
+    className?: string;
+    style?: CSSProperties;
+}

--- a/src/effects/lib/fullscreenVertexShader.ts
+++ b/src/effects/lib/fullscreenVertexShader.ts
@@ -1,0 +1,8 @@
+export const fullscreenVertexShader = `
+    attribute vec2 a_position;
+    varying vec2 v_texCoord;
+    void main() {
+        gl_Position = vec4(a_position, 0.0, 1.0);
+        v_texCoord = a_position * 0.5 + 0.5;
+    }
+`;

--- a/src/effects/lib/validate.test.ts
+++ b/src/effects/lib/validate.test.ts
@@ -19,9 +19,11 @@ describe('effects validate: finite numbers', () => {
 });
 
 describe('effects validate: vec3 tuples', () => {
-    it('returns a valid tuple unchanged', () => {
+    it('returns a fresh tuple with the same values', () => {
         const color: Vec3 = [0.1, 0.2, 0.3];
-        expect(assertVec3('color', color)).toBe(color);
+        const result = assertVec3('color', color);
+        expect(result).toEqual(color);
+        expect(result).not.toBe(color);
     });
 
     it('throws on the wrong tuple length', () => {
@@ -35,11 +37,13 @@ describe('effects validate: vec3 tuples', () => {
 });
 
 describe('effects validate: colors length 2 to 4', () => {
-    it('accepts 2 colors and 4 colors', () => {
+    it('accepts 2 colors and 4 colors, returning fresh tuples', () => {
         const two: Vec3[] = [[0, 0, 0], [1, 1, 1]];
         const four: Vec3[] = [[0, 0, 0], [1, 1, 1], [0.5, 0.5, 0.5], [0.2, 0.4, 0.6]];
-        expect(assertColors('colors', two)).toBe(two);
-        expect(assertColors('colors', four)).toBe(four);
+        const twoResult = assertColors('colors', two);
+        expect(twoResult).toEqual(two);
+        expect(twoResult[0]).not.toBe(two[0]);
+        expect(assertColors('colors', four)).toEqual(four);
     });
 
     it('throws for 1 color and for 5 colors', () => {

--- a/src/effects/lib/validate.test.ts
+++ b/src/effects/lib/validate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertColors, assertFinite, assertVec3 } from '@/effects/lib/validate';
+import type { Vec3 } from '@/types';
+
+describe('effects validate: finite numbers', () => {
+    it('returns a finite number unchanged', () => {
+        expect(assertFinite('speed', 0.2)).toBe(0.2);
+        expect(assertFinite('seed', -3)).toBe(-3);
+    });
+
+    it('throws naming the offending prop for NaN', () => {
+        expect(() => assertFinite('warp', Number.NaN)).toThrow(/"warp".*finite/s);
+    });
+
+    it('throws naming the offending prop for Infinity', () => {
+        expect(() => assertFinite('intensity', Number.POSITIVE_INFINITY)).toThrow(/"intensity".*finite/s);
+    });
+});
+
+describe('effects validate: vec3 tuples', () => {
+    it('returns a valid tuple unchanged', () => {
+        const color: Vec3 = [0.1, 0.2, 0.3];
+        expect(assertVec3('color', color)).toBe(color);
+    });
+
+    it('throws on the wrong tuple length', () => {
+        expect(() => assertVec3('color', [0.1, 0.2])).toThrow(/"color".*3-number tuple/s);
+        expect(() => assertVec3('color', [0.1, 0.2, 0.3, 0.4])).toThrow(/"color".*3-number tuple/s);
+    });
+
+    it('throws naming the offending channel for a NaN component', () => {
+        expect(() => assertVec3('grainColor', [0.1, Number.NaN, 0.3])).toThrow(/"grainColor\[1\]".*finite/s);
+    });
+});
+
+describe('effects validate: colors length 2 to 4', () => {
+    it('accepts 2 colors and 4 colors', () => {
+        const two: Vec3[] = [[0, 0, 0], [1, 1, 1]];
+        const four: Vec3[] = [[0, 0, 0], [1, 1, 1], [0.5, 0.5, 0.5], [0.2, 0.4, 0.6]];
+        expect(assertColors('colors', two)).toBe(two);
+        expect(assertColors('colors', four)).toBe(four);
+    });
+
+    it('throws for 1 color and for 5 colors', () => {
+        expect(() => assertColors('colors', [[0, 0, 0]])).toThrow(/"colors".*between 2 and 4/s);
+        expect(() => assertColors('colors', [[0, 0, 0], [1, 1, 1], [0, 0, 0], [1, 1, 1], [0, 0, 0]]))
+            .toThrow(/"colors".*between 2 and 4/s);
+    });
+});

--- a/src/effects/lib/validate.ts
+++ b/src/effects/lib/validate.ts
@@ -15,10 +15,11 @@ export const assertVec3 = (name: string, value: readonly number[]): Vec3 => {
             `micugl effects: "${name}" must be a 3-number tuple [r, g, b], received length ${String(value.length)}.`
         );
     }
-    assertFinite(`${name}[0]`, value[0]);
-    assertFinite(`${name}[1]`, value[1]);
-    assertFinite(`${name}[2]`, value[2]);
-    return value as unknown as Vec3;
+    return [
+        assertFinite(`${name}[0]`, value[0]),
+        assertFinite(`${name}[1]`, value[1]),
+        assertFinite(`${name}[2]`, value[2])
+    ];
 };
 
 export const assertColors = (name: string, colors: readonly (readonly number[])[]): Vec3[] => {
@@ -27,6 +28,5 @@ export const assertColors = (name: string, colors: readonly (readonly number[])[
             `micugl effects: "${name}" must hold between 2 and 4 colors, received ${String(colors.length)}.`
         );
     }
-    colors.forEach((color, index) => assertVec3(`${name}[${index}]`, color));
-    return colors as unknown as Vec3[];
+    return colors.map((color, index) => assertVec3(`${name}[${index}]`, color));
 };

--- a/src/effects/lib/validate.ts
+++ b/src/effects/lib/validate.ts
@@ -1,0 +1,32 @@
+import type { Vec3 } from '@/types';
+
+export const assertFinite = (name: string, value: number): number => {
+    if (!Number.isFinite(value)) {
+        throw new Error(
+            `micugl effects: "${name}" must be a finite number, received ${String(value)}.`
+        );
+    }
+    return value;
+};
+
+export const assertVec3 = (name: string, value: readonly number[]): Vec3 => {
+    if (value.length !== 3) {
+        throw new Error(
+            `micugl effects: "${name}" must be a 3-number tuple [r, g, b], received length ${String(value.length)}.`
+        );
+    }
+    assertFinite(`${name}[0]`, value[0]);
+    assertFinite(`${name}[1]`, value[1]);
+    assertFinite(`${name}[2]`, value[2]);
+    return value as unknown as Vec3;
+};
+
+export const assertColors = (name: string, colors: readonly (readonly number[])[]): Vec3[] => {
+    if (colors.length < 2 || colors.length > 4) {
+        throw new Error(
+            `micugl effects: "${name}" must hold between 2 and 4 colors, received ${String(colors.length)}.`
+        );
+    }
+    colors.forEach((color, index) => assertVec3(`${name}[${index}]`, color));
+    return colors as unknown as Vec3[];
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
                 embed: resolve(__dirname, 'src/embed/index.ts'),
                 testing: resolve(__dirname, 'src/testing/index.ts'),
                 devtools: resolve(__dirname, 'src/react/devtools/index.ts'),
+                effects: resolve(__dirname, 'src/effects/index.ts'),
             },
             formats: ['es','cjs'],
             fileName: (format, entry) =>


### PR DESCRIPTION
Track 5 (composition-effects) slice C4 of 6, independent of C1-C3: the `micugl/effects` subpath and its first two packaged effects — **MeshGradient** and **Grain** — each a polished prop-driven component on `BaseShaderComponent`, each with an optional audio-reactive prop. Dither/Blur + node factories are C5; Ripple promotion is C6.

## What's here

- **Packaging**: `./effects` export (ESM+CJS+types, `./devtools` pattern), vite `effects` entry, and an `assertTreeshaken` property check that no effects module is reachable from the main bundles (proven non-vacuous during development: a temporary static import made it fail). `sideEffects` untouched.
- **`<MeshGradient />`** — 2-4 colors on seeded Lissajous drift, inverse-distance-weighted blend with a value-noise domain warp. `colors` / `speed` / `warp` / `warpScale` / `seed` / `audio` / `audioStrength`.
- **`<Grain />`** — hash-based film grain re-seeded in ~24fps steps. `color` / `grainColor` / `intensity` / `scale` / `speed` / `audio` / `audioStrength`.
- **Audio reactivity** (`audio?: AudioUniformsResult` from `useAudioUniforms`): consumes ONLY the level uniform (bands' type varies with the `bands` option and would trip the #58 type guard by design — level is type-stable). The level `UniformParam` is forwarded **by reference**, so its `invalidation` and `nonReproducible` ride through untouched: demand-mode reactivity, the `'audio'` capture blocker, and the reduced-motion gate all work through the effect wrapper (each proven through the real component path, both directions). Custom `names` on the audio hook throw with a remedy. MeshGradient breathes (warp depth) and surges (bounded phase offset); Grain's intensity rides the level.
- **Validation**: fail-loud on NaN/non-finite, tuple lengths, colors length, `scale <= 0` — no clamps anywhere (a silent `max(u_scale, 1.0)` was found and removed in review).
- **Effect props**: `RenderControlProps` minus `speed` and the worker props — each effect's `speed` is a local animation multiplier (`u_speed`), not the engine clock; effects are main-thread-only v1 (their uniforms are functions).
- **Demo**: `?scene=effects-gallery` — knobs for every documented prop, 2/3/4-color presets, `speed=0` poster toggle, audio start/stop (mic requested ONLY on click; the scene renders fully with no permission).
- README section per effect, static-poster configuration shown first.

## The review story (worth reading)

The style lens found the blocking bug for the **seventh** time on this project: both shaders multiplied `u_time` by 0.001 on a path where the built-in updater already delivers seconds — every effect animated ~1000x too slow (Grain's "24fps flicker" re-seeded every ~42 s; MeshGradient's drift period was ~14 h), and every test passed because uploads advance in either unit and the GL stub never executes GLSL. The correctness lens independently traced the same chain, plus a latent one only visible after the fix: the audio drift term multiplied **unbounded elapsed time** by the live level, so a loud-to-quiet transition at minute five would whip the field backwards (now a bounded phase offset).

Because no unit test can see GLSL magnitude, the apply pass added a live headless verification: screenshots 2 s apart measured **23.9%** (MeshGradient) and **30.7%** (Grain) pixel change on the fixed shaders — and **exactly 0** pixels changed when the bug was temporarily reintroduced. The guard was watched failing. An upload-side unit-pin test (`u_time < 1` after ~160 ms of ticks) now pins the seconds convention.

The standalone edit-empowered pass found no surviving defect and closed the last coverage gap: an effect-level gated-audio test proving a reduced-motion poster stays frozen (level uploads 0, no scheduled frames) with a running mic — revert-verified sensitive to the gate.

## Gates

`typecheck` / `lint` / `test` / `build` green — **1,100 tests** (effects: 30). No counters/e2e (no render-loop or worker changes).

## Manual pass for Micu (the effects are visual; nothing below is machine-verified)

1. `bun run dev` -> `?scene=effects-gallery`: MeshGradient drifts visibly at default speed (composition reorganizes over ~30 s); Grain flickers filmically.
2. Cycle the color presets (4/3/2) — the two-color case should read as two lobes orbiting, not a broken gradient.
3. `speed=0` toggle: both freeze into intentional-looking posters.
4. Click audio start (mic prompt): gradient surges/breathes and grain bites harder with input level; stop clears the OS mic indicator.
5. OS reduced-motion on + reload: both render frozen posters; starting the mic must NOT animate them.

## Filed follow-ups

- Promote `uploadsOf`/`createFixture`-family test helpers into `@/testing` before C5 (this slice added copies 5 and 6).
- Pre-existing `* 0.001` ms assumptions in `examples/Ripple`, `demo/PerformanceTest.tsx`, `demo/scenes/shaders.ts` — same bug class on other paths; C6 (Ripple promotion) must re-verify its time units.
- `worker` prop is excluded from effect props at the type level only; a caller casting through `any` could still forward it (runtime strip would be dead code per TS — flagged, deliberately not fixed).
