### PR TITLE
demo: browsable homepage - grouped scene gallery

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -1,89 +1,36 @@
-import { useState } from 'react';
-
-import { PerformanceTest } from './PerformanceTest';
+import { Home } from './scenes/Home';
 import { getSceneComponent } from './scenes/registry';
 
 export const App = () => {
     const Scene = getSceneComponent();
     if (Scene) {
-        return <Scene />;
+        return (
+            <>
+                <Scene />
+                <a
+                    href='./'
+                    aria-label='Back to all scenes'
+                    style={{
+                        position: 'fixed',
+                        top: '12px',
+                        right: '12px',
+                        zIndex: 9999,
+                        padding: '6px 11px',
+                        fontSize: '12px',
+                        fontWeight: 600,
+                        letterSpacing: '0.02em',
+                        color: '#eee',
+                        textDecoration: 'none',
+                        background: 'rgba(15, 52, 96, 0.55)',
+                        border: '1px solid rgba(233, 69, 96, 0.45)',
+                        borderRadius: '7px',
+                        backdropFilter: 'blur(6px)'
+                    }}
+                >
+                    {'\u2039 scenes'}
+                </a>
+            </>
+        );
     }
-    return <DefaultScene />;
-};
-
-const DefaultScene = () => {
-    const [showTest, setShowTest] = useState(true);
-    const [iterations, setIterations] = useState(4);
-    const [triggerRerender, setTriggerRerender] = useState(0);
-
-    return (
-        <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-            <div style={{ 
-                padding: '12px 16px', 
-                background: '#16213e',
-                borderBottom: '1px solid #0f3460',
-                display: 'flex',
-                gap: '16px',
-                alignItems: 'center',
-                flexWrap: 'wrap'
-            }}>
-                <h1 style={{ fontSize: '16px', fontWeight: 600 }}>micugl Performance Test</h1>
-                
-                <button 
-                    type='button'
-                    onClick={() => { setShowTest(s => !s) }}
-                    style={{
-                        padding: '6px 12px',
-                        background: showTest ? '#e94560' : '#0f3460',
-                        border: 'none',
-                        borderRadius: '4px',
-                        color: '#fff',
-                        cursor: 'pointer'
-                    }}
-                >
-                    {showTest ? 'Unmount' : 'Mount'}
-                </button>
-
-                <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    Iterations:
-                    <input 
-                        type='range' 
-                        min='1' 
-                        max='16' 
-                        value={iterations}
-                        onChange={e => { setIterations(Number(e.target.value)) }}
-                    />
-                    <span style={{ minWidth: '20px' }}>{iterations}</span>
-                </label>
-
-                <button 
-                    type='button'
-                    onClick={() => { setTriggerRerender(n => n + 1) }}
-                    style={{
-                        padding: '6px 12px',
-                        background: '#0f3460',
-                        border: 'none',
-                        borderRadius: '4px',
-                        color: '#fff',
-                        cursor: 'pointer'
-                    }}
-                >
-                    Force Parent Rerender ({triggerRerender})
-                </button>
-
-                <div style={{ marginLeft: 'auto', fontSize: '12px', opacity: 0.7 }}>
-                    Open DevTools console to see debug logs
-                </div>
-            </div>
-
-            <div style={{ flex: 1, position: 'relative' }}>
-                {showTest && (
-                    <PerformanceTest 
-                        iterations={iterations} 
-                        parentRerenderCount={triggerRerender}
-                    />
-                )}
-            </div>
-        </div>
-    );
+    return <Home />;
 };

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>micugl - Performance Test</title>
+    <title>micugl demos</title>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       body { 

--- a/demo/scenes/Home.tsx
+++ b/demo/scenes/Home.tsx
@@ -1,0 +1,195 @@
+import type { SceneCategory, SceneMeta } from './registry';
+import { categoryLabels, categoryOrder, scenes } from './registry';
+
+const styles = `
+.home-root {
+    min-height: 100vh;
+    background:
+        radial-gradient(1200px 600px at 15% -10%, #16213e 0%, rgba(22, 33, 62, 0) 60%),
+        radial-gradient(1000px 700px at 100% 0%, #0f3460 0%, rgba(15, 52, 96, 0) 55%),
+        #1a1a2e;
+}
+.home-shell {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 72px 24px 96px;
+}
+.home-header {
+    margin-bottom: 56px;
+}
+.home-eyebrow {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: #e94560;
+    margin-bottom: 18px;
+}
+.home-wordmark {
+    font-size: clamp(40px, 8vw, 68px);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    margin-bottom: 18px;
+}
+.home-wordmark span {
+    color: #e94560;
+}
+.home-tagline {
+    max-width: 46ch;
+    font-size: 16px;
+    line-height: 1.6;
+    color: rgba(238, 238, 238, 0.68);
+}
+.home-section {
+    margin-top: 48px;
+}
+.home-section-head {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+.home-section-label {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: #eee;
+    white-space: nowrap;
+}
+.home-section-rule {
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(233, 69, 96, 0.35), rgba(15, 52, 96, 0.25));
+}
+.home-section-count {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    color: rgba(238, 238, 238, 0.45);
+    white-space: nowrap;
+}
+.home-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(268px, 1fr));
+    gap: 14px;
+}
+.home-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 18px 18px 20px;
+    background: rgba(22, 33, 62, 0.55);
+    border: 1px solid rgba(15, 52, 96, 0.9);
+    border-radius: 12px;
+    text-decoration: none;
+    color: inherit;
+    transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+.home-card:hover {
+    transform: translateY(-3px);
+    border-color: rgba(233, 69, 96, 0.7);
+    background: rgba(22, 33, 62, 0.9);
+}
+.home-card:focus-visible {
+    outline: 2px solid #e94560;
+    outline-offset: 3px;
+}
+.home-card-slug {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    color: rgba(238, 238, 238, 0.4);
+    overflow-wrap: anywhere;
+}
+.home-card-slug b {
+    font-weight: 600;
+    color: rgba(233, 69, 96, 0.85);
+}
+.home-card-title {
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+}
+.home-card-desc {
+    font-size: 13px;
+    line-height: 1.55;
+    color: rgba(238, 238, 238, 0.62);
+}
+@media (prefers-reduced-motion: reduce) {
+    .home-card {
+        transition: none;
+    }
+    .home-card:hover {
+        transform: none;
+    }
+}
+`;
+
+const bucketScenes = (): Map<SceneCategory, [string, SceneMeta][]> => {
+    const buckets = new Map<SceneCategory, [string, SceneMeta][]>();
+    for (const [key, meta] of Object.entries(scenes)) {
+        const bucket = buckets.get(meta.category);
+        if (bucket) {
+            bucket.push([key, meta]);
+        } else {
+            buckets.set(meta.category, [[key, meta]]);
+        }
+    }
+    return buckets;
+};
+
+export const Home = () => {
+    const buckets = bucketScenes();
+
+    const rendered = categoryOrder.reduce(
+        (sum, category) => sum + (buckets.get(category)?.length ?? 0),
+        0
+    );
+    if (rendered !== Object.keys(scenes).length) {
+        throw new Error(
+            `Home gallery would drop scenes: ${String(rendered)} of ${String(Object.keys(scenes).length)} rendered. A scene category is missing from categoryOrder.`
+        );
+    }
+
+    return (
+        <main className='home-root'>
+            <style>{styles}</style>
+            <div className='home-shell'>
+                <header className='home-header'>
+                    <div className='home-eyebrow'>Demo scenes</div>
+                    <h1 className='home-wordmark'>micu<span>gl</span></h1>
+                    <p className='home-tagline'>
+                        Live WebGL scenes built on the micugl React engine. Pick one to run it.
+                    </p>
+                </header>
+
+                {categoryOrder.map(category => {
+                    const bucket = buckets.get(category);
+                    if (bucket === undefined) {
+                        return null;
+                    }
+                    return (
+                        <section className='home-section' key={category}>
+                            <div className='home-section-head'>
+                                <h2 className='home-section-label'>{categoryLabels[category]}</h2>
+                                <span className='home-section-rule' />
+                                <span className='home-section-count'>
+                                    {bucket.length} {bucket.length === 1 ? 'scene' : 'scenes'}
+                                </span>
+                            </div>
+                            <div className='home-grid'>
+                                {bucket.map(([key, meta]) => (
+                                    <a className='home-card' href={`?scene=${key}`} key={key}>
+                                        <span className='home-card-slug'>?scene=<b>{key}</b></span>
+                                        <span className='home-card-title'>{meta.title}</span>
+                                        <span className='home-card-desc'>{meta.description}</span>
+                                    </a>
+                                ))}
+                            </div>
+                        </section>
+                    );
+                })}
+            </div>
+        </main>
+    );
+};

--- a/demo/scenes/Performance.tsx
+++ b/demo/scenes/Performance.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+import { PerformanceTest } from '../PerformanceTest';
+
+export const Performance = () => {
+    const [showTest, setShowTest] = useState(true);
+    const [iterations, setIterations] = useState(4);
+    const [triggerRerender, setTriggerRerender] = useState(0);
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+            <div style={{
+                padding: '12px 16px',
+                background: '#16213e',
+                borderBottom: '1px solid #0f3460',
+                display: 'flex',
+                gap: '16px',
+                alignItems: 'center',
+                flexWrap: 'wrap'
+            }}>
+                <h1 style={{ fontSize: '16px', fontWeight: 600 }}>micugl Performance Test</h1>
+
+                <button
+                    type='button'
+                    onClick={() => { setShowTest(s => !s) }}
+                    style={{
+                        padding: '6px 12px',
+                        background: showTest ? '#e94560' : '#0f3460',
+                        border: 'none',
+                        borderRadius: '4px',
+                        color: '#fff',
+                        cursor: 'pointer'
+                    }}
+                >
+                    {showTest ? 'Unmount' : 'Mount'}
+                </button>
+
+                <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                    Iterations:
+                    <input
+                        type='range'
+                        min='1'
+                        max='16'
+                        value={iterations}
+                        onChange={e => { setIterations(Number(e.target.value)) }}
+                    />
+                    <span style={{ minWidth: '20px' }}>{iterations}</span>
+                </label>
+
+                <button
+                    type='button'
+                    onClick={() => { setTriggerRerender(n => n + 1) }}
+                    style={{
+                        padding: '6px 12px',
+                        background: '#0f3460',
+                        border: 'none',
+                        borderRadius: '4px',
+                        color: '#fff',
+                        cursor: 'pointer'
+                    }}
+                >
+                    Force Parent Rerender ({triggerRerender})
+                </button>
+
+                <div style={{ marginLeft: 'auto', fontSize: '12px', opacity: 0.7 }}>
+                    Open DevTools console to see debug logs
+                </div>
+            </div>
+
+            <div style={{ flex: 1, position: 'relative' }}>
+                {showTest && (
+                    <PerformanceTest
+                        iterations={iterations}
+                        parentRerenderCount={triggerRerender}
+                    />
+                )}
+            </div>
+        </div>
+    );
+};

--- a/demo/scenes/registry.ts
+++ b/demo/scenes/registry.ts
@@ -13,6 +13,7 @@ import { ManyCanvases } from './ManyCanvases';
 import { ManyCanvasesDevtools } from './ManyCanvasesDevtools';
 import { Offscreen } from './Offscreen';
 import { ParticlesComponents } from './ParticlesComponents';
+import { Performance } from './Performance';
 import { PingPongSim } from './PingPongSim';
 import { getQueryString } from './query';
 import { ReducedMotion } from './ReducedMotion';
@@ -26,37 +27,205 @@ import { Webcam } from './Webcam';
 import { WorkerContextLoss } from './WorkerContextLoss';
 import { WorkerJank } from './WorkerJank';
 
-export const scenes: Record<string, ComponentType> = {
-    'rerender-storm': RerenderStorm,
-    'pingpong-sim': PingPongSim,
-    'ripple': RippleScene,
-    'static-idle': StaticIdle,
-    'offscreen': Offscreen,
-    'many-canvases': ManyCanvases,
-    'many-canvases-devtools': ManyCanvasesDevtools,
-    'devtools-debug': DevtoolsDebug,
-    'reduced-motion': ReducedMotion,
-    'transitions': Transitions,
-    'audio-bars': AudioBars,
-    'effects-gallery': EffectsGallery,
-    'effects-composed': EffectsComposed,
-    'visual-fixed': VisualFixed,
-    'export-demo': ExportDemo,
-    'image-texture': ImageTexture,
-    'webcam': Webcam,
-    'instanced-particles': InstancedParticles,
-    'particles-components': ParticlesComponents,
-    'worker-jank': WorkerJank,
-    'worker-context-loss': WorkerContextLoss,
-    'shader-graph': ShaderGraph,
-    'graph-inspector': GraphInspector,
-    'graph-pixels': GraphPixels
+export type SceneCategory =
+    | 'performance'
+    | 'simulation'
+    | 'composition'
+    | 'effects'
+    | 'textures'
+    | 'audio'
+    | 'motion'
+    | 'worker'
+    | 'devtools';
+
+export interface SceneMeta {
+    component: ComponentType;
+    title: string;
+    category: SceneCategory;
+    description: string;
+}
+
+export const scenes: Record<string, SceneMeta> = {
+    'performance-test': {
+        component: Performance,
+        title: 'Performance Playground',
+        category: 'performance',
+        description: 'Mount, unmount, and force parent rerenders to watch the engine stay identity-stable.'
+    },
+    'rerender-storm': {
+        component: RerenderStorm,
+        title: 'Rerender Storm',
+        category: 'performance',
+        description: 'Parent rerenders never rebuild the GL engine.'
+    },
+    'static-idle': {
+        component: StaticIdle,
+        title: 'Static Idle',
+        category: 'performance',
+        description: 'An idle engine schedules zero frames.'
+    },
+    'offscreen': {
+        component: Offscreen,
+        title: 'Offscreen',
+        category: 'performance',
+        description: 'Engines pause when scrolled out of view.'
+    },
+    'many-canvases': {
+        component: ManyCanvases,
+        title: 'Many Canvases',
+        category: 'performance',
+        description: 'Dozens of independent engines on one page.'
+    },
+    'many-canvases-devtools': {
+        component: ManyCanvasesDevtools,
+        title: 'Many Canvases + Devtools',
+        category: 'performance',
+        description: 'The zero-cost devtools guard, at scale.'
+    },
+    'particles-components': {
+        component: ParticlesComponents,
+        title: 'Particle Components',
+        category: 'performance',
+        description: 'Instanced particles through the component API.'
+    },
+    'instanced-particles': {
+        component: InstancedParticles,
+        title: 'Instanced Particles',
+        category: 'performance',
+        description: 'A single instanced draw call. Set ?count= to scale.'
+    },
+    'pingpong-sim': {
+        component: PingPongSim,
+        title: 'Ping-Pong Simulation',
+        category: 'simulation',
+        description: 'FBO ping-pong feedback. Set ?iterations= for sub-steps.'
+    },
+    'shader-graph': {
+        component: ShaderGraph,
+        title: 'Shader Graph',
+        category: 'composition',
+        description: 'Compose multiple shader nodes into one DAG.'
+    },
+    'graph-inspector': {
+        component: GraphInspector,
+        title: 'Graph Inspector',
+        category: 'composition',
+        description: 'The devtools DAG panel over a live graph.'
+    },
+    'graph-pixels': {
+        component: GraphPixels,
+        title: 'Graph Pixels',
+        category: 'composition',
+        description: 'Per-node pixel readback from the graph.'
+    },
+    'effects-gallery': {
+        component: EffectsGallery,
+        title: 'Effects Gallery',
+        category: 'effects',
+        description: 'The built-in effect components, side by side.'
+    },
+    'effects-composed': {
+        component: EffectsComposed,
+        title: 'Composed Effects',
+        category: 'effects',
+        description: 'Chained effects with shared-program dedup.'
+    },
+    'ripple': {
+        component: RippleScene,
+        title: 'Ripple',
+        category: 'effects',
+        description: 'A feedback-accumulator ripple. Move the pointer to disturb it.'
+    },
+    'image-texture': {
+        component: ImageTexture,
+        title: 'Image Texture',
+        category: 'textures',
+        description: 'A static image bound as a shader sampler.'
+    },
+    'webcam': {
+        component: Webcam,
+        title: 'Webcam',
+        category: 'textures',
+        description: 'A live camera feed as a texture. Starts on click.'
+    },
+    'audio-bars': {
+        component: AudioBars,
+        title: 'Audio Bars',
+        category: 'audio',
+        description: 'Microphone levels driving shader uniforms. Starts on click.'
+    },
+    'reduced-motion': {
+        component: ReducedMotion,
+        title: 'Reduced Motion',
+        category: 'motion',
+        description: 'Honors prefers-reduced-motion with a static poster frame.'
+    },
+    'transitions': {
+        component: Transitions,
+        title: 'Uniform Transitions',
+        category: 'motion',
+        description: 'Tweened and spring uniform changes.'
+    },
+    'visual-fixed': {
+        component: VisualFixed,
+        title: 'Visual Fixed Frame',
+        category: 'motion',
+        description: 'A deterministic single frame. Set ?frame= to seek.'
+    },
+    'export-demo': {
+        component: ExportDemo,
+        title: 'Export',
+        category: 'motion',
+        description: 'Render to an image, an image sequence, or video.'
+    },
+    'worker-jank': {
+        component: WorkerJank,
+        title: 'Worker Jank',
+        category: 'worker',
+        description: 'Block the main thread; the worker canvas animates through it. ?mode=worker.'
+    },
+    'worker-context-loss': {
+        component: WorkerContextLoss,
+        title: 'Worker Context Loss',
+        category: 'worker',
+        description: 'Recover from a real GL context loss inside the worker.'
+    },
+    'devtools-debug': {
+        component: DevtoolsDebug,
+        title: 'Devtools Debug',
+        category: 'devtools',
+        description: 'The uniform inspector with scrub controls and overrides.'
+    }
 };
+
+export const categoryLabels: Record<SceneCategory, string> = {
+    performance: 'Performance',
+    simulation: 'Simulation',
+    composition: 'Composition',
+    effects: 'Effects',
+    textures: 'Textures',
+    audio: 'Audio',
+    motion: 'Motion & Capture',
+    worker: 'Worker',
+    devtools: 'Devtools'
+};
+
+export const categoryOrder: readonly SceneCategory[] = [
+    'performance',
+    'simulation',
+    'composition',
+    'effects',
+    'textures',
+    'audio',
+    'motion',
+    'worker',
+    'devtools'
+];
 
 export const getSceneComponent = (): ComponentType | null => {
     const name = getQueryString('scene');
     if (name === null || !(name in scenes)) {
         return null;
     }
-    return scenes[name];
+    return scenes[name].component;
 };


### PR DESCRIPTION
## What

The dev-server demo had no browsable index: a scene was only reachable by typing `?scene=<name>` in the URL, and with no `?scene` the app fell back to `DefaultScene` (the PerformanceTest playground). This adds a real homepage: a grouped, browsable gallery of all 25 demo scenes, shown as the no-`?scene` default.

## Changes

- **`demo/scenes/registry.ts`** - the flat `Record<string, ComponentType>` becomes `Record<string, SceneMeta>` (`{ component, title, category, description }`). The string **keys are unchanged**, so every `?scene=` deep-link and its extra params (`mode`, `count`, `iterations`, `frame`, `strict`, `n`) route exactly as before. Adds a type-enforced `categoryLabels: Record<SceneCategory, string>` and an ordered `categoryOrder`.
- **`demo/scenes/Home.tsx`** - a grouped card gallery. One card per scene (title, description, and its `?scene=<key>` slug) linking to the scene. Buckets are derived from `Object.entries(scenes)` and rendered in `categoryOrder`; a **fail-loud guard throws** if any scene's category is missing from `categoryOrder`, so a scene can never silently vanish from the index.
- **`demo/scenes/Performance.tsx`** - the former inline `DefaultScene` playground, now a reachable scene registered as `performance-test`.
- **`demo/App.tsx`** - renders the routed scene else `<Home/>`, plus a small top-right back-to-index link shown **only while a scene is active** (never on the homepage, never as a full-page overlay).

## Verification

- `bun run typecheck && lint && test && build` - all green (1245 tests).
- `bun run test:e2e` - **10/10** (no `?scene` routing regression).
- `bun run bench` (counters) - **20/20**.
- Live in a real browser: 25 cards on the homepage (equals `Object.keys(scenes).length`), every scene resolves and renders its canvas, the back-link drops the query and returns to the homepage, zero console errors.

Demo-only (dev playground); not a published library entry.