### PR TITLE
testing: promote shared test fixtures into src/testing/fixtures

### DIFF
--- a/src/core/managers/TextureManager.test.ts
+++ b/src/core/managers/TextureManager.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
 import {
     GL_CLAMP_TO_EDGE,
     GL_LINEAR,
@@ -22,51 +21,10 @@ import { resolveSourceTextureOptions } from '@/core/lib/sourceTextureOptions';
 import { TextureManager } from '@/core/managers/TextureManager';
 import type { GLStubConfig, GLStubHandle } from '@/testing';
 import { createGLStub } from '@/testing';
-import type {
-    SourceTextureOptions,
-    TextureSource,
-    TextureUploadSource
-} from '@/types';
-
-const video = (videoWidth: number, videoHeight: number): TextureUploadSource =>
-    ({ videoWidth, videoHeight }) as unknown as TextureUploadSource;
-
-const bitmap = (width: number, height: number): TextureUploadSource =>
-    ({ width, height }) as unknown as TextureUploadSource;
+import { bitmap, createSource, video } from '@/testing/fixtures';
 
 const indexOfCall = (calls: readonly { name: string }[], name: string): number =>
     calls.findIndex(call => call.name === name);
-
-interface SourceHandle {
-    source: TextureSource;
-    push: (frame: TextureUploadSource) => void;
-    withhold: () => void;
-    reoffer: () => void;
-}
-
-function createSource(id: string, options?: SourceTextureOptions): SourceHandle {
-    let frame: TextureUploadSource | null = null;
-    let offered = true;
-    let version = 0;
-
-    const source: TextureSource = {
-        id,
-        get version() { return version },
-        options: resolveSourceTextureOptions(options),
-        getFrame: () => (offered ? frame : null),
-        invalidation: createFrameInvalidation()
-    };
-
-    return {
-        source,
-        push: (next: TextureUploadSource) => {
-            frame = next;
-            version += 1;
-        },
-        withhold: () => { offered = false },
-        reoffer: () => { offered = true }
-    };
-}
 
 interface Setup extends GLStubHandle {
     manager: TextureManager;

--- a/src/core/systems/Postprocessing.test.ts
+++ b/src/core/systems/Postprocessing.test.ts
@@ -6,6 +6,7 @@ import type { PostProcessEffect } from '@/core/systems/Postprocessing';
 import { Postprocessing } from '@/core/systems/Postprocessing';
 import type { GLStubHandle } from '@/testing';
 import { createCanvasStub } from '@/testing';
+import { uploadsOf } from '@/testing/fixtures';
 import type { FramebufferOptions, UniformType } from '@/types';
 
 const WIDTH = 64;
@@ -40,14 +41,6 @@ function makeEffect(id: string, enabled: boolean): PostProcessEffect {
         uniforms: { amount: { type: 'float', value: 0.25 } },
         enabled
     };
-}
-
-function uploadsOf(stub: GLStubHandle, name: string): unknown[] {
-    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
-    if (location === null) {
-        return [];
-    }
-    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
 }
 
 describe('Postprocessing pass caching', () => {

--- a/src/core/systems/graphRender.test.ts
+++ b/src/core/systems/graphRender.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
 import { GL_TEXTURE0 } from '@/core/lib/glConstants';
 import type { ShaderNode } from '@/core/lib/graphPlanning';
 import { planGraph, shaderNode, toRenderPasses } from '@/core/lib/graphPlanning';
-import { resolveSourceTextureOptions } from '@/core/lib/sourceTextureOptions';
 import { WebGLManager } from '@/core/managers/WebGLManager';
 import { Passes } from '@/core/systems/Passes';
 import type { CanvasStubHandle, GLStubConfig } from '@/testing';
 import { createCanvasStub } from '@/testing';
-import type { RenderPass, ShaderProgramConfig, TextureSource, TextureUploadSource, UniformType } from '@/types';
+import { bitmap, createSource } from '@/testing/fixtures';
+import type { RenderPass, ShaderProgramConfig, TextureSource, UniformType } from '@/types';
 
 type UniformsFor = (nodeId: string) => RenderPass['uniforms'];
 
@@ -23,35 +22,6 @@ function gcfg(uniformNames: Record<string, UniformType> = {}): ShaderProgramConf
 }
 
 const f32 = (values: number[]): Float32Array => new Float32Array(values);
-
-const bitmap = (width: number, height: number): TextureUploadSource =>
-    ({ width, height }) as unknown as TextureUploadSource;
-
-interface SourceHandle {
-    source: TextureSource;
-    push: (frame: TextureUploadSource) => void;
-}
-
-function createSource(id: string): SourceHandle {
-    let frame: TextureUploadSource | null = null;
-    let version = 0;
-
-    const source: TextureSource = {
-        id,
-        get version() { return version },
-        options: resolveSourceTextureOptions(),
-        getFrame: () => frame,
-        invalidation: createFrameInvalidation()
-    };
-
-    return {
-        source,
-        push: (next: TextureUploadSource) => {
-            frame = next;
-            version += 1;
-        }
-    };
-}
 
 interface GraphSetup {
     stub: CanvasStubHandle;

--- a/src/core/uniformGuardPipeline.test.ts
+++ b/src/core/uniformGuardPipeline.test.ts
@@ -21,6 +21,7 @@ import {
 import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
 import type { GLStubConfig, GLStubHandle } from '@/testing';
 import { createCanvasStub, createGLStub } from '@/testing';
+import { uploadsOf } from '@/testing/fixtures';
 import type {
     RenderPass,
     ShaderProgramConfig,
@@ -66,14 +67,6 @@ function build(
     manager.createProgram(PROGRAM_ID, config);
     manager.setSize(WIDTH, HEIGHT, WIDTH, HEIGHT);
     return { manager, stub };
-}
-
-function uploadsOf(stub: GLStubHandle, name: string): unknown[] {
-    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
-    if (location === null) {
-        return [];
-    }
-    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
 }
 
 function uploadCallsOf(stub: GLStubHandle, name: string): string[] {

--- a/src/effects/Grain/Grain.test.tsx
+++ b/src/effects/Grain/Grain.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Grain } from '@/effects/Grain/Grain';
 import type { GLStubHandle } from '@/testing';
 import { createGLStub } from '@/testing';
+import { uploadsOf } from '@/testing/fixtures';
 import type { FrameQueue } from '@/testing/frameQueue';
 import { createFrameQueue } from '@/testing/frameQueue';
 import type { Vec3 } from '@/types';
@@ -50,11 +51,6 @@ async function mount(element: ReactElement): Promise<void> {
     });
 }
 
-function uploadsOf(name: string): unknown[] {
-    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
-    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
-}
-
 describe('Grain: real uniforms reach the GL stub and advance', () => {
     it('uploads the fixture colors and drives u_time forward across ticks', async () => {
         await mount(
@@ -74,17 +70,17 @@ describe('Grain: real uniforms reach the GL stub and advance', () => {
             act(() => { frames.tick(time) });
         }
 
-        const color = uploadsOf('u_color').map(value => Array.from(value as Float32Array));
+        const color = uploadsOf(stub, 'u_color').map(value => Array.from(value as Float32Array));
         expect(color.length).toBeGreaterThan(0);
         expect(color[0]).toEqual(Array.from(new Float32Array([0.09, 0.61, 0.37])));
 
-        const grainColor = uploadsOf('u_grainColor').map(value => Array.from(value as Float32Array));
+        const grainColor = uploadsOf(stub, 'u_grainColor').map(value => Array.from(value as Float32Array));
         expect(grainColor[0]).toEqual(Array.from(new Float32Array([0.88, 0.24, 0.66])));
 
-        const intensity = uploadsOf('u_intensity') as number[];
+        const intensity = uploadsOf(stub, 'u_intensity') as number[];
         expect(intensity).toContain(0.42);
 
-        const times = uploadsOf('u_time') as number[];
+        const times = uploadsOf(stub, 'u_time') as number[];
         expect(times.length).toBeGreaterThan(5);
         for (let i = 1; i < times.length; i++) {
             expect(times[i]).toBeGreaterThan(times[i - 1]);

--- a/src/effects/MeshGradient/MeshGradient.test.tsx
+++ b/src/effects/MeshGradient/MeshGradient.test.tsx
@@ -10,6 +10,7 @@ import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
 import { asContext, createFakeStream, FakeContext, latestAnalyser, LOW_HALF } from '@/react/lib/fakeWebAudio';
 import type { GLStubHandle } from '@/testing';
 import { createGLStub } from '@/testing';
+import { uploadsOf } from '@/testing/fixtures';
 import type { FrameQueue } from '@/testing/frameQueue';
 import { createFrameQueue } from '@/testing/frameQueue';
 import type { AudioSourceSpec, Frameloop, ShaderHandle, Vec3 } from '@/types';
@@ -92,13 +93,8 @@ async function mount(element: ReactElement): Promise<void> {
     });
 }
 
-function uploadsOf(name: string): unknown[] {
-    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
-    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
-}
-
 function timeUploads(): number[] {
-    return uploadsOf('u_time') as number[];
+    return uploadsOf(stub, 'u_time') as number[];
 }
 
 interface Fixture {
@@ -171,7 +167,7 @@ describe('MeshGradient: real uniforms reach the GL stub and advance', () => {
             act(() => { frames.tick(time) });
         }
 
-        const color0 = uploadsOf('u_color0').map(value => Array.from(value as Float32Array));
+        const color0 = uploadsOf(stub, 'u_color0').map(value => Array.from(value as Float32Array));
         expect(color0.length).toBeGreaterThan(0);
         expect(color0[0]).toEqual(Array.from(new Float32Array([0.13, 0.71, 0.29])));
 
@@ -271,7 +267,7 @@ describe('MeshGradient: reduced motion gates the audio reaction into a frozen po
 
         await mount(<GatedAudioScene probe={probe} deps={fixture.deps} />);
         act(() => { frames.tick(0) });
-        expect(uploadsOf('u_audioLevel')).toEqual([0]);
+        expect(uploadsOf(stub, 'u_audioLevel')).toEqual([0]);
         expect(frames.pending()).toBe(0);
 
         await act(async () => { await current(probe).start() });
@@ -286,7 +282,7 @@ describe('MeshGradient: reduced motion gates the audio reaction into a frozen po
             expect(frames.pending()).toBe(0);
         }
 
-        expect((uploadsOf('u_audioLevel') as number[]).every(value => value === 0)).toBe(true);
+        expect((uploadsOf(stub, 'u_audioLevel') as number[]).every(value => value === 0)).toBe(true);
         expect(timeUploads().length).toBe(frozenTimes);
     });
 });

--- a/src/react/components/base/BaseShaderComponent.audio.test.tsx
+++ b/src/react/components/base/BaseShaderComponent.audio.test.tsx
@@ -12,6 +12,7 @@ import type { AudioAnalyserDriverDeps } from '@/react/lib/audioAnalyserDriver';
 import { asContext, createFakeStream, FakeContext, latestAnalyser, LOW_HALF } from '@/react/lib/fakeWebAudio';
 import type { GLStubHandle } from '@/testing';
 import { createGLStub } from '@/testing';
+import { uploadsOf } from '@/testing/fixtures';
 import type { FrameQueue } from '@/testing/frameQueue';
 import { createFrameQueue } from '@/testing/frameQueue';
 import type { AudioSourceSpec, AudioUniformsOptions, Frameloop, ShaderProgramConfig } from '@/types';
@@ -92,17 +93,12 @@ async function mount(element: ReactElement): Promise<void> {
     });
 }
 
-function uploadsOf(name: string): unknown[] {
-    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
-    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
-}
-
 function levelUploads(): number[] {
-    return uploadsOf('u_audioLevel') as number[];
+    return uploadsOf(stub, 'u_audioLevel') as number[];
 }
 
 function latestBands(): number[] {
-    const calls = uploadsOf('u_audioBands');
+    const calls = uploadsOf(stub, 'u_audioBands');
     if (calls.length === 0) {
         throw new Error('u_audioBands has never been uploaded');
     }
@@ -225,7 +221,7 @@ describe('audio uniforms reaching GL through a mounted BaseShaderComponent (real
         for (let time = 16; time <= 160; time += 16) {
             act(() => { frames.tick(time) });
         }
-        expect(uploadsOf('u_audioBands').every(value => Number.isFinite(value))).toBe(true);
+        expect(uploadsOf(stub, 'u_audioBands').every(value => Number.isFinite(value))).toBe(true);
 
         await mount(<Scene probe={probe} deps={fixture.deps} bands={4} />);
         fixture.hear();

--- a/src/react/lib/transitionPipeline.test.ts
+++ b/src/react/lib/transitionPipeline.test.ts
@@ -20,6 +20,7 @@ import {
 import { createTransitionRuntime } from '@/react/lib/transitionRuntime';
 import type { GLStubConfig, GLStubHandle } from '@/testing';
 import { createCanvasStub } from '@/testing';
+import { uploadsOf } from '@/testing/fixtures';
 import type { UniformParam } from '@/types';
 
 const PROGRAM_ID = 'transition-demo';
@@ -36,11 +37,6 @@ const CONFIG = createShaderConfig({
     fragmentShader: 'void main() {}',
     uniformNames: { u_swirl: 'float', u_color: 'vec3', u_texture0: 'sampler2D' }
 });
-
-function uploadsOf(stub: GLStubHandle, name: string): unknown[] {
-    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
-    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
-}
 
 function swirlUploads(stub: GLStubHandle): unknown[] {
     return uploadsOf(stub, 'u_swirl');

--- a/src/testing/fixtures.ts
+++ b/src/testing/fixtures.ts
@@ -1,0 +1,53 @@
+import { createFrameInvalidation } from '@/core/lib/frameInvalidation';
+import { resolveSourceTextureOptions } from '@/core/lib/sourceTextureOptions';
+import type { GLStubHandle } from '@/testing/glStub';
+import type {
+    SourceTextureOptions,
+    TextureSource,
+    TextureUploadSource
+} from '@/types';
+
+export function uploadsOf(stub: GLStubHandle, name: string): unknown[] {
+    const location = stub.gl.getUniformLocation({} as WebGLProgram, name);
+    if (location === null) {
+        return [];
+    }
+    return stub.uniformCalls.filter(call => call.location === location).map(call => call.value);
+}
+
+export const bitmap = (width: number, height: number): TextureUploadSource =>
+    ({ width, height }) as unknown as TextureUploadSource;
+
+export const video = (videoWidth: number, videoHeight: number): TextureUploadSource =>
+    ({ videoWidth, videoHeight }) as unknown as TextureUploadSource;
+
+export interface SourceHandle {
+    source: TextureSource;
+    push: (frame: TextureUploadSource) => void;
+    withhold: () => void;
+    reoffer: () => void;
+}
+
+export function createSource(id: string, options?: SourceTextureOptions): SourceHandle {
+    let frame: TextureUploadSource | null = null;
+    let offered = true;
+    let version = 0;
+
+    const source: TextureSource = {
+        id,
+        get version() { return version },
+        options: resolveSourceTextureOptions(options),
+        getFrame: () => (offered ? frame : null),
+        invalidation: createFrameInvalidation()
+    };
+
+    return {
+        source,
+        push: (next: TextureUploadSource) => {
+            frame = next;
+            version += 1;
+        },
+        withhold: () => { offered = false },
+        reoffer: () => { offered = true }
+    };
+}


### PR DESCRIPTION
Closes the standing pre-C5 item from the composition-effects plan: the `uploadsOf` GL-stub assertion helper existed in SIX copies (Postprocessing, uniformGuardPipeline, transitionPipeline, Grain, MeshGradient, BaseShaderComponent.audio tests) and the `createSource`/`bitmap` texture-source fixtures in two (TextureManager, graphRender tests).

All now live in `src/testing/fixtures.ts`, deliberately NOT re-exported from `src/testing/index.ts` — the `frameQueue.ts` precedent: internal to the repo's own tests, out of the published `micugl/testing` API surface (promoting `uploadsOf` to a published assertion was considered and deliberately deferred; it adds public API surface).

Consolidation notes:
- The shared `uploadsOf(stub, name)` carries the null-location guard two of the six copies had; behaviorally identical for the other four (WebGLManager never uploads on a null location, so the unguarded filter matched nothing anyway).
- `createSource` is the rich TextureManager variant (options, withhold/reoffer); graphRender's subset is a faithful specialization (its call sites never toggle offering).
- Local helpers with their own semantics stay local (`uploadCallsOf`, `readable`, `indexOfCall`, `swirlUploads`, `levelUploads`, `timeUploads` — the latter three now call the shared fixture).

Test-only change: 82 files, 1187 tests green; typecheck/lint/build green (treeshake + embed-size guards unaffected — fixtures.ts is unreachable from any build entry).