### PR TITLE
inspector: C3 dag-inspector - GraphDebugPort on the engine handle, per-node uniform ports, devtools DAG panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,46 @@ ref handle -- works the same way.
 
 Run the demo scene: `bun run dev`, then open `/?scene=shader-graph`.
 
+### Inspecting a graph
+
+Mount `<MicuglDevtools />` alongside a `ShaderGraph` and the panel replaces its flat uniforms and
+framebuffers sections with a per-node DAG view: the topology tree, per-node uniform controls, and an
+opt-in thumbnail per node (root included). The panel reads nothing but the engine's public graph
+port -- the same surface you can drive from the console.
+
+Every mounted engine registers a handle on `listEngines()`. A graph engine's handle carries an
+`@experimental` `graph` port:
+
+```ts
+import { listEngines } from 'micugl/devtools';
+
+const graph = listEngines()[0].graph;          // undefined for single-program engines
+
+graph.topology();                               // the plan the compiler actually built
+graph.readNode('noise');                        // that node's framebuffer pixels
+graph.nodeUniforms('noise').setOverride('u_scale', 12);
+```
+
+`topology()` returns exactly what `planGraph` emitted -- per node its `framebufferId` (`null` for the
+root), declared `width` / `height` (`0` means canvas-sized), `edges`, `sources`, and `uniformNames`.
+
+**Two ways to reach a uniform.** `handle.uniforms` is the combined port across all nodes: each listed
+entry carries the `nodeId` it came from, and `setOverride(name, value)` **fans** across every node
+that declares that name (two nodes both declaring `u_gain` both move). To target one node, go through
+`graph.nodeUniforms(nodeId).setOverride(...)` -- it changes that node alone and leaves a sibling that
+shares the name untouched.
+
+**`readNode` pixels.** `readNode(nodeId, maxSize?)` returns `{ width, height, pixels }` where `pixels`
+is an RGBA `Uint8ClampedArray` of `UNSIGNED_BYTE` samples, **not** premultiplied -- the bytes are what
+the framebuffer stored. Rows come back in raw `readPixels` order, **bottom-up**: row `0` is the visual
+bottom of the image, for the root read and every framebuffer read alike. Flip vertically for display.
+A non-readable target (zero size, a `maxSize` your buffer exceeds, a float framebuffer, an engine that
+was torn down) returns `{ unreadable: reason }` instead of pixels; only a caller mistake -- an unknown
+node id -- throws. The root read renders the current live-clock frame in the same task and reads it
+back, so it perturbs timing the way any framebuffer capture does.
+
+Run the demo scene: `bun run dev`, then open `/?scene=graph-inspector`.
+
 ## Worker rendering (OffscreenCanvas)
 
 `worker` moves the GL context and the render loop off the main thread, onto an

--- a/bench/graphReadNode.spec.ts
+++ b/bench/graphReadNode.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+
+import { DEV_URL } from '../e2e/servers';
+
+interface Center {
+    r: number;
+    g: number;
+    b: number;
+    unreadable?: string;
+}
+
+interface ReadNodeProbe {
+    a: Center;
+    b: Center;
+    root: Center;
+    rowLow: number;
+    rowHigh: number;
+}
+
+test('readNode attributes pixels per node and returns raw bottom-up rows', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+
+    await page.goto(`${DEV_URL}/?scene=graph-pixels`, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('canvas', { state: 'attached' });
+    await page.waitForTimeout(600);
+
+    const probe: ReadNodeProbe = await page.evaluate(() => {
+        interface ReadResult {
+            width: number;
+            height: number;
+            pixels: Uint8ClampedArray;
+        }
+        interface Unreadable {
+            unreadable: string;
+        }
+        type NodeRead = ReadResult | Unreadable;
+        interface GraphPort {
+            readNode: (id: string) => NodeRead;
+        }
+        interface Handle {
+            graph?: GraphPort;
+        }
+        const list = (window as unknown as { __listGraphEngines?: () => Handle[] }).__listGraphEngines;
+        if (!list) {
+            throw new Error('the graph-pixels scene did not expose __listGraphEngines');
+        }
+        const engines = list();
+        const graph = engines[engines.length - 1]?.graph;
+        if (!graph) {
+            throw new Error('the graph-pixels engine exposed no graph port');
+        }
+        const center = (read: NodeRead): Center => {
+            if ('unreadable' in read) {
+                return { r: -1, g: -1, b: -1, unreadable: read.unreadable };
+            }
+            const x = Math.floor(read.width / 2);
+            const y = Math.floor(read.height / 2);
+            const i = (y * read.width + x) * 4;
+            return { r: read.pixels[i], g: read.pixels[i + 1], b: read.pixels[i + 2] };
+        };
+        const a = graph.readNode('a');
+        const b = graph.readNode('b');
+        const root = graph.readNode('root');
+        let rowLow = -1;
+        let rowHigh = -1;
+        if (!('unreadable' in a)) {
+            const x = Math.floor(a.width / 2);
+            rowLow = a.pixels[(0 * a.width + x) * 4];
+            rowHigh = a.pixels[((a.height - 1) * a.width + x) * 4];
+        }
+        return { a: center(a), b: center(b), root: center(root), rowLow, rowHigh };
+    });
+
+    expect(probe.a.unreadable).toBeUndefined();
+    expect(probe.a.r).toBeGreaterThan(120);
+    expect(probe.a.b).toBeLessThan(60);
+
+    expect(probe.b.b).toBeGreaterThan(150);
+    expect(probe.b.r).toBeLessThan(60);
+
+    expect(probe.root.r).toBeGreaterThan(30);
+    expect(probe.root.b).toBeGreaterThan(60);
+
+    expect(probe.rowLow).toBeLessThan(probe.rowHigh - 40);
+
+    expect(pageErrors).toEqual([]);
+});

--- a/demo/scenes/GraphInspector.tsx
+++ b/demo/scenes/GraphInspector.tsx
@@ -1,0 +1,132 @@
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { shaderNode } from '../../src/core/lib/graphPlanning';
+import { ShaderGraph } from '../../src/react/components/ShaderGraph';
+import { MicuglDevtools } from '../../src/react/devtools/MicuglDevtools';
+import { useImageTexture } from '../../src/react/hooks/useImageTexture';
+import { QUAD_VERTEX } from './shaders';
+
+const STRIPES_IMAGE =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAG0lEQVR4nGB44FChIWCAST'
+    + 'JgFX3gUMEwKHUAAA4/QAFwjPYbAAAAAElFTkSuQmCC';
+
+const GLOW_FRAGMENT = `
+    precision highp float;
+    uniform float u_time;
+    uniform vec2 u_resolution;
+    uniform float u_gain;
+    varying vec2 v_uv;
+    void main() {
+        vec2 c = v_uv - 0.5;
+        float d = length(c);
+        float pulse = 0.5 + 0.5 * sin(u_time * 1.3);
+        float glow = u_gain * (0.6 + 0.4 * pulse) / (d * 5.0 + 0.25);
+        gl_FragColor = vec4(glow, glow * 0.5, glow * 1.2, 1.0);
+    }
+`;
+
+const GRAIN_FRAGMENT = `
+    precision highp float;
+    uniform float u_time;
+    uniform vec2 u_resolution;
+    uniform float u_gain;
+    varying vec2 v_uv;
+    float hash(vec2 p) {
+        return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+    }
+    void main() {
+        float n = hash(floor(v_uv * u_resolution) + floor(u_time * 30.0));
+        float g = u_gain * n;
+        gl_FragColor = vec4(g, g, g, 1.0);
+    }
+`;
+
+const COMPOSITE_FRAGMENT = `
+    precision highp float;
+    uniform vec2 u_resolution;
+    uniform sampler2D u_glow;
+    uniform sampler2D u_grain;
+    uniform sampler2D u_photo;
+    uniform float u_blend;
+    varying vec2 v_uv;
+    void main() {
+        vec3 glow = texture2D(u_glow, v_uv).rgb;
+        vec3 grain = texture2D(u_grain, v_uv).rgb;
+        vec3 photo = texture2D(u_photo, v_uv).rgb;
+        vec3 base = mix(photo, glow, u_blend);
+        gl_FragColor = vec4(base + grain * 0.15, 1.0);
+    }
+`;
+
+const glowConfig = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: GLOW_FRAGMENT,
+    uniformNames: { u_gain: 'float' }
+});
+
+const grainConfig = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: GRAIN_FRAGMENT,
+    uniformNames: { u_gain: 'float' }
+});
+
+const compositeConfig = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: COMPOSITE_FRAGMENT,
+    uniformNames: { u_blend: 'float' }
+});
+
+export const GraphInspector = () => {
+    const photo = useImageTexture(STRIPES_IMAGE);
+
+    const glow = shaderNode({
+        id: 'glow',
+        shaderConfig: glowConfig,
+        uniforms: { gain: { type: 'float', value: 0.25 } },
+        width: 320,
+        height: 200
+    });
+
+    const grain = shaderNode({
+        id: 'grain',
+        shaderConfig: grainConfig,
+        uniforms: { gain: { type: 'float', value: 0.75 } },
+        width: 160,
+        height: 160
+    });
+
+    const root = shaderNode({
+        id: 'composite',
+        shaderConfig: compositeConfig,
+        uniforms: {
+            glow,
+            grain,
+            photo: photo.texture,
+            blend: { type: 'float', value: (time?: number) => 0.5 + 0.4 * Math.sin((time ?? 0) * 0.001 * 0.5) }
+        }
+    });
+
+    return (
+        <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
+            <ShaderGraph root={root} style={{ width: '100%', height: '100%', display: 'block' }} />
+            <div
+                style={{
+                    position: 'absolute',
+                    top: '12px',
+                    left: '12px',
+                    padding: '8px 12px',
+                    background: 'rgba(0, 0, 0, 0.6)',
+                    color: '#fff',
+                    fontFamily: 'monospace',
+                    fontSize: '12px',
+                    borderRadius: '4px',
+                    lineHeight: 1.6
+                }}
+            >
+                <div>glow 320x200 + grain 160x160 + image {'->'} composite to canvas</div>
+                <div>glow and grain both declare u_gain (0.25 vs 0.75)</div>
+                <div>photo status: {photo.status}</div>
+            </div>
+            <MicuglDevtools defaultOpen />
+        </div>
+    );
+};

--- a/demo/scenes/GraphPixels.tsx
+++ b/demo/scenes/GraphPixels.tsx
@@ -1,0 +1,102 @@
+import { useEffect } from 'react';
+
+import { createShaderConfig } from '../../src/core/lib/createShaderConfig';
+import { shaderNode } from '../../src/core/lib/graphPlanning';
+import { ShaderGraph } from '../../src/react/components/ShaderGraph';
+import type { EngineHandle } from '../../src/react/devtools/beacon';
+import { listEngines } from '../../src/react/devtools/beacon';
+import { QUAD_VERTEX } from './shaders';
+
+declare global {
+    interface Window {
+        __listGraphEngines?: () => EngineHandle[];
+    }
+}
+
+const A_FRAGMENT = `
+    precision highp float;
+    varying vec2 v_uv;
+    void main() {
+        float t = step(0.5, v_uv.y);
+        vec3 col = mix(vec3(0.25, 0.0, 0.0), vec3(1.0, 0.0, 0.0), t);
+        gl_FragColor = vec4(col, 1.0);
+    }
+`;
+
+const B_FRAGMENT = `
+    precision highp float;
+    varying vec2 v_uv;
+    void main() {
+        gl_FragColor = vec4(0.0, 0.0, 1.0, 1.0);
+    }
+`;
+
+const ROOT_FRAGMENT = `
+    precision highp float;
+    uniform sampler2D u_a;
+    uniform sampler2D u_b;
+    varying vec2 v_uv;
+    void main() {
+        vec3 a = texture2D(u_a, v_uv).rgb;
+        vec3 b = texture2D(u_b, v_uv).rgb;
+        gl_FragColor = vec4(mix(a, b, 0.5), 1.0);
+    }
+`;
+
+const aConfig = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: A_FRAGMENT,
+    uniformNames: {}
+});
+
+const bConfig = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: B_FRAGMENT,
+    uniformNames: {}
+});
+
+const rootConfig = createShaderConfig({
+    vertexShader: QUAD_VERTEX,
+    fragmentShader: ROOT_FRAGMENT,
+    uniformNames: {}
+});
+
+export const GraphPixels = () => {
+    useEffect(() => {
+        window.__listGraphEngines = listEngines;
+        return () => { window.__listGraphEngines = undefined };
+    }, []);
+
+    const a = shaderNode({
+        id: 'a',
+        shaderConfig: aConfig,
+        uniforms: {},
+        width: 128,
+        height: 128
+    });
+
+    const b = shaderNode({
+        id: 'b',
+        shaderConfig: bConfig,
+        uniforms: {},
+        width: 128,
+        height: 128
+    });
+
+    const root = shaderNode({
+        id: 'root',
+        shaderConfig: rootConfig,
+        uniforms: { a, b }
+    });
+
+    return (
+        <ShaderGraph
+            root={root}
+            width={256}
+            height={256}
+            useDevicePixelRatio={false}
+            frameloop='always'
+            style={{ width: '256px', height: '256px', display: 'block' }}
+        />
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -4,6 +4,8 @@ import { AudioBars } from './AudioBars';
 import { DevtoolsDebug } from './DevtoolsDebug';
 import { EffectsGallery } from './EffectsGallery';
 import { ExportDemo } from './ExportDemo';
+import { GraphInspector } from './GraphInspector';
+import { GraphPixels } from './GraphPixels';
 import { ImageTexture } from './ImageTexture';
 import { InstancedParticles } from './InstancedParticles';
 import { ManyCanvases } from './ManyCanvases';
@@ -42,7 +44,9 @@ export const scenes: Record<string, ComponentType> = {
     'particles-components': ParticlesComponents,
     'worker-jank': WorkerJank,
     'worker-context-loss': WorkerContextLoss,
-    'shader-graph': ShaderGraph
+    'shader-graph': ShaderGraph,
+    'graph-inspector': GraphInspector,
+    'graph-pixels': GraphPixels
 };
 
 export const getSceneComponent = (): ComponentType | null => {

--- a/src/react/components/ShaderGraph.tsx
+++ b/src/react/components/ShaderGraph.tsx
@@ -3,6 +3,7 @@ import { forwardRef, memo, useRef } from 'react';
 
 import type { ShaderNode } from '@/core/lib/graphPlanning';
 import { PingPongShaderEngine } from '@/react/components/engine/PingPongShaderEngine';
+import type { GraphDebugSource } from '@/react/hooks/useShaderGraph';
 import { useShaderGraph } from '@/react/hooks/useShaderGraph';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import type { PingPongShaderHandle, RenderControlProps } from '@/types';
@@ -43,12 +44,16 @@ const ShaderGraphComponent = forwardRef<PingPongShaderHandle, ShaderGraphProps>(
         framebuffers,
         textureSources,
         port,
+        graphDebug,
         invalidation,
         capturesAreNonReproducible
     } = useShaderGraph(root, { reducedMotion, saveData });
 
     const debugPortRef = useRef<UniformDebugPort | null>(null);
     debugPortRef.current = port;
+
+    const graphDebugRef = useRef<GraphDebugSource | null>(null);
+    graphDebugRef.current = graphDebug;
 
     return (
         <PingPongShaderEngine
@@ -58,6 +63,7 @@ const ShaderGraphComponent = forwardRef<PingPongShaderHandle, ShaderGraphProps>(
             framebuffers={framebuffers}
             textureSources={textureSources}
             debugPortRef={debugPortRef}
+            graphDebugRef={graphDebugRef}
             invalidation={invalidation}
             capturesAreNonReproducible={capturesAreNonReproducible}
             className={className}

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -627,18 +627,26 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
                                     return { unreadable: 'engine destroyed' };
                                 }
                                 const gl = currentManager.context;
+                                if (gl.isContextLost()) {
+                                    return { unreadable: 'engine destroyed' };
+                                }
                                 const previousFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null;
                                 const previousViewport = gl.getParameter(gl.VIEWPORT) as ArrayLike<number>;
-                                passSystem.execute(frameToMs(controllerRef.current?.getFrame() ?? 0));
-                                const pixels = currentManager.readPixels(rootWidth, rootHeight);
-                                gl.bindFramebuffer(gl.FRAMEBUFFER, previousFramebuffer);
-                                gl.viewport(
-                                    previousViewport[0],
-                                    previousViewport[1],
-                                    previousViewport[2],
-                                    previousViewport[3]
-                                );
-                                return { width: rootWidth, height: rootHeight, pixels };
+                                try {
+                                    passSystem.execute(frameToMs(controllerRef.current?.getFrame() ?? 0));
+                                    const pixels = currentManager.readPixels(rootWidth, rootHeight);
+                                    return { width: rootWidth, height: rootHeight, pixels };
+                                } catch {
+                                    return { unreadable: 'engine destroyed' };
+                                } finally {
+                                    gl.bindFramebuffer(gl.FRAMEBUFFER, previousFramebuffer);
+                                    gl.viewport(
+                                        previousViewport[0],
+                                        previousViewport[1],
+                                        previousViewport[2],
+                                        previousViewport[3]
+                                    );
+                                }
                             }
                         };
                     }

--- a/src/react/components/engine/PingPongShaderEngine.tsx
+++ b/src/react/components/engine/PingPongShaderEngine.tsx
@@ -19,11 +19,13 @@ import type {
 import { CAPTURE_SCRATCH_FRAMEBUFFER_ID, captureFrame } from '@/core/lib/captureFrame';
 import { resolveExportDimensions, validateRenderToBlobOptions } from '@/core/lib/captureOptions';
 import type { FrameInvalidation, InvalidationKind } from '@/core/lib/frameInvalidation';
+import type { FramebufferReadResult, FramebufferUnreadable } from '@/core/managers/FBOManager';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import { Passes } from '@/core/systems/Passes';
-import type { EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
+import type { EngineDebugState, EngineHandle, GraphDebugPort } from '@/react/devtools/beacon';
 import { emitEngineMount, emitEngineUnmount } from '@/react/devtools/beacon';
 import { useMotionGate } from '@/react/hooks/useMotionGate';
+import type { GraphDebugSource } from '@/react/hooks/useShaderGraph';
 import type { WorkerBridgeInitPayload } from '@/react/hooks/useWorkerBridge';
 import { useWorkerBridge } from '@/react/hooks/useWorkerBridge';
 import { pixelsToBlob, pixelsToDataURL } from '@/react/lib/captureBlob';
@@ -76,6 +78,7 @@ interface PingPongShaderEngineBaseProps extends Omit<RenderControlProps, 'worker
     renderHeight?: number;
     debug?: boolean;
     debugPortRef?: RefObject<UniformDebugPort | null>;
+    graphDebugRef?: RefObject<GraphDebugSource | null>;
     invalidation?: FrameInvalidation;
     capturesAreNonReproducible?: CapturesAreNonReproducible;
 }
@@ -158,6 +161,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
     renderHeight,
     debug = false,
     debugPortRef,
+    graphDebugRef,
     workerUniforms,
     workerCustomPasses = false,
     invalidation,
@@ -568,7 +572,76 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
                     setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
                     getFrame: () => controllerRef.current?.getFrame() ?? 0,
                     setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) },
-                    uniforms: debugPortRef?.current ?? undefined
+                    get uniforms() {
+                        return debugPortRef?.current ?? undefined;
+                    },
+                    get graph(): GraphDebugPort | undefined {
+                        if (!graphDebugRef?.current) {
+                            return undefined;
+                        }
+                        return {
+                            topology: () => {
+                                const source = graphDebugRef.current;
+                                if (!source) {
+                                    throw new Error('micugl devtools: graph.topology read after the engine was torn down');
+                                }
+                                return source.topology();
+                            },
+                            nodeUniforms: nodeId => {
+                                const source = graphDebugRef.current;
+                                if (!source) {
+                                    throw new Error('micugl devtools: graph.nodeUniforms read after the engine was torn down');
+                                }
+                                return source.nodeUniforms(nodeId);
+                            },
+                            readNode: (nodeId, maxSize): FramebufferReadResult | FramebufferUnreadable => {
+                                const source = graphDebugRef.current;
+                                const topology = source?.topology();
+                                const node = topology?.nodes.find(candidate => candidate.id === nodeId);
+                                if (!node) {
+                                    const known = topology?.nodes.map(candidate => candidate.id).join(', ') ?? '';
+                                    throw new Error(
+                                        `micugl devtools: graph.readNode has no node "${nodeId}". Known node ids: ${known}.`
+                                    );
+                                }
+                                const currentManager = managerWeak.deref();
+                                if (!currentManager || !readyRef.current) {
+                                    return { unreadable: 'engine destroyed' };
+                                }
+                                if (node.framebufferId !== null) {
+                                    return currentManager.fbo.debugReadFramebuffer(node.framebufferId, maxSize);
+                                }
+                                const rootCanvas = currentManager.context.canvas as HTMLCanvasElement;
+                                const rootWidth = rootCanvas.width;
+                                const rootHeight = rootCanvas.height;
+                                if (rootWidth <= 0 || rootHeight <= 0) {
+                                    return { unreadable: 'framebuffer has zero size' };
+                                }
+                                if (maxSize !== undefined && (rootWidth > maxSize || rootHeight > maxSize)) {
+                                    return {
+                                        unreadable: `framebuffer ${rootWidth}x${rootHeight} exceeds capture maxSize ${maxSize}`
+                                    };
+                                }
+                                const passSystem = passSystemRef.current;
+                                if (!passSystem) {
+                                    return { unreadable: 'engine destroyed' };
+                                }
+                                const gl = currentManager.context;
+                                const previousFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer | null;
+                                const previousViewport = gl.getParameter(gl.VIEWPORT) as ArrayLike<number>;
+                                passSystem.execute(frameToMs(controllerRef.current?.getFrame() ?? 0));
+                                const pixels = currentManager.readPixels(rootWidth, rootHeight);
+                                gl.bindFramebuffer(gl.FRAMEBUFFER, previousFramebuffer);
+                                gl.viewport(
+                                    previousViewport[0],
+                                    previousViewport[1],
+                                    previousViewport[2],
+                                    previousViewport[3]
+                                );
+                                return { width: rootWidth, height: rootHeight, pixels };
+                            }
+                        };
+                    }
                 };
                 emitEngineMount(handle);
             }
@@ -584,7 +657,7 @@ const PingPongShaderEngineComponent = forwardRef<PingPongShaderHandle, PingPongS
             passSystemRef.current = null;
             emitEngineUnmount(engineIdRef.current);
         };
-    }, [workerActive, contentKey, epoch, debugPortRef]);
+    }, [workerActive, contentKey, epoch, debugPortRef, graphDebugRef]);
 
     useEffect(() => {
         applySize();

--- a/src/react/components/engine/ShaderEngine.tsx
+++ b/src/react/components/engine/ShaderEngine.tsx
@@ -677,7 +677,9 @@ const ShaderEngineComponent = forwardRef<ShaderHandle, ShaderEngineProps>(({
                     setFrame: (frame: number) => { controllerRef.current?.setFrame(frame) },
                     getFrame: () => controllerRef.current?.getFrame() ?? 0,
                     setFrameloop: mode => { controllerRef.current?.setFrameloop(mode) },
-                    uniforms: debugPortRef?.current ?? undefined
+                    get uniforms() {
+                        return debugPortRef?.current ?? undefined;
+                    }
                 };
                 emitEngineMount(handle);
             }

--- a/src/react/devtools/MicuglDevtools.tsx
+++ b/src/react/devtools/MicuglDevtools.tsx
@@ -13,6 +13,7 @@ import { FpsPanel } from '@/react/devtools/panels/FpsPanel';
 import { FramebuffersPanel } from '@/react/devtools/panels/FramebuffersPanel';
 import { FrameloopPanel } from '@/react/devtools/panels/FrameloopPanel';
 import { GlCountersPanel } from '@/react/devtools/panels/GlCountersPanel';
+import { GraphPanel } from '@/react/devtools/panels/GraphPanel';
 import { UniformsPanel } from '@/react/devtools/panels/UniformsPanel';
 import { diffCounters } from '@/testing/assertions';
 import type { GlCountersData, GlCountersHandle } from '@/testing/glCounters';
@@ -327,16 +328,22 @@ const DevtoolsPanel = ({ position, defaultOpen }: DevtoolsPanelProps): ReactElem
                                             onStep={handleStep}
                                             onSetFrame={handleSetFrame}
                                         />
-                                        <UniformsPanel engine={selected} />
-                                        {engineState.framebufferIds.length > 0
-                                            ? (
-                                                <FramebuffersPanel
-                                                    framebufferIds={engineState.framebufferIds}
-                                                    manager={selected?.getManager() ?? null}
-                                                    captureTick={captureTick}
-                                                />
-                                            )
-                                            : null}
+                                        {selected?.graph
+                                            ? <GraphPanel engine={selected} captureTick={captureTick} />
+                                            : (
+                                                <>
+                                                    <UniformsPanel engine={selected} />
+                                                    {engineState.framebufferIds.length > 0
+                                                        ? (
+                                                            <FramebuffersPanel
+                                                                framebufferIds={engineState.framebufferIds}
+                                                                manager={selected?.getManager() ?? null}
+                                                                captureTick={captureTick}
+                                                            />
+                                                        )
+                                                        : null}
+                                                </>
+                                            )}
                                     </>
                                 )
                                 : null}

--- a/src/react/devtools/beacon.ts
+++ b/src/react/devtools/beacon.ts
@@ -1,5 +1,7 @@
 import type { WebGLManager } from '@/core';
+import type { GraphTopology } from '@/core/lib/graphPlanning';
 import type { TextureCapabilities } from '@/core/lib/textureCapabilities';
+import type { FramebufferReadResult, FramebufferUnreadable } from '@/core/managers/FBOManager';
 import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 import type { Frameloop } from '@/types';
 
@@ -16,6 +18,12 @@ export interface EngineDebugState {
     speed?: number;
 }
 
+export interface GraphDebugPort {
+    topology: () => GraphTopology;
+    readNode: (nodeId: string, maxSize?: number) => FramebufferReadResult | FramebufferUnreadable;
+    nodeUniforms: (nodeId: string) => UniformDebugPort;
+}
+
 export interface EngineHandle {
     id: string;
     kind: 'shader' | 'pingpong';
@@ -26,6 +34,7 @@ export interface EngineHandle {
     setFrame?: (frame: number) => void;
     getFrame?: () => number;
     uniforms?: UniformDebugPort;
+    graph?: GraphDebugPort;
 }
 
 export interface DevtoolsSink {

--- a/src/react/devtools/graphInspector.test.tsx
+++ b/src/react/devtools/graphInspector.test.tsx
@@ -446,6 +446,73 @@ describe('graph inspector: the root read restores the framebuffer binding (T11)'
     });
 });
 
+describe('graph inspector: a lost or throwing root read degrades to unreadable and restores the binding (C3)', () => {
+    it('restores the sentinel binding when the read throws mid-capture and degrades to unreadable', async () => {
+        installStub({
+            overrides: {
+                readPixels: (): void => {
+                    throw new Error('simulated read failure');
+                }
+            }
+        });
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const handle = currentHandle();
+        const gl = handle.getManager()?.context;
+        if (!gl) {
+            throw new Error('no gl context');
+        }
+        const sentinel = gl.createFramebuffer();
+        gl.bindFramebuffer(gl.FRAMEBUFFER, sentinel);
+
+        const result = handle.graph?.readNode('root');
+        expect(result).toEqual({ unreadable: 'engine destroyed' });
+        expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBe(sentinel);
+    });
+
+    it('degrades to unreadable when the context is lost after mount and leaves the binding untouched', async () => {
+        const config: GLStubConfig = {};
+        installStub(config);
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const handle = currentHandle();
+        const gl = handle.getManager()?.context;
+        if (!gl) {
+            throw new Error('no gl context');
+        }
+        const sentinel = gl.createFramebuffer();
+        gl.bindFramebuffer(gl.FRAMEBUFFER, sentinel);
+
+        config.contextLost = true;
+
+        const result = handle.graph?.readNode('root');
+        expect(result).toEqual({ unreadable: 'engine destroyed' });
+        expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBe(sentinel);
+    });
+});
+
+describe('graph inspector: a zero-size root canvas degrades to unreadable (C3)', () => {
+    it('returns the zero-size reason for a root read when the canvas has no backing size', async () => {
+        await mount(
+            <ShaderGraph
+                root={sharedGainGraph(0.25, 0.75, 0.875)}
+                width={0}
+                height={0}
+                useDevicePixelRatio={false}
+                frameloop='demand'
+                reducedMotion='ignore'
+                saveData='ignore'
+            />
+        );
+        act(() => { frames.tick(0) });
+
+        const result = currentHandle().graph?.readNode('root');
+        expect(result).toEqual({ unreadable: 'framebuffer has zero size' });
+    });
+});
+
 function fakeGraphPort(): GraphDebugPort {
     const listFor = (nodeId: string): UniformListEntry[] => [
         { name: `u_${nodeId}`, type: 'float', value: 0.5, overridden: false, nodeId }

--- a/src/react/devtools/graphInspector.test.tsx
+++ b/src/react/devtools/graphInspector.test.tsx
@@ -1,0 +1,634 @@
+import { act, type ReactElement, StrictMode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createShaderConfig } from '@/core/lib/createShaderConfig';
+import type { ShaderNode } from '@/core/lib/graphPlanning';
+import { planGraph, shaderNode } from '@/core/lib/graphPlanning';
+import { BaseShaderComponent } from '@/react/components/base/BaseShaderComponent';
+import { ShaderGraph } from '@/react/components/ShaderGraph';
+import type { EngineHandle, GraphDebugPort } from '@/react/devtools/beacon';
+import { listEngines } from '@/react/devtools/beacon';
+import { MicuglDevtools } from '@/react/devtools/MicuglDevtools';
+import { GraphPanel } from '@/react/devtools/panels/GraphPanel';
+import type { UniformListEntry } from '@/react/lib/liveUniformUpdaters';
+import type { GLStubConfig, GLStubHandle } from '@/testing';
+import { createGLStub } from '@/testing';
+import type { FrameQueue } from '@/testing/frameQueue';
+import { createFrameQueue } from '@/testing/frameQueue';
+
+const WIDTH = 320;
+const HEIGHT = 200;
+
+const CHILD_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_gain: 'float' }
+});
+
+const TINT_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_shade: 'float' }
+});
+
+const ROOT_CONFIG = createShaderConfig({
+    vertexShader: 'void main() {}',
+    fragmentShader: 'void main() {}',
+    uniformNames: { u_mix: 'float' }
+});
+
+let container: HTMLDivElement;
+let root: Root;
+let frames: FrameQueue;
+let stub: GLStubHandle;
+let originalGetContext: unknown;
+let originalToBlob: unknown;
+
+class ImageDataStub {
+    constructor(
+        public data: Uint8ClampedArray,
+        public width: number,
+        public height: number
+    ) {}
+}
+
+function installStub(config: GLStubConfig = {}): void {
+    stub = createGLStub(config);
+}
+
+beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    frames = createFrameQueue();
+    globalThis.requestAnimationFrame = frames.schedule as unknown as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = frames.cancel;
+
+    installStub();
+
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown; toBlob: unknown };
+    originalGetContext = canvasProto.getContext;
+    originalToBlob = canvasProto.toBlob;
+    canvasProto.getContext = function stubGetContext(type: string): unknown {
+        if (type === '2d') {
+            return new Proxy({}, {
+                get: () => () => undefined,
+                set: () => true
+            });
+        }
+        return stub.gl;
+    };
+    canvasProto.toBlob = function stubToBlob(callback: (blob: Blob) => void, type?: string): void {
+        callback(new Blob([], { type: type ?? 'image/png' }));
+    };
+
+    (globalThis as { ImageData?: unknown }).ImageData = ImageDataStub;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => { root.unmount() });
+    container.remove();
+    const canvasProto = HTMLCanvasElement.prototype as unknown as { getContext: unknown; toBlob: unknown };
+    canvasProto.getContext = originalGetContext;
+    canvasProto.toBlob = originalToBlob;
+    delete (globalThis as { ImageData?: unknown }).ImageData;
+});
+
+async function mount(element: ReactElement): Promise<void> {
+    await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+    });
+}
+
+interface ShadowMount {
+    root: Root;
+    shadow: ShadowRoot;
+    host: HTMLElement;
+}
+
+function createShadowMount(): ShadowMount {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const inner = document.createElement('div');
+    shadow.appendChild(inner);
+    return { root: createRoot(inner), shadow, host };
+}
+
+function currentHandle(): EngineHandle {
+    const handle = listEngines().at(-1);
+    if (!handle) {
+        throw new Error('no engine mounted');
+    }
+    return handle;
+}
+
+function currentGraph(): GraphDebugPort {
+    const graph = currentHandle().graph;
+    if (!graph) {
+        throw new Error('the mounted engine exposes no graph debug port');
+    }
+    return graph;
+}
+
+function uploads(name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+function valueOf(entries: UniformListEntry[], name: string): unknown {
+    const entry = entries.find(candidate => candidate.name === name);
+    if (!entry) {
+        throw new Error(`no entry named ${name}`);
+    }
+    return entry.value;
+}
+
+function sharedGainGraph(glowGain: number, grainGain: number, mix: number, rootOptions?: { clear: boolean }): ShaderNode {
+    const glow = shaderNode({
+        id: 'glow',
+        shaderConfig: CHILD_CONFIG,
+        uniforms: { gain: { type: 'float', value: glowGain } },
+        width: 16,
+        height: 8
+    });
+    const grain = shaderNode({
+        id: 'grain',
+        shaderConfig: CHILD_CONFIG,
+        uniforms: { gain: { type: 'float', value: grainGain } },
+        width: 32,
+        height: 4
+    });
+    return shaderNode({
+        id: 'root',
+        shaderConfig: ROOT_CONFIG,
+        uniforms: { a: glow, b: grain, mix: { type: 'float', value: mix } },
+        renderOptions: rootOptions
+    });
+}
+
+function graphScene(node: ShaderNode): ReactElement {
+    return (
+        <ShaderGraph
+            root={node}
+            width={WIDTH}
+            height={HEIGHT}
+            useDevicePixelRatio={false}
+            frameloop='demand'
+            reducedMotion='ignore'
+            saveData='ignore'
+        />
+    );
+}
+
+describe('graph inspector: combined port attribution (T1)', () => {
+    it('lists both shared-name entries, each stamped with its own node id and value', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const gainEntries = currentHandle().uniforms?.list().filter(entry => entry.name === 'u_gain') ?? [];
+        expect(gainEntries.map(entry => [entry.nodeId, entry.value])).toEqual([
+            ['glow', 0.25],
+            ['grain', 0.75]
+        ]);
+    });
+});
+
+describe('graph inspector: combined-port fan (T2)', () => {
+    it('fans a name-addressed override across every declaring node and restores distinct bases', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const handle = currentHandle();
+        const graph = currentGraph();
+
+        act(() => { handle.uniforms?.setOverride('u_gain', 0.5) });
+        expect(valueOf(graph.nodeUniforms('glow').list(), 'u_gain')).toBe(0.5);
+        expect(valueOf(graph.nodeUniforms('grain').list(), 'u_gain')).toBe(0.5);
+
+        act(() => { handle.uniforms?.clearOverride('u_gain') });
+        expect(valueOf(graph.nodeUniforms('glow').list(), 'u_gain')).toBe(0.25);
+        expect(valueOf(graph.nodeUniforms('grain').list(), 'u_gain')).toBe(0.75);
+    });
+});
+
+describe('graph inspector: node-scoped override (T3)', () => {
+    it('changes only the targeted node and leaves the sibling that shares the name untouched', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const graph = currentGraph();
+        act(() => { graph.nodeUniforms('glow').setOverride('u_gain', 0.9) });
+
+        expect(valueOf(graph.nodeUniforms('glow').list(), 'u_gain')).toBe(0.9);
+        expect(valueOf(graph.nodeUniforms('grain').list(), 'u_gain')).toBe(0.75);
+    });
+});
+
+describe('graph inspector: unknown ids fail loud through the public path (T4)', () => {
+    it('names the unknown id and the known ids for both nodeUniforms and readNode', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const graph = currentGraph();
+        expect(() => graph.nodeUniforms('nope')).toThrow(/nope[\s\S]*glow[\s\S]*grain[\s\S]*root/);
+        expect(() => graph.readNode('nope')).toThrow(/nope[\s\S]*glow[\s\S]*grain[\s\S]*root/);
+    });
+});
+
+describe('graph inspector: topology is the compiler own output (T5)', () => {
+    it('deep-equals planGraph topology for the same root, never a hand-written tree', async () => {
+        const rootNode = sharedGainGraph(0.25, 0.75, 0.875);
+        await mount(graphScene(rootNode));
+        act(() => { frames.tick(0) });
+
+        expect(currentGraph().topology()).toEqual(planGraph(rootNode).topology);
+    });
+});
+
+describe('graph inspector: handle fields are live getters, not init-time snapshots (T6)', () => {
+    it('rebuilds the port on a renderOptions-only change while the manager survives', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875, { clear: true })));
+        act(() => { frames.tick(0) });
+
+        const handle = currentHandle();
+        const managerBefore = handle.getManager();
+        const portBefore = handle.uniforms;
+        expect(portBefore).toBeDefined();
+
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875, { clear: false })));
+        act(() => { frames.tick(16) });
+
+        const managerAfter = handle.getManager();
+        const portAfter = handle.uniforms;
+
+        expect(managerAfter).toBe(managerBefore);
+        expect(portAfter).not.toBe(portBefore);
+        expect(() => handle.graph?.nodeUniforms('root').list()).not.toThrow();
+    });
+});
+
+describe('graph inspector: a wiring swap re-inits and reports the swapped wiring (T6b)', () => {
+    it('changes manager identity and shows the swapped edges after the swap', async () => {
+        const build = (leftId: string, rightId: string): ShaderNode => {
+            const a = shaderNode({
+                id: 'a',
+                shaderConfig: CHILD_CONFIG,
+                uniforms: { gain: { type: 'float', value: 0.25 } },
+                width: 16,
+                height: 8
+            });
+            const b = shaderNode({
+                id: 'b',
+                shaderConfig: CHILD_CONFIG,
+                uniforms: { gain: { type: 'float', value: 0.75 } },
+                width: 32,
+                height: 4
+            });
+            const byId: Record<string, ShaderNode> = { a, b };
+            return shaderNode({
+                id: 'root',
+                shaderConfig: ROOT_CONFIG,
+                uniforms: { left: byId[leftId], right: byId[rightId], mix: { type: 'float', value: 0.875 } }
+            });
+        };
+
+        await mount(graphScene(build('a', 'b')));
+        act(() => { frames.tick(0) });
+        const managerBefore = currentHandle().getManager();
+
+        await mount(graphScene(build('b', 'a')));
+        act(() => { frames.tick(16) });
+
+        const handleAfter = currentHandle();
+        expect(handleAfter.getManager()).not.toBe(managerBefore);
+
+        const rootNode = handleAfter.graph?.topology().nodes.find(node => node.id === 'root');
+        const edgeFor = (sampler: string): string | undefined =>
+            rootNode?.edges.find(edge => edge.samplerName === sampler)?.childId;
+        expect(edgeFor('u_left')).toBe('b');
+        expect(edgeFor('u_right')).toBe('a');
+    });
+});
+
+describe('graph inspector: node ports stay live through a StrictMode remount and node addition (T7)', () => {
+    it('advances a function uniform, then resolves a node added after first render and lands its override on GL', async () => {
+        const build = (withChild: boolean): ShaderNode => {
+            const childA = shaderNode({
+                id: 'a',
+                shaderConfig: CHILD_CONFIG,
+                uniforms: { gain: { type: 'float', value: (time?: number) => time ?? 0 } },
+                width: 16,
+                height: 8
+            });
+            const childB = shaderNode({
+                id: 'b',
+                shaderConfig: TINT_CONFIG,
+                uniforms: { shade: { type: 'float', value: 0.125 } },
+                width: 8,
+                height: 8
+            });
+            return shaderNode({
+                id: 'root',
+                shaderConfig: ROOT_CONFIG,
+                uniforms: withChild
+                    ? { a: childA, b: childB, mix: { type: 'float', value: 0.875 } }
+                    : { a: childA, mix: { type: 'float', value: 0.875 } }
+            });
+        };
+
+        const scene = (withChild: boolean): ReactElement => (
+            <StrictMode>
+                <ShaderGraph
+                    root={build(withChild)}
+                    width={WIDTH}
+                    height={HEIGHT}
+                    useDevicePixelRatio={false}
+                    frameloop='always'
+                    reducedMotion='ignore'
+                    saveData='ignore'
+                />
+            </StrictMode>
+        );
+
+        await mount(scene(false));
+        act(() => { frames.tick(0) });
+        act(() => { frames.tick(16) });
+        act(() => { frames.tick(32) });
+
+        const gainUploads = uploads('u_gain') as number[];
+        expect(gainUploads.length).toBeGreaterThanOrEqual(2);
+        expect(gainUploads[gainUploads.length - 1]).toBeGreaterThan(gainUploads[0]);
+
+        await mount(scene(true));
+        act(() => { frames.tick(48) });
+
+        const graph = currentGraph();
+        expect(graph.nodeUniforms('b').list().map(entry => entry.name)).toContain('u_shade');
+
+        act(() => { graph.nodeUniforms('b').setOverride('u_shade', 0.9) });
+        act(() => { frames.tick(64) });
+        expect(uploads('u_shade')).toContain(0.9);
+    });
+});
+
+describe('graph inspector: readNode plumbing addresses the node own framebuffer (T8)', () => {
+    it('reads each child from its own framebuffer dims and the root from the canvas', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const graph = currentGraph();
+        const glow = graph.readNode('glow');
+        const grain = graph.readNode('grain');
+        const rootRead = graph.readNode('root');
+
+        expect('width' in glow ? [glow.width, glow.height] : glow).toEqual([16, 8]);
+        expect('width' in grain ? [grain.width, grain.height] : grain).toEqual([32, 4]);
+        expect('width' in rootRead ? [rootRead.width, rootRead.height] : rootRead).toEqual([WIDTH, HEIGHT]);
+    });
+});
+
+describe('graph inspector: unreadable variants surface verbatim (T9)', () => {
+    it('passes the debugReadFramebuffer maxSize refusal through readNode unchanged', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const handle = currentHandle();
+        const graph = handle.graph;
+        if (!graph) {
+            throw new Error('no graph port');
+        }
+        const throughReadNode = graph.readNode('glow', 4);
+        const direct = handle.getManager()?.fbo.debugReadFramebuffer('glow-out', 4);
+
+        expect(throughReadNode).toEqual({ unreadable: 'framebuffer 16x8 exceeds capture maxSize 4' });
+        expect(throughReadNode).toEqual(direct);
+    });
+});
+
+describe('graph inspector: dead-engine grace vs caller error (T10)', () => {
+    it('degrades a valid node to unreadable after unmount but still throws for an unknown id', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+        const handle = currentHandle();
+
+        await act(async () => {
+            root.render(<div />);
+            await Promise.resolve();
+        });
+
+        expect(handle.graph?.readNode('glow')).toEqual({ unreadable: 'engine destroyed' });
+        expect(() => handle.graph?.readNode('nope')).toThrow(/nope/);
+    });
+});
+
+describe('graph inspector: the root read restores the framebuffer binding (T11)', () => {
+    it('leaves FRAMEBUFFER_BINDING at its pre-call value after a root readNode', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const handle = currentHandle();
+        const gl = handle.getManager()?.context;
+        if (!gl) {
+            throw new Error('no gl context');
+        }
+        const sentinel = gl.createFramebuffer();
+        gl.bindFramebuffer(gl.FRAMEBUFFER, sentinel);
+
+        const result = handle.graph?.readNode('root');
+        expect(result && 'width' in result).toBe(true);
+        expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBe(sentinel);
+    });
+});
+
+function fakeGraphPort(): GraphDebugPort {
+    const listFor = (nodeId: string): UniformListEntry[] => [
+        { name: `u_${nodeId}`, type: 'float', value: 0.5, overridden: false, nodeId }
+    ];
+    return {
+        topology: () => ({
+            rootId: 'root',
+            nodes: [
+                { id: 'leaf', framebufferId: 'leaf-out', width: 16, height: 8, edges: [], sources: [{ samplerName: 'u_img', sourceId: 'clip' }], uniformNames: ['u_leaf'] },
+                { id: 'mid', framebufferId: 'mid-out', width: 64, height: 64, edges: [{ samplerName: 'u_src', childId: 'leaf' }], sources: [], uniformNames: ['u_mid'] },
+                { id: 'root', framebufferId: null, width: 0, height: 0, edges: [{ samplerName: 'u_warped', childId: 'mid' }], sources: [], uniformNames: ['u_root'] }
+            ]
+        }),
+        nodeUniforms: nodeId => ({
+            list: () => listFor(nodeId),
+            setOverride: () => undefined,
+            clearOverride: () => undefined
+        }),
+        readNode: () => ({ unreadable: 'zero frames captured' })
+    };
+}
+
+function fakeEngine(graph: GraphDebugPort): EngineHandle {
+    return {
+        id: 'fake',
+        kind: 'pingpong',
+        getManager: () => null,
+        getState: () => ({
+            kind: 'pingpong',
+            id: 'fake',
+            canvas: { renderWidth: 0, renderHeight: 0, displayWidth: 0, displayHeight: 0 },
+            programIds: [],
+            framebufferIds: [],
+            capabilities: {
+                floatRenderable: false,
+                halfFloatRenderable: false,
+                floatLinearFilterable: false,
+                halfFloatLinearFilterable: false,
+                halfFloatType: 0
+            },
+            floatFilterDowngraded: false
+        }),
+        graph
+    };
+}
+
+describe('graph inspector: GraphPanel renders the topology tree (T12 panel side)', () => {
+    it('lists nodes in topological order with source leaves and per-node uniform rows', async () => {
+        const panel = createShadowMount();
+        await act(async () => {
+            panel.root.render(<GraphPanel engine={fakeEngine(fakeGraphPort())} captureTick={0} />);
+            await Promise.resolve();
+        });
+
+        const text = panel.shadow.textContent ?? '';
+        const leafIndex = text.indexOf('leaf');
+        const midIndex = text.indexOf('mid');
+        const rootIndex = text.indexOf('root');
+        expect(leafIndex).toBeGreaterThanOrEqual(0);
+        expect(leafIndex).toBeLessThan(midIndex);
+        expect(midIndex).toBeLessThan(rootIndex);
+
+        expect(text).toContain('src: clip');
+        expect(panel.shadow.querySelector('[aria-label="u_leaf"]')).not.toBeNull();
+        expect(panel.shadow.querySelector('[aria-label="u_mid"]')).not.toBeNull();
+        expect(panel.shadow.querySelector('[aria-label="u_root"]')).not.toBeNull();
+
+        act(() => { panel.root.unmount() });
+        panel.host.remove();
+    });
+
+    it('shows the unreadable reason in the thumbnail placeholder when a node is captured', async () => {
+        const panel = createShadowMount();
+        await act(async () => {
+            panel.root.render(<GraphPanel engine={fakeEngine(fakeGraphPort())} captureTick={0} />);
+            await Promise.resolve();
+        });
+
+        const captureButton = Array.from(panel.shadow.querySelectorAll('button'))
+            .find(button => button.textContent === 'capture');
+        expect(captureButton).toBeDefined();
+        await act(async () => {
+            captureButton?.click();
+            await Promise.resolve();
+        });
+        await act(async () => {
+            panel.root.render(<GraphPanel engine={fakeEngine(fakeGraphPort())} captureTick={1} />);
+            await Promise.resolve();
+        });
+
+        expect(panel.shadow.textContent).toContain('zero frames captured');
+
+        act(() => { panel.root.unmount() });
+        panel.host.remove();
+    });
+});
+
+async function tickDevtools(timestamps: number[]): Promise<void> {
+    for (const timestamp of timestamps) {
+        await act(async () => {
+            frames.tick(timestamp);
+            await Promise.resolve();
+        });
+    }
+}
+
+function devtoolsText(): string {
+    const host = document.querySelector('[data-micugl-devtools]');
+    return host?.shadowRoot?.textContent ?? '';
+}
+
+describe('graph inspector: MicuglDevtools swaps in the graph panel (T12 integration, T14)', () => {
+    it('shows the graph section and hides the flat uniforms and framebuffers panels for a graph engine', async () => {
+        await mount(
+            <>
+                {graphScene(sharedGainGraph(0.25, 0.75, 0.875))}
+                <MicuglDevtools defaultOpen />
+            </>
+        );
+        await tickDevtools([0, 120, 240, 360]);
+
+        const text = devtoolsText();
+        expect(text).toContain('graph');
+        expect(text).toContain('glow');
+        expect(text).toContain('grain');
+        expect(text).not.toContain('framebuffers');
+    });
+});
+
+describe('graph inspector: panel override hygiene (T13)', () => {
+    it('clears panel-set overrides on unmount but leaves overrides set outside the panel', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+        const handle = currentHandle();
+
+        const panel = createShadowMount();
+        await act(async () => {
+            panel.root.render(<GraphPanel engine={handle} captureTick={0} />);
+            await Promise.resolve();
+        });
+
+        const glowInput = panel.shadow.querySelectorAll('[aria-label="u_gain"]')[0];
+        expect(glowInput).toBeDefined();
+        await act(async () => {
+            glowInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+            await Promise.resolve();
+        });
+
+        act(() => { handle.graph?.nodeUniforms('grain').setOverride('u_gain', 0.6) });
+
+        expect(handle.graph?.nodeUniforms('glow').list()[0].overridden).toBe(true);
+        expect(handle.graph?.nodeUniforms('grain').list()[0].overridden).toBe(true);
+
+        act(() => { panel.root.unmount() });
+        panel.host.remove();
+
+        expect(handle.graph?.nodeUniforms('glow').list()[0].overridden).toBe(false);
+        expect(handle.graph?.nodeUniforms('grain').list()[0].overridden).toBe(true);
+    });
+});
+
+describe('graph inspector: single-program engines keep the flat uniforms panel (T14 negative)', () => {
+    it('shows the uniforms panel and no graph section for a single-program engine', async () => {
+        await mount(
+            <>
+                <BaseShaderComponent
+                    programId='solid'
+                    shaderConfig={CHILD_CONFIG}
+                    uniforms={{ gain: { type: 'float', value: 0.375 } }}
+                    width={WIDTH}
+                    height={HEIGHT}
+                    useDevicePixelRatio={false}
+                    frameloop='demand'
+                    reducedMotion='ignore'
+                    saveData='ignore'
+                />
+                <MicuglDevtools defaultOpen />
+            </>
+        );
+        await tickDevtools([0, 120, 240, 360]);
+
+        const text = devtoolsText();
+        expect(text).toContain('uniforms');
+        expect(currentHandle().graph).toBeUndefined();
+    });
+});

--- a/src/react/devtools/graphInspector.test.tsx
+++ b/src/react/devtools/graphInspector.test.tsx
@@ -513,6 +513,30 @@ describe('graph inspector: a zero-size root canvas degrades to unreadable (C3)',
     });
 });
 
+describe('graph inspector: the root maxSize refusal matches the fbo path and leaves no ghost state (C3)', () => {
+    it('refuses an oversized root read with the same message shape as debugReadFramebuffer and does not touch GL', async () => {
+        await mount(graphScene(sharedGainGraph(0.25, 0.75, 0.875)));
+        act(() => { frames.tick(0) });
+
+        const handle = currentHandle();
+        const gl = handle.getManager()?.context;
+        if (!gl) {
+            throw new Error('no gl context');
+        }
+        const sentinel = gl.createFramebuffer();
+        gl.bindFramebuffer(gl.FRAMEBUFFER, sentinel);
+
+        const rootRefusal = handle.graph?.readNode('root', 100);
+        expect(rootRefusal).toEqual({ unreadable: `framebuffer ${WIDTH}x${HEIGHT} exceeds capture maxSize 100` });
+        expect(gl.getParameter(gl.FRAMEBUFFER_BINDING)).toBe(sentinel);
+
+        const fboRefusal = handle.graph?.readNode('glow', 4);
+        const rootPattern = (rootRefusal as { unreadable: string }).unreadable.replace(/\d+/g, '#');
+        const fboPattern = (fboRefusal as { unreadable: string }).unreadable.replace(/\d+/g, '#');
+        expect(rootPattern).toBe(fboPattern);
+    });
+});
+
 function fakeGraphPort(): GraphDebugPort {
     const listFor = (nodeId: string): UniformListEntry[] => [
         { name: `u_${nodeId}`, type: 'float', value: 0.5, overridden: false, nodeId }

--- a/src/react/devtools/index.ts
+++ b/src/react/devtools/index.ts
@@ -1,5 +1,7 @@
 /** @experimental */
-export type { DevtoolsSink, EngineDebugState, EngineHandle } from '@/react/devtools/beacon';
+export type { DevtoolsSink, EngineDebugState, EngineHandle, GraphDebugPort } from '@/react/devtools/beacon';
+/** @experimental */
+export type { FramebufferReadResult, FramebufferUnreadable } from '@/core/managers/FBOManager';
 /** @experimental */
 export { listEngines, setDevtoolsSink } from '@/react/devtools/beacon';
 /** @experimental */

--- a/src/react/devtools/lib/UniformRow.tsx
+++ b/src/react/devtools/lib/UniformRow.tsx
@@ -1,0 +1,143 @@
+import type { ReactElement } from 'react';
+
+import { ColorField } from '@/react/devtools/controls/ColorField';
+import { NumberField } from '@/react/devtools/controls/NumberField';
+import { DEFAULT_VECTOR_LABELS, VectorField } from '@/react/devtools/controls/VectorField';
+import { isColorUniform } from '@/react/devtools/lib/detectColor';
+import { stepForType } from '@/react/devtools/lib/step';
+import { buttonStyle, COLORS, rowStyle } from '@/react/devtools/lib/theme';
+import type { UniformListEntry } from '@/react/lib/liveUniformUpdaters';
+
+export type ColorMode = 'auto' | 'color' | 'number';
+
+const formatReadonlyValue = (value: unknown): string => {
+    if (typeof value === 'function') {
+        return '\u0192()';
+    }
+    if (typeof value === 'number') {
+        return value.toFixed(3);
+    }
+    if (ArrayBuffer.isView(value)) {
+        return Array.from(value as unknown as ArrayLike<number>)
+            .map(component => component.toFixed(2))
+            .join(', ');
+    }
+    return String(value);
+};
+
+const toComponentArray = (value: unknown, length: number): Float32Array => {
+    const out = new Float32Array(length);
+    if (ArrayBuffer.isView(value)) {
+        const view = value as unknown as ArrayLike<number>;
+        for (let i = 0; i < length; i++) {
+            out[i] = view[i] ?? 0;
+        }
+    } else if (Array.isArray(value)) {
+        for (let i = 0; i < length; i++) {
+            out[i] = typeof value[i] === 'number' ? value[i] as number : 0;
+        }
+    }
+    return out;
+};
+
+export interface UniformRowProps {
+    entry: UniformListEntry;
+    mode: ColorMode;
+    error?: string;
+    onToggleMode: (name: string) => void;
+    onSetOverride: (name: string, value: number | ArrayLike<number>) => void;
+    onClearOverride: (name: string) => void;
+}
+
+export const UniformRow = ({
+    entry,
+    mode,
+    error,
+    onToggleMode,
+    onSetOverride,
+    onClearOverride
+}: UniformRowProps): ReactElement => {
+    const resetButton = entry.overridden
+        ? (
+            <button type='button' onClick={() => { onClearOverride(entry.name) }} style={buttonStyle}>
+                reset
+            </button>
+        )
+        : null;
+
+    let control: ReactElement;
+    let modeToggle: ReactElement | null = null;
+
+    if (entry.type === 'float' || entry.type === 'int') {
+        control = (
+            <div style={{ width: '96px' }}>
+                <NumberField
+                    value={typeof entry.value === 'number' ? entry.value : 0}
+                    step={stepForType(entry.type, typeof entry.value === 'number' ? entry.value : 0)}
+                    ariaLabel={entry.name}
+                    onChange={value => { onSetOverride(entry.name, value) }}
+                />
+            </div>
+        );
+    } else if (entry.type === 'vec2') {
+        control = (
+            <VectorField
+                value={toComponentArray(entry.value, 2)}
+                length={2}
+                type={entry.type}
+                labels={DEFAULT_VECTOR_LABELS}
+                ariaLabelPrefix={entry.name}
+                onChange={next => { onSetOverride(entry.name, next) }}
+            />
+        );
+    } else if (entry.type === 'vec3' || entry.type === 'vec4') {
+        const length = entry.type === 'vec4' ? 4 : 3;
+        const colorEligible = mode === 'color' || (mode === 'auto' && isColorUniform(entry.name));
+        control = colorEligible
+            ? (
+                <ColorField
+                    value={toComponentArray(entry.value, length)}
+                    type={entry.type}
+                    ariaLabelPrefix={entry.name}
+                    onChange={next => { onSetOverride(entry.name, next) }}
+                />
+            )
+            : (
+                <VectorField
+                    value={toComponentArray(entry.value, length)}
+                    length={length}
+                    type={entry.type}
+                    labels={DEFAULT_VECTOR_LABELS}
+                    ariaLabelPrefix={entry.name}
+                    onChange={next => { onSetOverride(entry.name, next) }}
+                />
+            );
+        modeToggle = (
+            <button type='button' onClick={() => { onToggleMode(entry.name) }} style={buttonStyle}>
+                {colorEligible ? 'as vector' : 'as color'}
+            </button>
+        );
+    } else {
+        control = (
+            <span style={{ fontSize: '11px', color: COLORS.dim }}>
+                {entry.type} {'\u00b7'} {formatReadonlyValue(entry.value)}
+            </span>
+        );
+    }
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            <div style={rowStyle}>
+                <span style={{ color: entry.overridden ? COLORS.accent : COLORS.dim, fontSize: '11px' }}>
+                    {entry.overridden ? '\u25cf ' : ''}{entry.name}
+                </span>
+                {modeToggle}
+            </div>
+            <div style={{ display: 'flex', gap: '4px', alignItems: 'flex-start' }}>
+                {control}
+                {resetButton}
+            </div>
+            {error ? <div style={{ fontSize: '10px', color: COLORS.danger }}>{error}</div> : null}
+        </div>
+    );
+};

--- a/src/react/devtools/lib/thumbnail.ts
+++ b/src/react/devtools/lib/thumbnail.ts
@@ -1,0 +1,28 @@
+import type { FramebufferReadResult } from '@/core/managers/FBOManager';
+import { flipImageRows } from '@/react/devtools/lib/flipRows';
+
+export function paintFramebufferThumbnail(
+    canvas: HTMLCanvasElement,
+    scratchRef: { current: HTMLCanvasElement | null },
+    result: FramebufferReadResult
+): void {
+    const flipped = flipImageRows(result.pixels, result.width, result.height);
+    let scratch = scratchRef.current;
+    if (!scratch) {
+        scratch = document.createElement('canvas');
+        scratchRef.current = scratch;
+    }
+    scratch.width = result.width;
+    scratch.height = result.height;
+    const scratchCtx = scratch.getContext('2d');
+    if (!scratchCtx) {
+        return;
+    }
+    scratchCtx.putImageData(new ImageData(flipped, result.width, result.height), 0, 0);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+        return;
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(scratch, 0, 0, result.width, result.height, 0, 0, canvas.width, canvas.height);
+}

--- a/src/react/devtools/panels/FramebuffersPanel.tsx
+++ b/src/react/devtools/panels/FramebuffersPanel.tsx
@@ -2,8 +2,8 @@ import type { ReactElement } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { WebGLManager } from '@/core';
-import { flipImageRows } from '@/react/devtools/lib/flipRows';
 import { activeButtonStyle, buttonStyle, COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
+import { paintFramebufferThumbnail } from '@/react/devtools/lib/thumbnail';
 
 interface FramebuffersPanelProps {
     framebufferIds: string[];
@@ -79,25 +79,7 @@ export const FramebuffersPanel = ({ framebufferIds, manager, captureTick }: Fram
             if (!canvas) {
                 continue;
             }
-            const flipped = flipImageRows(result.pixels, result.width, result.height);
-            let scratch = scratchRef.current;
-            if (!scratch) {
-                scratch = document.createElement('canvas');
-                scratchRef.current = scratch;
-            }
-            scratch.width = result.width;
-            scratch.height = result.height;
-            const scratchCtx = scratch.getContext('2d');
-            if (!scratchCtx) {
-                continue;
-            }
-            scratchCtx.putImageData(new ImageData(flipped, result.width, result.height), 0, 0);
-            const ctx = canvas.getContext('2d');
-            if (!ctx) {
-                continue;
-            }
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            ctx.drawImage(scratch, 0, 0, result.width, result.height, 0, 0, canvas.width, canvas.height);
+            paintFramebufferThumbnail(canvas, scratchRef, result);
         }
     }, [captureTick]);
 

--- a/src/react/devtools/panels/GraphPanel.tsx
+++ b/src/react/devtools/panels/GraphPanel.tsx
@@ -1,0 +1,290 @@
+import type { ReactElement } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import type { GraphTopology } from '@/core/lib/graphPlanning';
+import type { EngineHandle, GraphDebugPort } from '@/react/devtools/beacon';
+import { listEngines } from '@/react/devtools/beacon';
+import { isColorUniform } from '@/react/devtools/lib/detectColor';
+import { activeButtonStyle, buttonStyle, COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
+import { paintFramebufferThumbnail } from '@/react/devtools/lib/thumbnail';
+import type { ColorMode } from '@/react/devtools/lib/UniformRow';
+import { UniformRow } from '@/react/devtools/lib/UniformRow';
+
+interface GraphPanelProps {
+    engine: EngineHandle;
+    captureTick: number;
+}
+
+const THUMBNAIL_WIDTH = 96;
+const THUMBNAIL_HEIGHT = 96;
+const CAPTURE_MAX_SIZE = 1024;
+
+const placeholderStyle = {
+    width: `${THUMBNAIL_WIDTH}px`,
+    height: `${THUMBNAIL_HEIGHT}px`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center' as const,
+    fontSize: '9px',
+    color: COLORS.warn,
+    border: `1px dashed ${COLORS.border}`,
+    borderRadius: '4px',
+    padding: '4px',
+    boxSizing: 'border-box' as const
+};
+
+const thumbnailCanvasStyle = {
+    width: `${THUMBNAIL_WIDTH}px`,
+    height: `${THUMBNAIL_HEIGHT}px`,
+    display: 'block',
+    background: 'rgba(0,0,0,0.25)',
+    borderRadius: '4px'
+};
+
+const nodeBlockStyle = {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '6px',
+    padding: '6px',
+    border: `1px solid ${COLORS.border}`,
+    borderRadius: '4px'
+};
+
+const dimsLabel = (width: number, height: number): string =>
+    width > 0 && height > 0 ? `${width}x${height}` : 'canvas';
+
+const trackKey = (nodeId: string, name: string): string => `${nodeId}\u0001${name}`;
+
+export const GraphPanel = ({ engine, captureTick }: GraphPanelProps): ReactElement | null => {
+    const graph = engine.graph;
+    const engineId = engine.id;
+
+    const [captureOn, setCaptureOn] = useState<Record<string, boolean>>({});
+    const [unreadableByNode, setUnreadableByNode] = useState<Record<string, string>>({});
+    const [errorsByKey, setErrorsByKey] = useState<Record<string, string>>({});
+    const [colorModeByKey, setColorModeByKey] = useState<Record<string, ColorMode>>({});
+
+    const canvasRefs = useRef<Map<string, HTMLCanvasElement>>(new Map());
+    const scratchRef = useRef<HTMLCanvasElement | null>(null);
+    const trackedRef = useRef<Map<string, Set<string>>>(new Map());
+
+    const graphRef = useRef<GraphDebugPort | undefined>(graph);
+    const captureOnRef = useRef(captureOn);
+    const topologyRef = useRef<GraphTopology | null>(null);
+
+    useEffect(() => {
+        graphRef.current = graph;
+        captureOnRef.current = captureOn;
+    });
+
+    useEffect(() => {
+        const currentGraph = graphRef.current;
+        if (!currentGraph) {
+            return;
+        }
+        const topology = topologyRef.current;
+        if (!topology) {
+            return;
+        }
+        for (const node of topology.nodes) {
+            if (!captureOnRef.current[node.id]) {
+                continue;
+            }
+            const result = currentGraph.readNode(node.id, CAPTURE_MAX_SIZE);
+            if ('unreadable' in result) {
+                setUnreadableByNode(prev =>
+                    prev[node.id] === result.unreadable ? prev : { ...prev, [node.id]: result.unreadable }
+                );
+                continue;
+            }
+            setUnreadableByNode(prev => {
+                if (!(node.id in prev)) {
+                    return prev;
+                }
+                const next = { ...prev };
+                Reflect.deleteProperty(next, node.id);
+                return next;
+            });
+            const canvas = canvasRefs.current.get(node.id);
+            if (!canvas) {
+                continue;
+            }
+            paintFramebufferThumbnail(canvas, scratchRef, result);
+        }
+    }, [captureTick]);
+
+    useEffect(() => () => {
+        const handle = listEngines().find(candidate => candidate.id === engineId);
+        const port = handle?.graph;
+        if (port) {
+            const known = new Set(port.topology().nodes.map(node => node.id));
+            for (const [nodeId, names] of trackedRef.current) {
+                if (!known.has(nodeId)) {
+                    continue;
+                }
+                const nodePort = port.nodeUniforms(nodeId);
+                for (const name of names) {
+                    if (nodePort.list().some(entry => entry.name === name && entry.overridden)) {
+                        nodePort.clearOverride(name);
+                    }
+                }
+            }
+        }
+        trackedRef.current = new Map();
+    }, [engineId]);
+
+    if (!graph) {
+        return null;
+    }
+
+    const topology = graph.topology();
+    topologyRef.current = topology;
+
+    const toggleCapture = (nodeId: string): void => {
+        setCaptureOn(prev => ({ ...prev, [nodeId]: !prev[nodeId] }));
+    };
+
+    const track = (nodeId: string, name: string): void => {
+        const names = trackedRef.current.get(nodeId) ?? new Set<string>();
+        names.add(name);
+        trackedRef.current.set(nodeId, names);
+    };
+
+    const setError = (key: string, message: string): void => {
+        setErrorsByKey(prev => ({ ...prev, [key]: message }));
+    };
+
+    const clearError = (key: string): void => {
+        setErrorsByKey(prev => {
+            if (!(key in prev)) {
+                return prev;
+            }
+            const next = { ...prev };
+            Reflect.deleteProperty(next, key);
+            return next;
+        });
+    };
+
+    const handleSetOverride = (nodeId: string, name: string, value: number | ArrayLike<number>): void => {
+        const key = trackKey(nodeId, name);
+        try {
+            graph.nodeUniforms(nodeId).setOverride(name, value);
+            track(nodeId, name);
+            clearError(key);
+        } catch (error) {
+            setError(key, error instanceof Error ? error.message : String(error));
+        }
+    };
+
+    const handleClearOverride = (nodeId: string, name: string): void => {
+        const key = trackKey(nodeId, name);
+        try {
+            graph.nodeUniforms(nodeId).clearOverride(name);
+            clearError(key);
+        } catch (error) {
+            setError(key, error instanceof Error ? error.message : String(error));
+        }
+    };
+
+    const handleToggleMode = (nodeId: string, name: string): void => {
+        const key = trackKey(nodeId, name);
+        setColorModeByKey(prev => {
+            const current = prev[key] ?? 'auto';
+            const currentlyColor = current === 'color' || (current === 'auto' && isColorUniform(name));
+            const next: ColorMode = currentlyColor ? 'number' : 'color';
+            return { ...prev, [key]: next };
+        });
+    };
+
+    return (
+        <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>graph</div>
+            <div style={{ fontSize: '10px', color: COLORS.warn }}>
+                capture stalls the GPU pipeline {'\u2014'} perturbs timing; thumbnails draw at node aspect
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                {topology.nodes.map(node => {
+                    const uniforms = graph.nodeUniforms(node.id).list();
+                    const capturing = captureOn[node.id] ?? false;
+                    const unreadable = unreadableByNode[node.id];
+                    return (
+                        <div key={node.id} style={nodeBlockStyle}>
+                            <div style={rowStyle}>
+                                <span style={{ fontSize: '11px', color: COLORS.text, fontWeight: 600 }}>
+                                    {node.id}
+                                </span>
+                                <span style={{ fontSize: '10px', color: COLORS.dim }}>
+                                    {dimsLabel(node.width, node.height)}
+                                </span>
+                            </div>
+                            {node.edges.map(edge => (
+                                <div
+                                    key={`${edge.samplerName}\u0001${edge.childId}`}
+                                    style={{ fontSize: '10px', color: COLORS.dim }}
+                                >
+                                    {'\u2192'} {edge.childId} ({edge.samplerName})
+                                </div>
+                            ))}
+                            {node.sources.map(source => (
+                                <div
+                                    key={`${source.samplerName}\u0001${source.sourceId}`}
+                                    style={{ fontSize: '10px', color: COLORS.dim }}
+                                >
+                                    src: {source.sourceId} ({source.samplerName})
+                                </div>
+                            ))}
+                            {uniforms.length > 0
+                                ? (
+                                    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                                        {uniforms.map(entry => (
+                                            <UniformRow
+                                                key={entry.name}
+                                                entry={entry}
+                                                mode={colorModeByKey[trackKey(node.id, entry.name)] ?? 'auto'}
+                                                error={errorsByKey[trackKey(node.id, entry.name)]}
+                                                onToggleMode={name => { handleToggleMode(node.id, name) }}
+                                                onSetOverride={(name, value) => { handleSetOverride(node.id, name, value) }}
+                                                onClearOverride={name => { handleClearOverride(node.id, name) }}
+                                            />
+                                        ))}
+                                    </div>
+                                )
+                                : null}
+                            <div style={rowStyle}>
+                                <span style={{ fontSize: '10px', color: COLORS.dim }}>output</span>
+                                <button
+                                    type='button'
+                                    onClick={() => { toggleCapture(node.id) }}
+                                    style={capturing ? activeButtonStyle : buttonStyle}
+                                >
+                                    {capturing ? 'capturing' : 'capture'}
+                                </button>
+                            </div>
+                            {capturing
+                                ? (
+                                    unreadable
+                                        ? <div style={placeholderStyle}>{unreadable}</div>
+                                        : (
+                                            <canvas
+                                                ref={el => {
+                                                    if (el) {
+                                                        canvasRefs.current.set(node.id, el);
+                                                    } else {
+                                                        canvasRefs.current.delete(node.id);
+                                                    }
+                                                }}
+                                                width={THUMBNAIL_WIDTH}
+                                                height={THUMBNAIL_HEIGHT}
+                                                style={thumbnailCanvasStyle}
+                                            />
+                                        )
+                                )
+                                : null}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/src/react/devtools/panels/UniformsPanel.tsx
+++ b/src/react/devtools/panels/UniformsPanel.tsx
@@ -3,144 +3,15 @@ import { useEffect, useRef, useState } from 'react';
 
 import type { EngineHandle } from '@/react/devtools/beacon';
 import { listEngines } from '@/react/devtools/beacon';
-import { ColorField } from '@/react/devtools/controls/ColorField';
-import { NumberField } from '@/react/devtools/controls/NumberField';
-import { DEFAULT_VECTOR_LABELS, VectorField } from '@/react/devtools/controls/VectorField';
 import { isColorUniform } from '@/react/devtools/lib/detectColor';
-import { stepForType } from '@/react/devtools/lib/step';
 import { activeButtonStyle, buttonStyle, COLORS, rowStyle, sectionStyle, sectionTitleStyle } from '@/react/devtools/lib/theme';
-import type { UniformDebugPort, UniformListEntry } from '@/react/lib/liveUniformUpdaters';
+import type { ColorMode } from '@/react/devtools/lib/UniformRow';
+import { UniformRow } from '@/react/devtools/lib/UniformRow';
+import type { UniformDebugPort } from '@/react/lib/liveUniformUpdaters';
 
 interface UniformsPanelProps {
     engine: EngineHandle | null;
 }
-
-type ColorMode = 'auto' | 'color' | 'number';
-
-const formatReadonlyValue = (value: unknown): string => {
-    if (typeof value === 'function') {
-        return '\u0192()';
-    }
-    if (typeof value === 'number') {
-        return value.toFixed(3);
-    }
-    if (ArrayBuffer.isView(value)) {
-        return Array.from(value as unknown as ArrayLike<number>)
-            .map(component => component.toFixed(2))
-            .join(', ');
-    }
-    return String(value);
-};
-
-const toComponentArray = (value: unknown, length: number): Float32Array => {
-    const out = new Float32Array(length);
-    if (ArrayBuffer.isView(value)) {
-        const view = value as unknown as ArrayLike<number>;
-        for (let i = 0; i < length; i++) {
-            out[i] = view[i] ?? 0;
-        }
-    } else if (Array.isArray(value)) {
-        for (let i = 0; i < length; i++) {
-            out[i] = typeof value[i] === 'number' ? value[i] as number : 0;
-        }
-    }
-    return out;
-};
-
-interface UniformRowProps {
-    entry: UniformListEntry;
-    mode: ColorMode;
-    error?: string;
-    onToggleMode: (name: string) => void;
-    onSetOverride: (name: string, value: number | ArrayLike<number>) => void;
-    onClearOverride: (name: string) => void;
-}
-
-const UniformRow = ({ entry, mode, error, onToggleMode, onSetOverride, onClearOverride }: UniformRowProps): ReactElement => {
-    const resetButton = entry.overridden
-        ? (
-            <button type='button' onClick={() => { onClearOverride(entry.name) }} style={buttonStyle}>
-                reset
-            </button>
-        )
-        : null;
-
-    let control: ReactElement;
-    let modeToggle: ReactElement | null = null;
-
-    if (entry.type === 'float' || entry.type === 'int') {
-        control = (
-            <div style={{ width: '96px' }}>
-                <NumberField
-                    value={typeof entry.value === 'number' ? entry.value : 0}
-                    step={stepForType(entry.type, typeof entry.value === 'number' ? entry.value : 0)}
-                    ariaLabel={entry.name}
-                    onChange={value => { onSetOverride(entry.name, value) }}
-                />
-            </div>
-        );
-    } else if (entry.type === 'vec2') {
-        control = (
-            <VectorField
-                value={toComponentArray(entry.value, 2)}
-                length={2}
-                type={entry.type}
-                labels={DEFAULT_VECTOR_LABELS}
-                ariaLabelPrefix={entry.name}
-                onChange={next => { onSetOverride(entry.name, next) }}
-            />
-        );
-    } else if (entry.type === 'vec3' || entry.type === 'vec4') {
-        const length = entry.type === 'vec4' ? 4 : 3;
-        const colorEligible = mode === 'color' || (mode === 'auto' && isColorUniform(entry.name));
-        control = colorEligible
-            ? (
-                <ColorField
-                    value={toComponentArray(entry.value, length)}
-                    type={entry.type}
-                    ariaLabelPrefix={entry.name}
-                    onChange={next => { onSetOverride(entry.name, next) }}
-                />
-            )
-            : (
-                <VectorField
-                    value={toComponentArray(entry.value, length)}
-                    length={length}
-                    type={entry.type}
-                    labels={DEFAULT_VECTOR_LABELS}
-                    ariaLabelPrefix={entry.name}
-                    onChange={next => { onSetOverride(entry.name, next) }}
-                />
-            );
-        modeToggle = (
-            <button type='button' onClick={() => { onToggleMode(entry.name) }} style={buttonStyle}>
-                {colorEligible ? 'as vector' : 'as color'}
-            </button>
-        );
-    } else {
-        control = (
-            <span style={{ fontSize: '11px', color: COLORS.dim }}>
-                {entry.type} {'\u00b7'} {formatReadonlyValue(entry.value)}
-            </span>
-        );
-    }
-
-    return (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-            <div style={rowStyle}>
-                <span style={{ color: entry.overridden ? COLORS.accent : COLORS.dim, fontSize: '11px' }}>
-                    {entry.overridden ? '\u25cf ' : ''}{entry.name}
-                </span>
-                {modeToggle}
-            </div>
-            <div style={{ display: 'flex', gap: '4px', alignItems: 'flex-start' }}>
-                {control}
-                {resetButton}
-            </div>
-            {error ? <div style={{ fontSize: '10px', color: COLORS.danger }}>{error}</div> : null}
-        </div>
-    );
-};
 
 export const UniformsPanel = ({ engine }: UniformsPanelProps): ReactElement | null => {
     const [errorsByName, setErrorsByName] = useState<Record<string, string>>({});

--- a/src/react/hooks/usePingPongPasses.ts
+++ b/src/react/hooks/usePingPongPasses.ts
@@ -91,8 +91,11 @@ export const usePingPongPasses = ({
     ]);
 
     const port = useMemo(
-        () => combineUniformDebugPorts([primary.port, secondary.port]),
-        [primary.port, secondary.port]
+        () => combineUniformDebugPorts([
+            { nodeId: programId, port: primary.port },
+            { nodeId: secondaryProgramId ?? `${programId}-secondary`, port: secondary.port }
+        ]),
+        [primary.port, secondary.port, programId, secondaryProgramId]
     );
 
     const invalidation = useMemo(

--- a/src/react/hooks/useShaderGraph.ts
+++ b/src/react/hooks/useShaderGraph.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import type { FrameInvalidation } from '@/core/lib/frameInvalidation';
 import { combineFrameInvalidation } from '@/core/lib/frameInvalidation';
-import type { GraphPlan, ShaderNode } from '@/core/lib/graphPlanning';
+import type { GraphPlan, GraphTopology, ShaderNode } from '@/core/lib/graphPlanning';
 import { planGraph, toRenderPasses } from '@/core/lib/graphPlanning';
 import { useMotionGate } from '@/react/hooks/useMotionGate';
 import type { CapturesAreNonReproducible } from '@/react/lib/captureLiveness';
@@ -26,12 +26,18 @@ export interface ShaderGraphOptions {
     saveData?: MotionPolicy;
 }
 
+export interface GraphDebugSource {
+    topology: () => GraphTopology;
+    nodeUniforms: (nodeId: string) => UniformDebugPort;
+}
+
 export interface ShaderGraphResult {
     programConfigs: Record<string, ShaderProgramConfig>;
     passes: RenderPass[];
     framebuffers: Record<string, FramebufferOptions>;
     textureSources: TextureSource[];
     port: UniformDebugPort;
+    graphDebug: GraphDebugSource;
     invalidation: FrameInvalidation;
     capturesAreNonReproducible: CapturesAreNonReproducible;
 }
@@ -49,7 +55,8 @@ function sameRuntimes(a: UniformRuntime[], b: UniformRuntime[]): boolean {
 function buildResult(
     plan: GraphPlan,
     runtimes: UniformRuntime[],
-    updaters: Record<string, UniformUpdaterDef[]>
+    updaters: Record<string, UniformUpdaterDef[]>,
+    graphDebug: GraphDebugSource
 ): ShaderGraphResult {
     const capturesAreNonReproducible: CapturesAreNonReproducible = () => {
         for (const runtime of runtimes) {
@@ -71,7 +78,10 @@ function buildResult(
         passes: toRenderPasses(plan, nodeId => passUniformsFrom(updaters[nodeId])),
         framebuffers: plan.framebuffers,
         textureSources: plan.sources,
-        port: combineUniformDebugPorts(runtimes.map(runtime => runtime.port)),
+        port: combineUniformDebugPorts(
+            plan.passes.map((pass, index) => ({ nodeId: pass.nodeId, port: runtimes[index].port }))
+        ),
+        graphDebug,
         invalidation: combineFrameInvalidation([
             ...runtimes.map(runtime => runtime.invalidation),
             ...plan.sources.map(source => source.invalidation)
@@ -88,6 +98,25 @@ export const useShaderGraph = (root: ShaderNode, options?: ShaderGraphOptions): 
 
     const runtimesRef = useRef(new Map<string, UniformRuntime>());
     const runtimes = runtimesRef.current;
+
+    const topologyRef = useRef(plan.topology);
+    topologyRef.current = plan.topology;
+
+    const graphDebugRef = useRef<GraphDebugSource | null>(null);
+    graphDebugRef.current ??= {
+        topology: () => topologyRef.current,
+        nodeUniforms: (nodeId: string): UniformDebugPort => {
+            const runtime = runtimesRef.current.get(nodeId);
+            if (!runtime) {
+                const known = [...runtimesRef.current.keys()].join(', ');
+                throw new Error(
+                    `micugl devtools: graph has no node "${nodeId}". Known node ids: ${known}.`
+                );
+            }
+            return runtime.port;
+        }
+    };
+    const graphDebug = graphDebugRef.current;
 
     const ordered: UniformRuntime[] = [];
     const updatersByNode: Record<string, UniformUpdaterDef[]> = {};
@@ -111,7 +140,7 @@ export const useShaderGraph = (root: ShaderNode, options?: ShaderGraphOptions): 
         : {
             key: structureKey,
             runtimes: ordered,
-            result: buildResult(plan, ordered, updatersByNode)
+            result: buildResult(plan, ordered, updatersByNode, graphDebug)
         };
     memoRef.current = memo;
 

--- a/src/react/lib/liveUniformUpdaters.test.ts
+++ b/src/react/lib/liveUniformUpdaters.test.ts
@@ -372,19 +372,33 @@ describe('combineUniformDebugPorts', () => {
         const refsA = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
         const refsB = createPortRefs([{ name: 'u_b', type: 'float' }], { u_b: 2 });
         const combined = combineUniformDebugPorts([
-            createUniformDebugPort(refsA),
-            createUniformDebugPort(refsB)
+            { nodeId: 'a', port: createUniformDebugPort(refsA) },
+            { nodeId: 'b', port: createUniformDebugPort(refsB) }
         ]);
 
         expect(combined.list().map(entry => entry.name)).toEqual(['u_a', 'u_b']);
+    });
+
+    it('stamps each listed entry with its owning node id', () => {
+        const refsA = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
+        const refsB = createPortRefs([{ name: 'u_b', type: 'float' }], { u_b: 2 });
+        const combined = combineUniformDebugPorts([
+            { nodeId: 'alpha', port: createUniformDebugPort(refsA) },
+            { nodeId: 'beta', port: createUniformDebugPort(refsB) }
+        ]);
+
+        expect(combined.list().map(entry => [entry.name, entry.nodeId])).toEqual([
+            ['u_a', 'alpha'],
+            ['u_b', 'beta']
+        ]);
     });
 
     it('setOverride routes to the port that owns the uniform', () => {
         const refsA = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
         const refsB = createPortRefs([{ name: 'u_b', type: 'float' }], { u_b: 2 });
         const combined = combineUniformDebugPorts([
-            createUniformDebugPort(refsA),
-            createUniformDebugPort(refsB)
+            { nodeId: 'a', port: createUniformDebugPort(refsA) },
+            { nodeId: 'b', port: createUniformDebugPort(refsB) }
         ]);
 
         combined.setOverride('u_b', 9);
@@ -397,8 +411,8 @@ describe('combineUniformDebugPorts', () => {
         const refsA = createPortRefs([{ name: 'u_time', type: 'float' }], { u_time: 1 });
         const refsB = createPortRefs([{ name: 'u_time', type: 'float' }], { u_time: 1 });
         const combined = combineUniformDebugPorts([
-            createUniformDebugPort(refsA),
-            createUniformDebugPort(refsB)
+            { nodeId: 'a', port: createUniformDebugPort(refsA) },
+            { nodeId: 'b', port: createUniformDebugPort(refsB) }
         ]);
 
         combined.setOverride('u_time', 7);
@@ -409,7 +423,7 @@ describe('combineUniformDebugPorts', () => {
 
     it('throws for a uniform unknown to every port', () => {
         const refsA = createPortRefs([{ name: 'u_a', type: 'float' }], { u_a: 1 });
-        const combined = combineUniformDebugPorts([createUniformDebugPort(refsA)]);
+        const combined = combineUniformDebugPorts([{ nodeId: 'a', port: createUniformDebugPort(refsA) }]);
 
         expect(() => { combined.setOverride('u_missing', 1) }).toThrow(/unknown uniform/);
         expect(() => { combined.clearOverride('u_missing') }).toThrow(/unknown uniform/);

--- a/src/react/lib/liveUniformUpdaters.ts
+++ b/src/react/lib/liveUniformUpdaters.ts
@@ -28,6 +28,7 @@ export interface UniformListEntry {
     type: UniformType;
     value: unknown;
     overridden: boolean;
+    nodeId?: string;
 }
 
 export interface UniformDebugPort {
@@ -118,25 +119,32 @@ export function createUniformDebugPort(options: UniformDebugPortOptions): Unifor
     };
 }
 
-export function combineUniformDebugPorts(ports: UniformDebugPort[]): UniformDebugPort {
-    const portsWithName = (name: string): UniformDebugPort[] =>
-        ports.filter(port => port.list().some(entry => entry.name === name));
+export interface AttributedDebugPort {
+    nodeId: string;
+    port: UniformDebugPort;
+}
+
+export function combineUniformDebugPorts(entries: AttributedDebugPort[]): UniformDebugPort {
+    const entriesWithName = (name: string): AttributedDebugPort[] =>
+        entries.filter(entry => entry.port.list().some(item => item.name === name));
 
     return {
-        list: () => ports.flatMap(port => port.list()),
+        list: () => entries.flatMap(entry =>
+            entry.port.list().map(item => ({ ...item, nodeId: entry.nodeId }))
+        ),
         setOverride: (name, value) => {
-            const targets = portsWithName(name);
+            const targets = entriesWithName(name);
             if (targets.length === 0) {
                 throw new Error(`micugl devtools: unknown uniform "${name}"`);
             }
-            targets.forEach(port => { port.setOverride(name, value) });
+            targets.forEach(entry => { entry.port.setOverride(name, value) });
         },
         clearOverride: name => {
-            const targets = portsWithName(name);
+            const targets = entriesWithName(name);
             if (targets.length === 0) {
                 throw new Error(`micugl devtools: unknown uniform "${name}"`);
             }
-            targets.forEach(port => { port.clearOverride(name) });
+            targets.forEach(entry => { entry.port.clearOverride(name) });
         }
     };
 }


### PR DESCRIPTION
Track 5 slice C3: the composition DAG inspector, with the data layer as the public API (design call 2 from the 2026-07-13 design pass).

## What ships

- **`EngineHandle.graph?: GraphDebugPort`** (`@experimental`, beacon gains types only):
  - `topology()` — the plan `planGraph` actually emitted (never a parallel reconstruction).
  - `readNode(nodeId, maxSize?)` — per-node pixels via `FBOManager.debugReadFramebuffer`; the root renders the current loop-clock frame and reads the canvas in the same task (`preserveDrawingBuffer:false` makes out-of-band reads return black — probe-verified). Raw bottom-up rows for root and children alike; one flip location (the devtools thumbnail helper).
  - `nodeUniforms(nodeId)` — the per-node `UniformDebugPort`, overrides included. Fixes #65's filed inspector bug: per-node targeting now exists.
- **Attributed combined port**: `UniformListEntry.nodeId` (optional, additive). The graph's combined port stamps every entry with its node, so `list()` duplicates are now attributed; `setOverride` keeps the documented fan-across-declaring-nodes semantics as the name-addressed convenience.
- **Live handle getters** (#65's filed bug b): `handle.uniforms` and `handle.graph` read their refs at call time instead of snapshotting at init-effect time — on both engines. Probing showed the filed strand is not reachable today (a child rewire reorders the unsorted content keys and re-inits the whole engine); the getters close the latent class and make a future content-key sort safe. Follow-up filed below.
- **Devtools `GraphPanel`**, consuming ONLY the port (dogfooded): topology tree with dims/edges/source leaves, per-node opt-in thumbnails through `readNode`, per-node uniform controls through `nodeUniforms`. For graph engines it replaces the flat uniforms/framebuffers panels. `UniformRow` and the thumbnail draw were extracted (moved, not forked) and shared.
- **`?scene=graph-inspector`** (two nodes sharing `u_gain` at distinct values — the attribution demo) and **`?scene=graph-pixels`** backing the kept live spec.
- **`bench/graphReadNode.spec.ts`** (Playwright, local): proves attribution with real pixels — `readNode('a')` reads the red node, `readNode('b')` the blue one, row order bottom-up. Watched failing (swapped ids) before trusting green. Joins the counters project: **the local counters gate is now 20 specs** (was 19).
- README "Inspecting a graph" (console walkthrough, fan vs node-scoped, pixel format/row order pinned).

## Review record

Full protocol: probe pass -> plan -> Opus implementer -> double read-only Opus review -> apply -> standalone edit-empowered pass. 1187 tests (was 1165).

- The probe pass **corrected the plan's own premise**: the filed strand scenario re-inits the engine rather than stranding the handle (unsorted content-key serialization + DFS reorder), so the liveness anchor test uses the renderOptions-only rebuild (the reachable rebuild-without-re-init) with a manager-identity assertion to stay non-vacuous. Also settled: root reads must be same-task render-then-read.
- The implementer caught a plan error (`combineUniformDebugPorts` has a second caller in `usePingPongPasses`) and redesigned two tests whose specified reverts could not discriminate.
- Correctness review proved the root-read clock is exact (`frameToMs(getFrame())` — no reduced-motion poster repaint at a different time) and found the one real defect: no `try/finally` around the root render-then-read, so a context-lost read threw a raw error and left FRAMEBUFFER_BINDING/viewport unrestored. Fixed with an `isContextLost` pre-check + catch/finally grace (b77dd74); reverts observed failing.
- The apply agent rejected one orchestrator fix-list item with proof (the suggested T6 strengthening was vacuous as specified; the committed assertion already fails under the snapshot revert).
- The standalone pass added the only missing guard coverage (root maxSize refusal — a hand-written message that could drift from the FBO path) and cleared the demand-mode/multi-engine/fan-cleanup attack surfaces.

Deliberately kept: three type-forced null-narrowing guards (TypeScript-forced, degrade correctly, the ref re-read they wrap is load-bearing).

## Follow-ups filed (not fixed here)

- Order-sensitive content keys: a wiring-only graph rewire tears down and rebuilds the entire GL context (new `WebGLManager`) because `programConfigsContentKey`/`framebuffersContentKey` serialize in insertion order. Sorting would fix the perf — and this PR's live getters are what make that change safe.
- `GraphPanel` UI-state bleed when switching between two graph engines (un-keyed panel; matches pre-existing flat-panel behavior — fix all three together).
- Root `readNode`'s catch labels any render/read throw as `engine destroyed`; a non-teardown GL error is mislabeled as a lifecycle race.

## Manual pass (Micu)

`bun run dev` then:
- `?scene=graph-inspector`: tree shows glow/grain/composite with dims and the `src:` leaf; scrub `u_gain` on ONE node — only that node's look changes; from the console, `micugl.listEngines()[0].uniforms.setOverride('u_gain', 1)` moves BOTH; per-node `capture` thumbnails match their nodes; root capture matches the canvas.
- `?scene=shader-graph`: still composites (screenshot judged in-session; never previously eyeballed).
